### PR TITLE
Fix authentication resolver to sign in only at users of a context account

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,1 @@
+/usr/local/lib/node_modules/vtex/.eslintrc

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node/**/!(main).js
 node/**/*.js.map
 .vscode/
 .DS_Store
+node/package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix authentication resolver to sign in only account users.
+
 ## [2.4.2]
 ### Changed
- * Changed `shipping` query to perform freight simulation correctly.
+- Change `shipping` query to perform freight simulation correctly.
+
 ### Fixed
- - Fixed `profile` query permissions to read masterdata private fields
+ - Fix `profile` query permissions to read masterdata private fields
 
 ## [2.3.3] - 2018-04-10
 ### Changed
-- **Resolver** Changed the `OrderForm` query to parse the integer prices to float.
+- **Resolver** Change the `OrderForm` query to parse the integer prices to float.
 ### Added
-- **Resolver** Added to the `autocomplete` query the `slug` property
+- **Resolver** Add to the `autocomplete` query the `slug` property
 
 ## [2.3.2] - 2018-04-05
 ### Fixed
@@ -23,15 +29,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.3.1] - 2018-05-03
 ### Added
-- Added `map` param to the `products` query
+- Add `map` param to the `products` query
 ### Fixed
-- Fixed the `products` query to reject invalid characters
+- Fix the `products` query to reject invalid characters
 
 ## [2.1.0] - 2018-09-04
 ### Added
-- Added `map` param to the `products` query
+- Add `map` param to the `products` query
 ### Fixed
