### PR TITLE
resolve parameters were incongruous

### DIFF
--- a/service/resolvers/catalog/fieldsResolver.ts
+++ b/service/resolvers/catalog/fieldsResolver.ts
@@ -80,8 +80,8 @@ export const resolveProductFields = async (ioContext: IOContext, product: any, f
   }
 
   const [view, buy] = await Promise.all([
-    resolveView(ioContext.account, product),
-    resolveBuy(ioContext.account, product)
+    resolveView(ioContext, product),
+    resolveBuy(ioContext, product)
   ])
 
   return {...resolvedProduct, recommendations: {buy, view}}


### PR DESCRIPTION
a resolver were receiving the ioContext property as account
so, in the previous versions I ended up treating the variables inconsistently.

But my previous changes (0.0.27 and 0.0.28) embraced more endpoints and I did not test the crossSelling properly.

Now everything is fixed due to @firstdoit noticing it was not working well with our shelf example https://github.com/vtex-apps/fetch-from-store-graphql