### PR TITLE
Fix products query to accept map param and reject invalid characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Added `map` param to the `products` query
+
+### Fixed
+
+* Fixed the `products` query to reject invalid characters
+
 ## [2.3.0] - 2018-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.3.1] - 2018-05-03
+
 ### Added
 
 * Added `map` param to the `products` query

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -2,6 +2,7 @@ type Query {
   product(slug: String): Product
   products(
     query: String = "",
+    map: String = "",
     category: String = "",
     specificationFilters: [String],
     priceRange: String = "",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -33,7 +33,7 @@ export default {
 
   products: async (_, data, {vtex: ioContext}: ColossusContext, info) => {
     const queryTerm = data.query
-    if (test(/[\?\=\,]/, queryTerm)) {
+    if (test(/[\?\&\[\]\=\,]/, queryTerm)) {
       throw new ResolverError(`The query term: '${queryTerm}' contains invalid characters.`, 500)
     }
     const url = paths.products(ioContext.account, data)

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -1,7 +1,7 @@
 import axios, {AxiosResponse} from 'axios'
 import {ColossusContext} from 'colossus'
 import graphqlFields from 'graphql-fields'
-import {compose, equals, head, find, map, prop} from 'ramda'
+import {compose, equals, head, find, map, prop, test} from 'ramda'
 import ResolverError from '../../errors/resolverError'
 import {withAuthToken} from '../headers'
 import paths from '../paths'
@@ -32,6 +32,10 @@ export default {
   },
 
   products: async (_, data, {vtex: ioContext}: ColossusContext, info) => {
+    const queryTerm = data.query
+    if (test(/[\?\=\,]/, queryTerm)) {
+      throw new ResolverError(`The query term: '${queryTerm}' contains invalid characters.`, 500)
+    }
     const url = paths.products(ioContext.account, data)
     const {data: products} = await axios.get(url, { headers: withAuthToken()(ioContext) })
     const fields = graphqlFields(info)

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -11,19 +11,7 @@ const paths = {
   category: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pvt/category/${id}`,
   categories: (account, {treeLevel}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/category/tree/${treeLevel}/`,
   
-  products: (account, {
-    query = '', 
-    map= '',
-    fulltext = '', 
-    category ='', 
-    specificationFilters = '', 
-    priceRange ='', 
-    collection = '', 
-    salesChannel = '',
-    orderBy = '', 
-    from = 0, 
-    to = 9
-  }) => `${paths.search(account)}/${encodeURIComponent(query)}?${map && `map=${map}`}${category && `&fq=C:/${category}/`}${specificationFilters && '&' + specificationFilters}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
+  products: (account, {query = '', map= '', fulltext = '', category ='', specificationFilters = '', priceRange ='', collection = '', salesChannel = '', orderBy = '', from = 0, to = 9}) => `${paths.search(account)}/${encodeURIComponent(query)}?${map && `map=${map}`}${category && `&fq=C:/${category}/`}${specificationFilters && '&' + specificationFilters}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
   
   facets: (account, {facets=''}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/facets/search/${encodeURI(facets)}`,
 

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -1,16 +1,30 @@
 const paths = {
-  product: (account, {slug}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search/${slug}/p`,
-  productByEan: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=alternateIds_Ean=${id}`,
-  productById: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=productId:${id}`,
-  productByReference: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=alternateIds_RefId=${id}`,
-  productBySku: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search?fq=skuId=${id}`,
-
+  search: (account) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search`,
+  
+  product: (account, {slug}) => `${paths.search(account)}/${slug}/p`,
+  productByEan: (account, {id}) => `${paths.search(account)}?fq=alternateIds_Ean=${id}`,
+  productById: (account, {id}) => `${paths.search(account)}?fq=productId:${id}`,
+  productByReference: (account, {id}) => `${paths.search(account)}?fq=alternateIds_RefId=${id}`,
+  productBySku: (account, {id}) => `${paths.search(account)}?fq=skuId=${id}`,
+  
   brand: (account) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pvt/brand/list`,
   category: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pvt/category/${id}`,
   categories: (account, {treeLevel}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/category/tree/${treeLevel}/`,
-
-  products: (account, {query = '', fulltext = '', category ='', specificationFilters, priceRange ='', collection = '', salesChannel = '', orderBy = '', from = 0, to = 9}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search/${encodeURIComponent(query)}?${category && `&fq=C:/${category}/`}${specificationFilters && '&' + specificationFilters}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
-
+  
+  products: (account, {
+    query = '', 
+    map= '',
+    fulltext = '', 
+    category ='', 
+    specificationFilters = '', 
+    priceRange ='', 
+    collection = '', 
+    salesChannel = '',
+    orderBy = '', 
+    from = 0, 
+    to = 9
+  }) => `${paths.search(account)}/${encodeURIComponent(query)}?${map && `map=${map}`}${category && `&fq=C:/${category}/`}${specificationFilters && '&' + specificationFilters}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
+  
   facets: (account, {facets=''}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/facets/search/${encodeURI(facets)}`,
 
   crossSelling: (account, id, type) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/crossselling/${type}/${id}`,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Give the possibility to the user to add a `map` param to the `Products` query and reject query terms that use invalid characters, as `? & = , [ ]`.

#### How should this be manually tested?
Access: https://andre--storecomponents.myvtex.com/_v/vtex.store-graphql/graphiql/v1

Query: 
```
query products($query:String,$orderBy:String, $map:String) {
  products(query:$query, orderBy: $orderBy, map: $map) {
    productName
  }
}
```

Query variables:
```
{
  "query": "TV",
  "map": "c,c",
  "orderBy": "OrderByNameASC"
}
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
