### PR TITLE
Fix products search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.7.2] - 2018-6-20
+
 ### Fixed 
 - Fix products search query only adding a category if there is not a search term.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.7.1] - 2018-6-20
+### Fixed 
+- Fix products search query only adding a category if there is not a search term.
 
+## [2.7.1] - 2018-6-20
 ### Fixed
 - Fix `vtexId` use on `paths.ts`. 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -22,7 +22,7 @@ const paths = {
     from = 0,
     to = 9,
     map = ''
-  }) => `${paths.catalog(account)}/pub/products/search/${encodeURIComponent(query)}?${category && `&fq=C:/${category}/`}${(specificationFilters && specificationFilters.length > 0 && specificationFilters.map(filter => `&fq=${filter}`)) || ''}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${map && `&map=${map}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
+  }) => `${paths.catalog(account)}/pub/products/search/${encodeURIComponent(query)}?${category && !query && `&fq=C:/${category}/`}${(specificationFilters && specificationFilters.length > 0 && specificationFilters.map(filter => `&fq=${filter}`)) || ''}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${map && `&map=${map}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`,
 
   brand: account => `${paths.catalog(account)}/pvt/brand/list`,
   category: (account, { id }) => `${paths.catalog(account)}/pvt/category/${id}`,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a condition to only use a category in the products' search query if there isn't a search term.  

#### What problem is this solving?
When there's a category on the search URL the results only match this parameter, the search term is ignored.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