-- Fixed the `products` query to reject invalid characters
+- Fix the `products` query to reject invalid characters
 
 ## [2.3.0] - 2018-04-27
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -56,8 +56,8 @@ type Mutation {
   createPaymentSession: PaymentSession
   createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
   setPlaceholder(fields: PlaceholderInput): Boolean
-  sendEmailVerification(email: String): AuthToken
-  signIn(fields: AuthInput): AuthClientToken
+  sendEmailVerification(email: String): String
+  signIn(fields: AuthInput): Boolean
   createDocument(acronym: String, document: DocumentInput): DocumentResponse
   updateDocument(acronym: String, document: DocumentInput): DocumentResponse
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -56,7 +56,7 @@ type Mutation {
   createPaymentSession: PaymentSession
   createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
   setPlaceholder(fields: PlaceholderInput): Boolean
-  sendEmailVerification(email: String): AuthToken
+  sendEmailVerification(email: String): Boolean
   accessKeySignIn(fields: AuthInput): Boolean
   createDocument(acronym: String, document: DocumentInput): DocumentResponse
   updateDocument(acronym: String, document: DocumentInput): DocumentResponse

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -57,7 +57,7 @@ type Mutation {
   createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
   setPlaceholder(fields: PlaceholderInput): Boolean
   sendEmailVerification(email: String): AuthToken
-  signIn(fields: AuthInput): Boolean
+  accessKeySignIn(fields: AuthInput): Boolean
   createDocument(acronym: String, document: DocumentInput): DocumentResponse
   updateDocument(acronym: String, document: DocumentInput): DocumentResponse
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -56,7 +56,7 @@ type Mutation {
   createPaymentSession: PaymentSession
   createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
   setPlaceholder(fields: PlaceholderInput): Boolean
-  sendEmailVerification(email: String): String
+  sendEmailVerification(email: String): AuthToken
   signIn(fields: AuthInput): Boolean
   createDocument(acronym: String, document: DocumentInput): DocumentResponse
   updateDocument(acronym: String, document: DocumentInput): DocumentResponse

--- a/graphql/types/Auth.graphql
+++ b/graphql/types/Auth.graphql
@@ -1,10 +1,6 @@
-""" Return session token"""
-type AuthToken {
-  authToken: String
-}
 """Data needed to authentication """
 input AuthInput {
   email: String, 
   code: String, 
-  authToken: String
+  temporarySession: String
 }

--- a/graphql/types/Auth.graphql
+++ b/graphql/types/Auth.graphql
@@ -1,4 +1,8 @@
-"""Input to sign in by access code based authentication"""
+""" Return session token"""
+type AuthToken {
+  authToken: String
+}
+"""Data needed to authentication """
 input AuthInput {
   email: String, 
   code: String, 

--- a/graphql/types/Auth.graphql
+++ b/graphql/types/Auth.graphql
@@ -2,5 +2,5 @@
 input AuthInput {
   email: String, 
   code: String, 
-  temporarySession: String
+  VtexTemporarySession: String
 }

--- a/graphql/types/Auth.graphql
+++ b/graphql/types/Auth.graphql
@@ -1,12 +1,4 @@
-type AuthClientToken {
-  name: String,
-  value: String
-}
-
-type AuthToken {
-  authToken: String
-}
-
+"""Input to sign in by access code based authentication"""
 input AuthInput {
   email: String, 
   code: String, 

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   },
   "mustUpdateAt": "2017-09-05",
   "scripts": {
-    "postreleasy": "vtex publish --public"
+    "postreleasy": "vtex -r vtex --verbose"
   },
   "policies": [
     {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,5 @@
 {
   "name": "vtex.store-graphql",
-  "version": null,
   "dependencies": {
     "axios": "0.16.2",
     "bluebird": "^3.5.0",

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -27,6 +27,7 @@ export const mutations = {
   },
 
   accessKeySignIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
+    // FIXME: Get temporarySession in cookies instead of args. @brunojdo - 08/06/2018 
     const { fields: { email, temporarySession, code } } = args
     const { data, status } = await makeRequest(ioContext, paths.accessKeySignIn(email, temporarySession, code))
     if (!data.authCookie) {

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -15,7 +15,7 @@ const makeRequest = async (ctx, url) => {
 
 export const mutations = {
   sendEmailVerification: async (_, args, { vtex: ioContext }) => {
-    const { data: { authenticationToken } } = await makeRequest(ioContext, paths.getTemporaryToken())
+    const { data: { authenticationToken } } = await makeRequest(ioContext, paths.getTemporaryToken(ioContext.account, ioContext.account))
     await makeRequest(ioContext, paths.sendEmailVerification(args.email, authenticationToken))
     return { authToken: authenticationToken }
   },
@@ -24,5 +24,6 @@ export const mutations = {
     const { fields: { email, authToken, code } } = args
     const { data: { authCookie } } = await makeRequest(ioContext, paths.signIn(email, authToken, code))
     response.set('Set-Cookie', serialize(authCookie.Name, authCookie.Value, { httpOnly: true }))
+    return authCookie
   }
 }

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -1,5 +1,5 @@
 import http from 'axios'
-import { serialize } from 'cookie'
+import { serialize, parse } from 'cookie'
 import paths from '../paths'
 import { withAuthToken, headers } from '../headers'
 import ResolverError from '../../errors/resolverError'
@@ -22,13 +22,13 @@ export const mutations = {
       throw new ResolverError(`ERROR ${data}`, status)
     }
     await makeRequest(ioContext, paths.sendEmailVerification(args.email, data.authenticationToken))
-    response.set('Set-Cookie', serialize('temporarySession', data.authenticationToken, { httpOnly: true }))
+    response.set('Set-Cookie', serialize('temporarySession', data.authenticationToken, { path: '/', }))
     return data.authenticationToken ? true : false
   },
 
-  accessKeySignIn: async (_, args, { vtex: ioContext, response }) => {
-    const { fields: { email, authToken, code } } = args
-    const { data, status } = await makeRequest(ioContext, paths.accessKeySignIn(email, authToken, code))
+  accessKeySignIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
+    const { fields: { email, temporarySession, code } } = args
+    const { data, status } = await makeRequest(ioContext, paths.accessKeySignIn(email, temporarySession, code))
     if (!data.authCookie) {
       throw new ResolverError(`ERROR ${data.authStatus}`, status)
     }

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -1,19 +1,19 @@
 const paths = {
   search: (account) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search`,
 
-  product: (account, {slug}) => `${paths.search(account)}/${slug}/p`,
-  productByEan: (account, {id}) => `${paths.search(account)}?fq=alternateIds_Ean=${id}`,
-  productById: (account, {id}) => `${paths.search(account)}?fq=productId:${id}`,
-  productByReference: (account, {id}) => `${paths.search(account)}?fq=alternateIds_RefId=${id}`,
-  productBySku: (account, {id}) => `${paths.search(account)}?fq=skuId:${id}`,
+  product: (account, { slug }) => `${paths.search(account)}/${slug}/p`,
+  productByEan: (account, { id }) => `${paths.search(account)}?fq=alternateIds_Ean=${id}`,
+  productById: (account, { id }) => `${paths.search(account)}?fq=productId:${id}`,
+  productByReference: (account, { id }) => `${paths.search(account)}?fq=alternateIds_RefId=${id}`,
+  productBySku: (account, { id }) => `${paths.search(account)}?fq=skuId:${id}`,
 
   brand: (account) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pvt/brand/list`,
-  category: (account, {id}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pvt/category/${id}`,
-  categories: (account, {treeLevel}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/category/tree/${treeLevel}/`,
+  category: (account, { id }) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pvt/category/${id}`,
+  categories: (account, { treeLevel }) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/category/tree/${treeLevel}/`,
 
-  products: (account, {query = '', fulltext = '', category ='', specificationFilters, priceRange ='', collection = '', salesChannel = '', orderBy = '', from = 0, to = 9, map = ''}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search/${encodeURIComponent(query)}?${category && `&fq=C:/${category}/`}${(specificationFilters && specificationFilters.length > 0 && specificationFilters.map(filter => `&fq=${filter}`)) || ''}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${map && `&map=${map}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
+  products: (account, { query = '', fulltext = '', category = '', specificationFilters, priceRange = '', collection = '', salesChannel = '', orderBy = '', from = 0, to = 9, map = '' }) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/search/${encodeURIComponent(query)}?${category && `&fq=C:/${category}/`}${(specificationFilters && specificationFilters.length > 0 && specificationFilters.map(filter => `&fq=${filter}`)) || ''}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${map && `&map=${map}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
 
-  facets: (account, {facets=''}) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/facets/search/${encodeURI(facets)}`,
+  facets: (account, { facets = '' }) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/facets/search/${encodeURI(facets)}`,
 
   crossSelling: (account, id, type) => `http://${account}.vtexcommercestable.com.br/api/catalog_system/pub/products/crossselling/${type}/${id}`,
 
@@ -21,29 +21,29 @@ const paths = {
 
   orderForm: (account) => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orderForm`,
 
-  orderFormProfile: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/attachments/clientProfileData`,
+  orderFormProfile: (account, { orderFormId }) => `${paths.orderForm(account)}/${orderFormId}/attachments/clientProfileData`,
 
-  orderFormShipping: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/attachments/shippingData`,
+  orderFormShipping: (account, { orderFormId }) => `${paths.orderForm(account)}/${orderFormId}/attachments/shippingData`,
 
-  orderFormPayment: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/attachments/paymentData`,
+  orderFormPayment: (account, { orderFormId }) => `${paths.orderForm(account)}/${orderFormId}/attachments/paymentData`,
 
-  orderFormPaymentToken: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/paymentData/paymentToken`,
+  orderFormPaymentToken: (account, { orderFormId }) => `${paths.orderForm(account)}/${orderFormId}/paymentData/paymentToken`,
 
-  orderFormPaymentTokenId: (account, {orderFormId, tokenId}) => `${paths.orderForm(account)}/${orderFormId}/paymentData/paymentToken/${tokenId}`,
+  orderFormPaymentTokenId: (account, { orderFormId, tokenId }) => `${paths.orderForm(account)}/${orderFormId}/paymentData/paymentToken/${tokenId}`,
 
-  orderFormIgnoreProfile: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/profile`,
+  orderFormIgnoreProfile: (account, { orderFormId }) => `${paths.orderForm(account)}/${orderFormId}/profile`,
 
-  orderFormCustomData: (account, {orderFormId, appId, field}) => `${paths.orderForm(account)}/${orderFormId}/customData/${appId}/${field}`,
+  orderFormCustomData: (account, { orderFormId, appId, field }) => `${paths.orderForm(account)}/${orderFormId}/customData/${appId}/${field}`,
 
-  addItem: (account, {orderFormId}) => `${paths.orderForm(account)}/${orderFormId}/items`,
+  addItem: (account, { orderFormId }) => `${paths.orderForm(account)}/${orderFormId}/items`,
 
   updateItems: (account, data) => `${paths.addItem(account, data)}/update`,
 
   orders: account => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orders`,
 
-  cancelOrder: (account, {orderFormId}) => `${paths.orders(account)}/${orderFormId}/user-cancel-request`,
+  cancelOrder: (account, { orderFormId }) => `${paths.orders(account)}/${orderFormId}/user-cancel-request`,
 
-  identity: (account, {token}) => `http://vtexid.vtex.com.br/api/vtexid/pub/authenticated/user?authToken=${encodeURIComponent(token)}`,
+  identity: (account, { token }) => `http://vtexid.vtex.com.br/api/vtexid/pub/authenticated/user?authToken=${encodeURIComponent(token)}`,
 
   profile: account => ({
     address: (id) => `http://api.vtex.com/${account}/dataentities/AD/documents/${id}`,
@@ -56,18 +56,18 @@ const paths = {
 
   gatewayPaymentSession: account => `${paths.gateway(account)}/pvt/sessions`,
 
-  gatewayTokenizePayment: (account, {sessionId}) => `${paths.gateway(account)}/pub/sessions/${sessionId}/tokens`,
+  gatewayTokenizePayment: (account, { sessionId }) => `${paths.gateway(account)}/pub/sessions/${sessionId}/tokens`,
 
-  autocomplete: (account, {maxRows, searchTerm}) => `http://portal.vtexcommercestable.com.br/buscaautocomplete/?an=${account}&maxRows=${maxRows}&productNameContains=${encodeURIComponent(searchTerm)}`,
+  autocomplete: (account, { maxRows, searchTerm }) => `http://portal.vtexcommercestable.com.br/buscaautocomplete/?an=${account}&maxRows=${maxRows}&productNameContains=${encodeURIComponent(searchTerm)}`,
 
-  getTemporaryToken: () => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/start`,
+  getTemporaryToken: (scope, account) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/start?appStart=true&scope=${scope}&accountName=${account}`,
   sendEmailVerification: (email, token) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
   signIn: (email, token, code) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
 
   searchDocument: (account, acronym, fields) => `http://api.vtex.com/${account}/dataentities/${acronym}/search?_fields=${fields}`,
   documents: (account, acronym) => `http://api.vtex.com/${account}/dataentities/${acronym}/documents`,
   document: (account, acronym, id) => `${paths.documents(account, acronym)}/${id}`,
-  documentFields: (account, acronym, fields="_all", id) => `${paths.document(account, acronym, id)}?_fields=${fields}`,
+  documentFields: (account, acronym, fields = "_all", id) => `${paths.document(account, acronym, id)}?_fields=${fields}`,
 }
 
 export default paths

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -62,7 +62,7 @@ const paths = {
 
   getTemporaryToken: (scope, account) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/start?appStart=true&scope=${scope}&accountName=${account}`,
   sendEmailVerification: (email, token) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
-  signIn: (email, token, code) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
+  accessKeySignIn: (email, token, code) => `http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
 
   searchDocument: (account, acronym, fields) => `http://api.vtex.com/${account}/dataentities/${acronym}/search?_fields=${fields}`,
   documents: (account, acronym) => `http://api.vtex.com/${account}/dataentities/${acronym}/documents`,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Now, this resolver authenticates only users of a context account

#### What problem is this solving?
Before, the auth resolver were sign in admin mode.

#### Screenshots or example usage
To test [access here](https://dev--storecomponents.myvtex.com/_v/vtex.store-graphql/graphiql/v1?variables=%7B%0A%20%20%22email%22%3A%20%22example%40vtex.com%22%2C%0A%20%20%22authInput%22%3A%20%7B%0A%20%20%20%20%22email%22%3A%20%22example%40vtex.com%22%2C%0A%20%20%20%20%22code%22%3A%20%22791639%22%2C%0A%20%20%20%20%22authToken%22%3A%20%226CD4C196ED9DEFB727548AD991F4B61C446BC4468913D1DCDA360B93EF6F40B6%22%0A%20%20%7D%0A%7D&operationName=signin&query=mutation%20sendCode(%24email%3A%20String)%20%7B%0A%20%20sendEmailVerification(email%3A%20%24email)%20%7B%0A%20%20%20%20authToken%0A%20%20%7D%0A%7D%0A%0A%23Perform%20the%20authentication%20passing%20the%20email%2C%20code%20and%20authToken%20(returned%20by%20the%20sendCode)%0Amutation%20signin(%24authInput%3A%20AuthInput)%20%7B%0A%20%20signIn(fields%3A%20%24authInput)%0A%7D%0A%0A)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
