### PR TITLE
add missing endpoints brand, category and categories

### DIFF
--- a/masterdata/schema/Query.gql
+++ b/masterdata/schema/Query.gql
@@ -14,10 +14,10 @@ type Query {
 
   facets(facets: String = ""): Facets
 
-  category(slug: String): Category
-  categories: [Category]
+  category(id: Int): Category
+  categories(treeLevel: Int = 3): [Category]
 
-  brand(slug: String): Brand
+  brand(id: Int): Brand
 
   shipping(skuId: String, postalCode: String): ShippingData
 

--- a/masterdata/schema/types/Brand.gql
+++ b/masterdata/schema/types/Brand.gql
@@ -1,7 +1,6 @@
 type Brand {
-  href: String
   name: String
   slug: String
-  logo: String
-  description: String
+  id: Int
+  active: Boolean
 }

--- a/masterdata/schema/types/Category.gql
+++ b/masterdata/schema/types/Category.gql
@@ -3,4 +3,6 @@ type Category {
   slug: String
   name: String
   children: [Category]
+  id: Int
+  hasChildren: Boolean
 }

--- a/service/package.json
+++ b/service/package.json
@@ -9,7 +9,8 @@
     "cookie": "^0.3.1",
     "ramda": "^0.24.1",
     "ts-node": "3.3.0",
-    "typescript": "^2.5.2"
+    "typescript": "^2.5.2",
+    "url-parse": "^1.2.0"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.0",

--- a/service/package.json
+++ b/service/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "axios": "0.16.2",
     "bluebird": "^3.5.0",
+    "slugify": "^1.2.6",
     "co-body": "^5.1.1",
     "cookie": "^0.3.1",
     "ramda": "^0.24.1",

--- a/service/resolvers/catalog/fieldsResolver.ts
+++ b/service/resolvers/catalog/fieldsResolver.ts
@@ -1,7 +1,8 @@
 import axios from 'axios'
 import {IOContext} from 'colossus'
-import {compose, evolve, juxt, map, omit, path, pick, prop, propOr, toPairs} from 'ramda'
+import {compose, evolve, juxt, map, omit, path, pick, prop, propOr, toPairs, assoc, last, split} from 'ramda'
 import paths from './../paths'
+import slugify from 'slugify'
 import {resolveBuy, resolveView} from './recommendationsResolver'
 
 const knownNotPG = [
@@ -91,3 +92,19 @@ export const resolveFacetFields = (facets) => {
   const SpecificationFilters = resolvers.specificationFilters(facets)
   return {...facets, SpecificationFilters}
 }
+
+export const resolveCategoryFields = (category) => ({
+  href: category.url,
+  slug: category.url ? compose(last, split('/'), prop('url'))(category) : null,
+  children: category.children ? map(resolveCategoryFields, category.children): [],
+  name: category.name,
+  id: category.id,
+  hasChildren: category.hasChildren
+})
+
+export const resolveBrandFields = (brand) => ({
+  id: brand.id,
+  name: brand.name,
+  active: brand.isActive,
+  // slug: slugify(brand.name, {lower: true})
+})

--- a/service/resolvers/catalog/fieldsResolver.ts
+++ b/service/resolvers/catalog/fieldsResolver.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import {IOContext} from 'colossus'
 import {compose, evolve, juxt, map, omit, path, pick, prop, propOr, toPairs, assoc, last, split} from 'ramda'
 import paths from './../paths'
-import slugify from 'slugify'
+import * as slugify from 'slugify'
 import {resolveBuy, resolveView} from './recommendationsResolver'
 
 const knownNotPG = [
@@ -106,5 +106,5 @@ export const resolveBrandFields = (brand) => ({
   id: brand.id,
   name: brand.name,
   active: brand.isActive,
-  // slug: slugify(brand.name, {lower: true})
+  slug: slugify(brand.name, {lower: true})
 })

--- a/service/resolvers/catalog/index.ts
+++ b/service/resolvers/catalog/index.ts
@@ -39,9 +39,9 @@ export default {
     return {data: resolvedProducts}
   },
 
-  brand: async ({data, fields}: GraphqlRequestBody, ioContext: IOContext) => {
+  brand: async ({data, fields, cookie}: GraphqlRequestBody, ioContext: IOContext) => {
     const url = paths.brand(ioContext.account)
-    const {data: brands} = await axios.get(url, {headers: withAuthToken()(ioContext) })
+    const {data: brands} = await axios.get(url, {headers: withAuthToken()(ioContext, cookie) })
 
     const brand = find(compose(equals(data.id), prop('id')), brands)
     if (!brand) {
@@ -50,9 +50,9 @@ export default {
     return {data: resolveBrandFields(brand)}
   },
 
-  category: async ({data, fields}: GraphqlRequestBody, ioContext: IOContext) => {
+  category: async ({data, fields, cookie}: GraphqlRequestBody, ioContext: IOContext) => {
     const url = paths.category(ioContext.account, data)
-    const {data: category} = await axios.get(url, {headers: withAuthToken()(ioContext) })
+    const {data: category} = await axios.get(url, {headers: withAuthToken()(ioContext, cookie) })
     return {data: resolveCategoryFields(category)}
   },
 

--- a/service/resolvers/catalog/index.ts
+++ b/service/resolvers/catalog/index.ts
@@ -2,7 +2,9 @@ import axios, {AxiosResponse} from 'axios'
 import {IOContext} from 'colossus'
 import {GraphqlRequestBody} from 'graphql'
 import paths from '../paths'
-import {resolveFacetFields, resolveProductFields} from './fieldsResolver'
+import ResolverError from '../../errors/resolverError'
+import {map, find, equals, prop, compose} from 'ramda'
+import {resolveFacetFields, resolveProductFields, resolveCategoryFields, resolveBrandFields} from './fieldsResolver'
 import {withAuthToken} from '../headers'
 
 export default {
@@ -35,5 +37,28 @@ export default {
     const resolvedProducts = await Promise.map(products, product => resolveProductFields(ioContext, product, fields))
 
     return {data: resolvedProducts}
+  },
+
+  brand: async ({data, fields}: GraphqlRequestBody, ioContext: IOContext) => {
+    const url = paths.brand(ioContext.account)
+    const {data: brands} = await axios.get(url, {headers: withAuthToken()(ioContext) })
+
+    const brand = find(compose(equals(data.id), prop('id')), brands)
+    if (!brand) {
+      throw new ResolverError(`Brand with id ${data.id} not found`, 404)
+    }
+    return {data: resolveBrandFields(brand)}
+  },
+
+  category: async ({data, fields}: GraphqlRequestBody, ioContext: IOContext) => {
+    const url = paths.category(ioContext.account, data)
+    const {data: category} = await axios.get(url, {headers: withAuthToken()(ioContext) })
+    return {data: resolveCategoryFields(category)}
+  },
+
+  categories: async ({data, fields}: GraphqlRequestBody, ioContext: IOContext) => {
+    const url = paths.categories(ioContext.account, data)
+    const {data: categories} = await axios.get(url, {headers: withAuthToken()(ioContext) })
+    return {data: map(resolveCategoryFields, categories)}
   }
 }

--- a/service/resolvers/checkout/index.ts
+++ b/service/resolvers/checkout/index.ts
@@ -28,8 +28,10 @@ export default {
   }),
 
   createPaymentSession: httpResolver({
-    headers: withAuthToken(headers.json),
+    headers: withAuthToken({...headers.json}),
     method: 'POST',
+    enableCookies: true,
+    secure: true,
     url: paths.gatewayPaymentSession,
   }),
 

--- a/service/resolvers/headers.ts
+++ b/service/resolvers/headers.ts
@@ -12,5 +12,6 @@ export const headers = {
 export const withAuthToken = (currentHeaders = {}) => (ioContext) => ({
   ...currentHeaders,
   Authorization: `bearer ${ioContext.authToken}`,
-  'Proxy-Authorization': `bearer ${ioContext.authToken}`
+  'Proxy-Authorization': `bearer ${ioContext.authToken}`,
+  VtexIdclientAutCookie: ioContext.authToken
 })

--- a/service/resolvers/headers.ts
+++ b/service/resolvers/headers.ts
@@ -1,3 +1,5 @@
+import * as cookies from 'cookie'
+
 export const headers = {
   json: {
     accept: 'application/json',
@@ -9,9 +11,16 @@ export const headers = {
   },
 }
 
-export const withAuthToken = (currentHeaders = {}) => (ioContext) => ({
-  ...currentHeaders,
-  Authorization: `bearer ${ioContext.authToken}`,
-  'Proxy-Authorization': `bearer ${ioContext.authToken}`,
-  VtexIdclientAutCookie: ioContext.authToken
-})
+export const withAuthToken = (currentHeaders = {}) => (ioContext, cookie = null) => {
+  let VtexIdclientAutCookie
+  let ans = {...currentHeaders}
+  if (cookie) {
+    const parsedCookie = cookies.parse(cookie)
+    ans['VtexIdclientAutCookie'] = parsedCookie.VtexIdclientAutCookie
+  }
+  return {
+    ...ans,
+    Authorization: `${ioContext.authToken}`,
+    'Proxy-Authorization': `${ioContext.authToken}`
+  }
+}

--- a/service/resolvers/paths.ts
+++ b/service/resolvers/paths.ts
@@ -1,59 +1,63 @@
 const paths = {
-  product: (account, {slug}) => `https://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search$/${slug}/p`,
-  productByEan: (account, {id}) => `https://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=alternateIds_Ean=${id}`,
-  productById: (account, {id}) => `https://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=productId:${id}`,
-  productByReference: (account, {id}) => `https://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=alternateIds_RefId=${id}`,
-  productBySku: (account, {id}) => `https://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=skuId=${id}`,
+  product: (account, {slug}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search$/${slug}/p`,
+  productByEan: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=alternateIds_Ean=${id}`,
+  productById: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=productId:${id}`,
+  productByReference: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=alternateIds_RefId=${id}`,
+  productBySku: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=skuId=${id}`,
 
-  products: (account, {query = '', fulltext = '', category ='', specificationFilters, priceRange ='', collection = '', salesChannel = '', orderBy = '', from = 0, to = 9}) => `https://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search/${encodeURIComponent(query)}?${category && `&fq=C:/${category}/`}${specificationFilters && '&' + specificationFilters}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
+  brand: (account) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pvt/brand/list`,
+  category: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pvt/category/${id}`,
+  categories: (account, {treeLevel}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/category/tree/${treeLevel}/`,
 
-  facets: (account, {facets=''}) => `https://${account}.vtexcommercestable.com.br/api/catalog_system/pub/facets/search/${encodeURI(facets)}`,
+  products: (account, {query = '', fulltext = '', category ='', specificationFilters, priceRange ='', collection = '', salesChannel = '', orderBy = '', from = 0, to = 9}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search/${encodeURIComponent(query)}?${category && `&fq=C:/${category}/`}${specificationFilters && '&' + specificationFilters}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
 
-  crossSelling: (account, id, type) => `https://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/crossselling/${type}/${id}`,
+  facets: (account, {facets=''}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/facets/search/${encodeURI(facets)}`,
+
+  crossSelling: (account, id, type) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/crossselling/${type}/${id}`,
 
   shipping: (account, {skuId, postalCode}) =>
-    `https://${account}.vtexcommercestable.com.br/api/checkout/pub/orderForms/simulation?request.items[0].id=${skuId}&request.items[0].quantity=1&request.items[0].seller=1&request.postalCode=${postalCode}&request.country=BRA`,
+    `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orderForms/simulation?request.items[0].id=${skuId}&request.items[0].quantity=1&request.items[0].seller=1&request.postalCode=${postalCode}&request.country=BRA`,
 
-  orderForm: (account, env = 'stable') => `https://${account}.vtexcommercestable.com.br/api/checkout/pub/orderForm`,
+  orderForm: (account) => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orderForm`,
 
-  orderFormProfile: (account, {orderFormId}) => `${paths.orderForm(account, 'beta')}/${orderFormId}/attachments/clientProfileData`,
+  orderFormProfile: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/attachments/clientProfileData`,
 
-  orderFormShipping: (account, {orderFormId}) => `${paths.orderForm(account, 'beta')}/${orderFormId}/attachments/shippingData`,
+  orderFormShipping: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/attachments/shippingData`,
 
-  orderFormPayment: (account, {orderFormId}) => `${paths.orderForm(account, 'beta')}/${orderFormId}/attachments/paymentData`,
+  orderFormPayment: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/attachments/paymentData`,
 
-  orderFormPaymentToken: (account, {orderFormId}) => `${paths.orderForm(account, 'beta')}/${orderFormId}/paymentData/paymentToken`,
+  orderFormPaymentToken: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/paymentData/paymentToken`,
 
-  orderFormPaymentTokenId: (account, {orderFormId, tokenId}) => `${paths.orderForm(account, 'beta')}/${orderFormId}/paymentData/paymentToken/${tokenId}`,
+  orderFormPaymentTokenId: (account, {orderFormId, tokenId}) => `${paths.orderForm(account)}/${orderFormId}/paymentData/paymentToken/${tokenId}`,
 
-  orderFormIgnoreProfile: (account, {orderFormId}) => `${paths.orderForm(account, 'beta')}/${orderFormId}/profile`,
+  orderFormIgnoreProfile: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/profile`,
 
-  orderFormCustomData: (account, {orderFormId, appId, field}) => `${paths.orderForm(account, 'beta')}/${orderFormId}/customData/${appId}/${field}`,
+  orderFormCustomData: (account, {orderFormId, appId, field}) => `${paths.orderForm(account)}/${orderFormId}/customData/${appId}/${field}`,
 
   addItem: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/items`,
 
   updateItems: (account, data) => `${paths.addItem(account, data)}/update`,
 
-  orders: account => `https://${account}.vtexcommercestable.com.br/api/checkout/pub/orders`,
+  orders: account => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orders`,
 
   cancelOrder: (account, {orderFormId}) => `${paths.orders(account)}/${orderFormId}/user-cancel-request`,
 
-  identity: (account, {token}) => `https://vtexid.vtex.com.br/api/vtexid/pub/authenticated/user?authToken=${encodeURIComponent(token)}`,
+  identity: (account, {token}) => `http://vtexid.vtex.com.br/api/vtexid/pub/authenticated/user?authToken=${encodeURIComponent(token)}`,
 
   profile: account => ({
-    address: (id) => `https://api.vtex.com/${account}/dataentities/AD/documents/${id}`,
-    filterAddress: (id) => `https://api.vtex.com/${account}/dataentities/AD/search?userId=${id}&_fields=userId,id,receiverName,complement,neighborhood,state,number,street,postalCode,city,reference,addressName,addressType`,
-    filterUser: (email) => `https://api.vtex.com/${account}/dataentities/CL/search?email=${email}&_fields=userId,id,firstName,lastName,birthDate,gender,homePhone,businessPhone,document,email`,
-    profile: (id) => `https://api.vtex.com/${account}/dataentities/CL/documents/${id}`,
+    address: (id) => `http://api.vtex.com/${account}/dataentities/AD/documents/${id}`,
+    filterAddress: (id) => `http://api.vtex.com/${account}/dataentities/AD/search?userId=${id}&_fields=userId,id,receiverName,complement,neighborhood,state,number,street,postalCode,city,reference,addressName,addressType`,
+    filterUser: (email) => `http://api.vtex.com/${account}/dataentities/CL/search?email=${email}&_fields=userId,id,firstName,lastName,birthDate,gender,homePhone,businessPhone,document,email`,
+    profile: (id) => `http://api.vtex.com/${account}/dataentities/CL/documents/${id}`,
   }),
 
-  gateway: account => `https://${account}.vtexpayments.com.br/api`,
+  gateway: account => `http://${account}.vtexpayments.com.br/api`,
 
   gatewayPaymentSession: account => `${paths.gateway(account)}/pvt/sessions`,
 
   gatewayTokenizePayment: (account, {sessionId}) => `${paths.gateway(account)}/pub/sessions/${sessionId}/tokens`,
 
-  autocomplete: (account, {maxRows, searchTerm}) => `https://portal.vtexcommercestable.com.br/buscaautocomplete/?an=${account}&maxRows=${maxRows}&productNameContains=${encodeURIComponent(searchTerm)}`,
+  autocomplete: (account, {maxRows, searchTerm}) => `http://portal.vtexcommercestable.com.br/buscaautocomplete/?an=${account}&maxRows=${maxRows}&productNameContains=${encodeURIComponent(searchTerm)}`,
 }
 
 export default paths

--- a/service/resolvers/profile/profileResolver.ts
+++ b/service/resolvers/profile/profileResolver.ts
@@ -21,7 +21,6 @@ const profile = (ctx) => async (data) => {
   const {user} = data
   const profileRequest = await configRequest(ctx, paths.profile(ctx.account).filterUser(user))
   const profileData = await http.request(profileRequest).then<any>(pipe(prop('data'), head))
-
   const addressRequest = profileData && await configRequest(ctx, paths.profile(ctx.account).filterAddress(profileData.id))
   const address = addressRequest && await http.request(addressRequest).then(prop('data'))
 
@@ -37,7 +36,7 @@ export default async (body, ioContext) => {
   if (!token) {
     throw new ResolverError('User is not authenticated.', 401)
   }
-
-  const data = await http.get(paths.identity(account, {token})).then(prop('data')).then(profile(ioContext))
+  const addressRequest = await configRequest(ioContext, paths.identity(account, {token}))
+  const data = await http.request(addressRequest).then(prop('data')).then(profile(ioContext))
   return {data}
 }

--- a/service/service.json
+++ b/service/service.json
@@ -3,6 +3,15 @@
   "memory": 256,
   "runtimeArgs": ["--max_old_space_size=200"],
   "routes": {
+    "brand": {
+      "path": "/query/brand"
+    },
+    "category": {
+      "path": "/query/category"
+    },
+    "categories": {
+      "path": "/query/categories"
+    },
     "product": {
       "path": "/query/product"
     },


### PR DESCRIPTION
Iago received a complaint via Facebook about a user trying to access category query.

That made me realize neither brand, nor category related queries were declared, so it was natural the user would received status 404.

I implemented those endpoints but I am still not very satisfied with some things:

- It seems like the (catalog api)[https://documenter.getpostman.com/view/845/catalogsystem-102/Hs44#daa0c5ee-5c69-a192-7228-29a395726e70] returns weird data, for example, categories query return a list of categories, and each of them has the url attribute, but when searching for an specific category via category query it returns an object without the url attribute. Who might be responsible for that API ? 

- Second, I imported the slugify lib via package.json but I'm having trouble using it. Can you help me ? It's not a lib specific issue, because I've used this lib before, I don't know the details of how the TS is transpiled, so I may be referencing it wrong, look for 'slugify' in the changes and see if you can find something unusual in the way I'm using it.