### PR TITLE
Fix profile resolver to use ioContext authToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add documentation in `graphql` files. 
+- Profile Query will return the user email in case of data not found.
+
+###
+- Fix `profile resolver` to use ioContext authToken.
 
 ## [2.6.1] - 2018-6-15
 ### Fixed 

--- a/node/resolvers/profile/profileResolver.ts
+++ b/node/resolvers/profile/profileResolver.ts
@@ -27,10 +27,15 @@ const profile = (ctx) => async (data) => {
   const profileURL = paths.profile(ctx.account).filterUser(user)
   const profileData = await http.get(profileURL, config).then<any>(pipe(prop('data'), head))
 
-  const addressURL = paths.profile(ctx.account).filterAddress(profileData.id)
-  const address = profileData && await http.get(addressURL, config).then(prop('data'))
+  if (profileData && profileData.id) {
+    const addressURL = paths.profile(ctx.account).filterAddress(profileData.id)
+    const address = profileData && await http.get(addressURL, config).then(prop('data'))
 
-  return merge({ address }, profileData)
+    return merge({ address }, profileData)
+  }
+  return {
+    email: user
+  }
 }
 
 export default async (_, args, { vtex: ioContext, request: { headers: { cookie } } }) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix profile resolver to use ioContext authToken.
- Profile Query will return the user email in case of data not found.

#### What problem is this solving?
Profile resolver was using the client token to make requests to the Master Data.

#### How should this be manually tested?
Access: https://profile--storecomponents.myvtex.com/_v/vtex.store-graphql/graphiql/v1

**Data to make some tests:** 

> **_Needed to signIn first_**
> ````
>mutation sendCode {
>  sendEmailVerification(email:"email@vtex.com")
>}
>mutation signIn {
>  accessKeySignIn(fields:{
>    email:"email@vtex.com",
>    code:"CODE_SENT_TO_EMAIL"
>  })
>}
>````

```
mutation updateProfile {
  updateProfile(fields: {
    firstName: "Sherlock"
  }) {
    firstName,
    lastName,
    email
  }
}

mutation createAddress {
  createAddress(fields: {
    street: "Beaker Str.",
    number:"221b",
    addressName: "Home"
  }) {
    address {
      addressName
    }
  }
}

mutation updateAddress {
  updateAddress(id:"6efd021b-6f19-11e8-81f2-e741e33d0078", fields: {
    street: "Beaker Street"
    addressName:"Sherlock"
    number: "310"
  }) {
    address {
      id
      number
      street
    }
  }
}

mutation deleteAddress {
  deleteAddress(id:"85f55eff-6db1-11e8-81f2-ebd2fe49ba22")
}

query profile {
  profile {
    id
    firstName
    address {
      id
      addressName
      street
      number
    }
  }
}
```

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)
- New feature (a non-breaking change which adds functionality)