### PR TITLE
Fix authResolver to set HTTPOnly on cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-* **Resolver** Master data resolver to provide get, get by id and create document.
+* **Resolver** Create `documentResolver` to provide get, get by id and create document.
+
+### Changed
+
+* **Resolver** Fix `authResolver` to set `HTTPOnly` on cookies.
 
 ## [2.1.0] - 2018-09-04
 

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -23,7 +23,6 @@ export const mutations = {
   signIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
     const { fields: { email, authToken, code } } = args
     const { data: { authCookie } } = await makeRequest(ioContext, paths.signIn(email, authToken, code))
-    response.set('Set-Cookie', serialize(authCookie.Name, authCookie.Value))
-    return { name: authCookie.Name, value: authCookie.Value }
+    response.set('Set-Cookie', serialize(authCookie.Name, authCookie.Value, { httpOnly: true }))
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Set `HTTPOnly=true` on cookies, and remove the return of authToken to `signIn` mutation.

#### What problem is this solving?
Its add the `HTTPOnly` on cookies. 

#### How should this be manually tested?

Access: https://bruno--storecomponents.myvtexdev.com/_v/graphiqlServer

Set the queries variables. Put your e-mail 
```
{
  "email": "example@vtex.com.br",
  "authInput": {
    "email": "example@vtex.com.br",
    "code": "217316",
    "authToken": "427c90f0-2cb3-4aa8-9cd1-ad6034a104ea"
  }
}
```

Execute this mutation and put the `authToken` in query variable object `authInput` Next, check your e-mail and put the access code too. 
```
mutation sendCode($email : String) { 
	vtex_storegraphql_2_1_1_sendEmailVerification(email : $email) {
    vtex_storegraphql_2_1_1_authToken
  }
}
```
Execute this mutation and check in the headers response that `set-cookie` have HTTPOnly now. 
```
mutation signIn($authInput: vtex_storegraphql_2_1_1_AuthInput) {
  vtex_storegraphql_2_1_1_signIn(fields: $authInput) {
    vtex_storegraphql_2_1_1_name
    vtex_storegraphql_2_1_1_value
  }
}
```

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
