### PR TITLE
Add to the autocomplete query the slug property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* **Resolver** Added to the `autocomplete` query the `slug` property
+
 ## [2.3.2] - 2018-04-05
 
 ### Fixed

--- a/graphql/types/Suggestions.graphql
+++ b/graphql/types/Suggestions.graphql
@@ -7,4 +7,5 @@ type Items {
   name: String
   href: String
   criteria: String
+  slug: String
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add to the autocomplete query the `slug`  property

#### What problem is this solving?
The `slug` property is needed by the search component to create the link to the product page.

#### How should this be manually tested?
Access: https://autocomplete-slug--storecomponents.myvtex.com/_v/vtex.store-graphql/graphiql/v1

```
query autocomplete {
  autocomplete(searchTerm: "lg") {
    itemsReturned {
      name
      href
      slug
    }
  }
}
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
