### PR TITLE
Authentication resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.0] - 2018-09-04
+
+### Added
+
+* **Resolver** Login resolver to provide GraphQL queries and mutations.

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -47,5 +47,5 @@ type Mutation {
   createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
   setPlaceholder(fields: PlaceholderInput): Boolean
   sendEmailVerification(email: String): AuthToken
-  signin(fields: AuthInput): AuthClientToken
+  signIn(fields: AuthInput): AuthClientToken
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -46,4 +46,6 @@ type Mutation {
   createPaymentSession: PaymentSession
   createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
   setPlaceholder(fields: PlaceholderInput): Boolean
+  sendEmailVerification(email: String): String
+  signin(fields: AuthInput): AuthToken
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -46,6 +46,6 @@ type Mutation {
   createPaymentSession: PaymentSession
   createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
   setPlaceholder(fields: PlaceholderInput): Boolean
-  sendEmailVerification(email: String): String
-  signin(fields: AuthInput): AuthToken
+  sendEmailVerification(email: String): AuthToken
+  signin(fields: AuthInput): AuthClientToken
 }

--- a/graphql/types/Auth.graphql
+++ b/graphql/types/Auth.graphql
@@ -1,6 +1,10 @@
-type AuthToken {
+type AuthClientToken {
     Name: String,
     Value: String
+}
+
+type AuthToken {
+    authToken: String
 }
 
 input AuthInput {

--- a/graphql/types/Auth.graphql
+++ b/graphql/types/Auth.graphql
@@ -1,0 +1,10 @@
+type AuthToken {
+    Name: String,
+    Value: String
+}
+
+input AuthInput {
+    email: String, 
+    code: String, 
+    authToken: String
+}

--- a/graphql/types/Auth.graphql
+++ b/graphql/types/Auth.graphql
@@ -1,14 +1,14 @@
 type AuthClientToken {
-    Name: String,
-    Value: String
+  name: String,
+  value: String
 }
 
 type AuthToken {
-    authToken: String
+  authToken: String
 }
 
 input AuthInput {
-    email: String, 
-    code: String, 
-    authToken: String
+  email: String, 
+  code: String, 
+  authToken: String
 }

--- a/manifest.json
+++ b/manifest.json
@@ -62,6 +62,20 @@
     {
       "name": "outbound-access",
       "attrs": {
+        "host": "vtexid.vtex.com.br",
+        "path": "/api/vtexid/pub/authentication/start"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "vtexid.vtex.com.br",
+        "path": "/api/vtexid/pub/authentication/accesskey/*"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
         "host": "{{account}}.vtexpayments.com.br",
         "path": "/api/pvt/sessions"
       }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/graphql/index.ts
+++ b/node/graphql/index.ts
@@ -2,6 +2,7 @@ import '../axiosConfig'
 import catalogQueries from '../resolvers/catalog'
 import {mutations as checkoutMutations, queries as checkoutQueries} from '../resolvers/checkout'
 import {mutations as profileMutations, queries as profileQueries} from '../resolvers/profile'
+import {mutations as authMutations} from '../resolvers/auth'
 
 // tslint:disable-next-line:no-var-requires
 Promise = require('bluebird')
@@ -16,5 +17,6 @@ export const resolvers = {
   Mutation: {
     ...profileMutations,
     ...checkoutMutations,
+    ...authMutations,
   },
 }

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -1,33 +1,29 @@
 import http from 'axios'
-import {serialize} from 'cookie'
+import { serialize } from 'cookie'
 import paths from '../paths'
-import { withAuthToken, headers } from '../headers';
+import { withAuthToken, headers } from '../headers'
 
 const makeRequest = async (ctx, url) => {
-    const configRequest = async (ctx, url) => ({
-        headers: withAuthToken(headers.profile)(ctx),
-        enableCookies: true,
-        method: 'GET',
-        url,
-    })
-    return await http.request(await configRequest(ctx, url))
+  const configRequest = async (ctx, url) => ({
+    headers: withAuthToken(headers.profile)(ctx),
+    enableCookies: true,
+    method: 'GET',
+    url,
+  })
+  return await http.request(await configRequest(ctx, url))
 }
 
 export const mutations = {
+  sendEmailVerification: async (_, args, { vtex: ioContext }) => {
+    const { data: { authenticationToken } } = await makeRequest(ioContext, paths.getTemporaryToken())
+    await makeRequest(ioContext, paths.sendEmailVerification(args.email, authenticationToken))
+    return { authToken: authenticationToken }
+  },
 
-    sendEmailVerification: async (_, args, {vtex: ioContext}) => {
-        const {data: {authenticationToken}} = await makeRequest(ioContext, paths.getTemporaryToken())
-        await makeRequest(ioContext, paths.sendEmailVerification(args.email, authenticationToken))
-        const authToken = {
-            authToken: authenticationToken
-        }
-        return authToken
-    },
-
-    signin: async (_, args, {vtex: ioContext, request: {headers: {cookie}}, response}) => {
-        const {fields: {email, authToken, code}} = args
-        const {data: {authCookie}} = await makeRequest(ioContext, paths.signin(email, authToken, code))
-        response.set('Set-Cookie', serialize(authCookie.Name, authCookie.Value))
-        return authCookie
-    }
+  signIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
+    const { fields: { email, authToken, code } } = args
+    const { data: { authCookie } } = await makeRequest(ioContext, paths.signin(email, authToken, code))
+    response.set('Set-Cookie', serialize(authCookie.Name, authCookie.Value))
+    return { name: authCookie.Name, value: authCookie.Value }
+  }
 }

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -1,0 +1,30 @@
+import http from 'axios'
+import {serialize} from 'cookie'
+import paths from '../paths'
+import { withAuthToken, headers } from '../headers';
+
+const makeRequest = async (ctx, url) => {
+    const configRequest = async (ctx, url) => ({
+        headers: withAuthToken(headers.profile)(ctx),
+        enableCookies: true,
+        method: 'GET',
+        url,
+    })
+    return await http.request(await configRequest(ctx, url))
+}
+
+export const mutations = {
+
+    sendEmailVerification: async (_, args, {vtex: ioContext}) => {
+        const {data: {authenticationToken}} = await makeRequest(ioContext, paths.getTemporaryToken())
+        await makeRequest(ioContext, paths.sendEmailVerification(args.email, authenticationToken))
+        return authenticationToken
+    },
+
+    signin: async (_, args, {vtex: ioContext, request: {headers: {cookie}}, response}) => {
+        const {fields: {email, authToken, code}} = args
+        const {data: {authCookie}} = await makeRequest(ioContext, paths.signin(email, authToken, code))
+        response.set('Set-Cookie', serialize(authCookie.Name, authCookie.Value))
+        return authCookie
+    }
+}

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -22,7 +22,7 @@ export const mutations = {
 
   signIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
     const { fields: { email, authToken, code } } = args
-    const { data: { authCookie } } = await makeRequest(ioContext, paths.signin(email, authToken, code))
+    const { data: { authCookie } } = await makeRequest(ioContext, paths.signIn(email, authToken, code))
     response.set('Set-Cookie', serialize(authCookie.Name, authCookie.Value))
     return { name: authCookie.Name, value: authCookie.Value }
   }

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -18,7 +18,10 @@ export const mutations = {
     sendEmailVerification: async (_, args, {vtex: ioContext}) => {
         const {data: {authenticationToken}} = await makeRequest(ioContext, paths.getTemporaryToken())
         await makeRequest(ioContext, paths.sendEmailVerification(args.email, authenticationToken))
-        return authenticationToken
+        const authToken = {
+            authToken: authenticationToken
+        }
+        return authToken
     },
 
     signin: async (_, args, {vtex: ioContext, request: {headers: {cookie}}, response}) => {

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -63,7 +63,7 @@ const paths = {
 
   sendEmailVerification: (email, token) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
 
-  signin: (email, token, code) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
+  signIn: (email, token, code) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
 }
 
 export default paths

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -58,6 +58,12 @@ const paths = {
   gatewayTokenizePayment: (account, {sessionId}) => `${paths.gateway(account)}/pub/sessions/${sessionId}/tokens`,
 
   autocomplete: (account, {maxRows, searchTerm}) => `http://portal.vtexcommercestable.com.br/buscaautocomplete/?an=${account}&maxRows=${maxRows}&productNameContains=${encodeURIComponent(searchTerm)}`,
+
+  getTemporaryToken: () => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/start`,
+
+  sendEmailVerification: (email, token) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
+
+  signin: (email, token, code) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
 }
 
 export default paths


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create a new resolver to provide authentication through GraphQL mutations.

#### What problem is this solving?
Makes possible to the frontend authenticate using GraphQL without the need to include the script of vtexID.

#### How should this be manually tested?
Access: https://login-resolver--storecomponents.myvtex.com/_v/graphiqlServer
```
# Send a code to the email provided
mutation sendCode($email: String) {
  vtex_storegraphql_2_0_2_sendEmailVerification(email: $email) {
    vtex_storegraphql_2_0_2_authToken
  }
}

#Perform the authentication passing the email, code and authToken (returned by the sendCode)
mutation signin($authInput: vtex_storegraphql_2_0_2_AuthInput) {
  vtex_storegraphql_2_0_2_signIn(fields: $authInput) {
    vtex_storegraphql_2_0_2_Name
    vtex_storegraphql_2_0_2_Value
  }
}

# Query Variables
{
  "email": "example@vtex.com",
  "authInput": {
    "email": "example@vtex.com",
    "code": "886913",
    "authToken": "82052212-4381-464f-b900-6af975e98950"
  }
}

```
#### Screenshots or example usage
N/A

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
