### PR TITLE
Change orderForm query to parse prices to float

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 #### Screenshots or example usage
 
 #### Types of changes
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Bug fix (a non-breaking change which fixes an issue)
+- [ ] New feature (a non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Requires change to documentation, which has been updated accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* **Resolver** Changed the `OrderForm` query to parse the integer prices to float.
+
 ## [2.3.2] - 2018-04-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.3.3] - 2018-04-05
+## [2.3.3] - 2018-04-10
 ### Changed
 - **Resolver** Changed the `OrderForm` query to parse the integer prices to float.
 ### Added

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -26,10 +26,10 @@ type OrderFormItem {
   refId: String
   ean: String
   priceValidUntil: String
-  price: Int
+  price: Float
   tax: Int
-  listPrice: Int
-  sellingPrice: Int
+  listPrice: Float
+  sellingPrice: Float
   rewardValue: Int
   isGift: Boolean
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.3.2",
+  "version": "2.3.3-beta",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.3.3-beta",
+  "version": "2.3.3",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -4,9 +4,30 @@ import httpResolver from '../httpResolver'
 import paths from '../paths'
 import paymentTokenResolver from './paymentTokenResolver'
 
+/**
+ * It will convert an integer to float moving the
+ * float point two positions left. That is needed
+ * once the OrderForm REST API return an integer
+ * colapsing the floating point into the integer
+ * part.
+ * 
+ * @param int An integer number
+ */
+const convertIntToFloat = int => int * 0.01
+
 export const queries = {
   orderForm: httpResolver({
     data: {expectedOrderFormSections: ['items']},
+    merge: (bodyData, responseData) => ({
+      ...responseData,
+      value: convertIntToFloat(responseData.value),
+      items: map((item) => ({
+        ...item,
+        price: convertIntToFloat(item.price),
+        listPrice: convertIntToFloat(item.listPrice),
+        sellingPrice: convertIntToFloat(item.sellingPrice)
+      }), responseData.items)
+    }),
     enableCookies: true,
     headers: withAuthToken(headers.json),
     method: 'POST',

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -6,10 +6,14 @@ import paymentTokenResolver from './paymentTokenResolver'
 
 /**
  * It will convert an integer to float moving the
- * float point two positions left. That is needed
- * once the OrderForm REST API return an integer
+ * float point two positions left.
+ * 
+ * The OrderForm REST API return an integer
  * colapsing the floating point into the integer
- * part.
+ * part. We needed to make a convention of the product 
+ * price on different API's. Once the Checkout API 
+ * returns an integer instead of a float, and the 
+ * Catalog API returns a float.
  * 
  * @param int An integer number
  */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change `orderForm ` query to parse prices to float

#### What problem is this solving?
When the price component uses the query `OrderForm` the prices properties returns integer numbers instead float which is what this component expected.

#### How should this be manually tested?
Access: https://ordersform-resolver--storecomponents.myvtex.com/_v/vtex.store-graphql/graphiql/v1

**Query**: 

```
query orders {
  orderForm {
    orderFormId
    value
    items {
      id
      name
      sellingPrice
      price
    }
  }
}
```
#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
