### PR TITLE
Set the maxAge received from VTEXID to VtexIdclientAutCookie_${account}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.6.1] - 2018-6-15
 ### Fixed 
 - Set the `maxAge` received from VTEXID to `VtexIdclientAutCookie_${account}` in `accessKeySigIn` mutation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Set the `maxAge` received from VTEXID to `VtexIdclientAutCookie_${account}` in `accessKeySigIn` mutation.
 
 ## [2.6.0] - 2018-6-15
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -42,9 +42,10 @@ export const mutations = {
         {
           httpOnly: true,
           path: '/',
-          expires: new Date(authCookie['expires']).toISOString,
+          maxAge: new Date(authCookie['expires']).getTime(),
           secure: true
-        }))
+        }),
+    )
     return true
   },
 
@@ -53,13 +54,8 @@ export const mutations = {
   logout: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
     const authAccount = `VtexIdclientAutCookie_${ioContext.account}`
     response.set('Set-Cookie',
-      serialize(authAccount, '',
-        {
-          httpOnly: true,
-          path: '/',
-          maxAge: 0,
-          secure: true
-        }))
+      serialize(authAccount, '', { path: '/', maxAge: 0, })
+    )
     return true
   }
 }

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -42,6 +42,7 @@ export const mutations = {
         {
           httpOnly: true,
           path: '/',
+          expires: new Date(authCookie['expires']).toISOString,
           secure: true
         }))
     return true


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Set the maxAge received from VTEXID to VtexIdclientAutCookie_${account} cookie

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Send expires date that was received by VTEXID API in the response. 

#### Screenshots or example usage
[Access here](https://login--storecomponents.myvtexdev.com/_v/vtex.store-graphql/graphiql/v1?query=mutation%20sendEmail%20%7B%0A%20%20sendEmailVerification(email%3A%22bruno.dias%40vtex.com%22)%0A%7D%0A%0Amutation%20signIn%20%7B%0A%20%20accessKeySignIn(fields%3A%7Bemail%3A%22bruno.dias%40vtex.com%22%2C%20code%3A%22496442%22%7D)%0A%7D%0A%0Amutation%20logout%7B%0A%20%20logout%0A%7D&operationName=logout)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
