### PR TITLE
Fix profile query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.2]
 ### Changed
  * Changed `shipping` query to perform freight simulation correctly.
+### Fixed
+ - Fixed `profile` query permissions to read masterdata private fields
 
 ## [2.3.3] - 2018-04-10
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -93,6 +93,9 @@
         "host": "api.vtex.com",
         "path": "/{{account}}/dataentities/*"
       }
+    },
+    {
+      "name": "POWER_USER_DS"
     }
   ]
 }

--- a/node/resolvers/profile/profileResolver.ts
+++ b/node/resolvers/profile/profileResolver.ts
@@ -19,10 +19,18 @@ const profile = (ctx) => async (data) => {
   }
 
   const {user} = data
-  const profileRequest = await configRequest(ctx, paths.profile(ctx.account).filterUser(user))
-  const profileData = await http.request(profileRequest).then<any>(pipe(prop('data'), head))
-  const addressRequest = profileData && await configRequest(ctx, paths.profile(ctx.account).filterAddress(profileData.id))
-  const address = addressRequest && await http.request(addressRequest).then(prop('data'))
+  const config = {
+    headers: {
+      'Proxy-Authorization': ctx.authToken,
+      vtexidclientautcookie: ctx.authToken,
+    },
+  }
+
+  const profileURL = paths.profile(ctx.account).filterUser(user)
+  const profileData = await http.get(profileURL, config).then<any>(pipe(prop('data'), head))
+
+  const addressURL = paths.profile(ctx.account).filterAddress(profileData.id)
+  const address = profileData && await http.get(addressURL, config).then(prop('data'))
 
   return merge({address}, profileData)
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
It fixes permissions to get profile data form masterdata

#### What problem is this solving?
There are some fields in masterdata that are `private`. It means you can't read them unless you have authorization. Our profile query is broken because it brings a lot of these `private` fields, like `email`.

```
"Forbidden access to the fields 'email'"
```

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
