### PR TITLE
Update document through Master Data API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.0] - 2018-16-04
+
 ### Added
 
-* **Resolver** Create `documentResolver` to provide get, get by id and create document.
+* **Resolver** Create `documentResolver` to provide `create`, `retrieve` and `update` Documents.
 * **Resolver** Create `brands` resolver to provide all brands from store.
 
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -54,5 +54,4 @@ type Mutation {
   signIn(fields: AuthInput): AuthClientToken
   createDocument(acronym: String, document: DocumentInput): DocumentResponse
   updateDocument(acronym: String, document: DocumentInput): DocumentResponse
-  deleteDocument(acronym: String, id: String): String
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -53,4 +53,6 @@ type Mutation {
   sendEmailVerification(email: String): AuthToken
   signIn(fields: AuthInput): AuthClientToken
   createDocument(acronym: String, document: DocumentInput): DocumentResponse
+  updateDocument(acronym: String, document: DocumentInput): DocumentResponse
+  deleteDocument(acronym: String, id: String): String
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -53,12 +53,5 @@ export const mutations = {
     makeRequest(args, ioContext, cookie, http.get),
 
   updateDocument: async (_, args, { vtex: ioContext, request: {headers: {cookie}}}) =>
-    makeRequest(args, ioContext, cookie, http.patch),
-
-  deleteDocument: async (_, args, { vtex: ioContext, request: {headers: {cookie}}}) => {
-    const {acronym, id} = args
-    const url = paths.document(ioContext.account, acronym, id)
-    const {data: status} = await http.delete(url, {headers: withAuthToken()(ioContext, cookie)})
-    return status
-  }
+    makeRequest(args, ioContext, cookie, http.patch)
 }

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -60,17 +60,12 @@ const paths = {
   autocomplete: (account, {maxRows, searchTerm}) => `http://portal.vtexcommercestable.com.br/buscaautocomplete/?an=${account}&maxRows=${maxRows}&productNameContains=${encodeURIComponent(searchTerm)}`,
 
   getTemporaryToken: () => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/start`,
-
   sendEmailVerification: (email, token) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
-
   signIn: (email, token, code) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
 
   searchDocument: (account, acronym, fields) => `http://api.vtex.com/${account}/dataentities/${acronym}/search?_fields=${fields}`,
-  
   documents: (account, acronym) => `http://api.vtex.com/${account}/dataentities/${acronym}/documents`,
-
   document: (account, acronym, id) => `${paths.documents(account, acronym)}/${id}`,
-
   documentFields: (account, acronym, fields="_all", id) => `${paths.document(account, acronym, id)}?_fields=${fields}`,
 }
 

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -66,10 +66,12 @@ const paths = {
   signIn: (email, token, code) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
 
   searchDocument: (account, acronym, fields) => `http://api.vtex.com/${account}/dataentities/${acronym}/search?_fields=${fields}`,
+  
+  documents: (account, acronym) => `http://api.vtex.com/${account}/dataentities/${acronym}/documents`,
 
-  document: (account, acronym, fields="_all", id) => `http://api.vtex.com/${account}/dataentities/${acronym}/documents/${id}?_fields=${fields}`,
+  document: (account, acronym, id) => `${paths.documents(account, acronym)}/${id}`,
 
-  documents: (account, acronym) => `http://api.vtex.com/${account}/dataentities/${acronym}/documents`
+  documentFields: (account, acronym, fields="_all", id) => `${paths.document(account, acronym, id)}?_fields=${fields}`,
 }
 
 export default paths


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add  update document, on Master Data API

#### What problem is this solving?
Provide a GraphQL layer to update generic documents.

#### How should this be manually tested?
Access: https://andre--storecomponents.myvtex.com/_v/vtex.store-graphql/graphiql/v1

```

mutation updateDocument($acronym: String, $documentToUpdate: vtex_storegraphql_2_1_1_DocumentInput) {
  vtex_storegraphql_2_1_1_updateDocument(acronym: $acronym, document: $documentToUpdate) {
    vtex_storegraphql_2_1_1_id
    vtex_storegraphql_2_1_1_href
    vtex_storegraphql_2_1_1_documentId
  }
}

query getDocument($acronym: String, $id: String, $fieldsToQuery: [String]) {
  vtex_storegraphql_2_1_1_document( acronym: $acronym, id: $id, fields: $fieldsToQuery) {
    vtex_storegraphql_2_1_1_id
    vtex_storegraphql_2_1_1_fields {
      vtex_storegraphql_2_1_1_key
      vtex_storegraphql_2_1_1_value
    }
  }
}

```

```
{
  "acronym": "CL",
  "id": "e10e9c9a-3e4c-11e8-81df-b109c3959c52",
  "fieldsToQuery": [
    "firstName",
    "lastName",
    "email",
    "id"
  ],
  "documentToUpdate": {
    "fields": [
      {
        "key": "id",
        "value": "e10e9c9a-3e4c-11e8-81df-b109c3959c52"
      },
      {
        "key": "firstName",
        "value": "Jessika"
      }
    ]
  }
}
```
#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
