### PR TITLE
 Add classic login mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.8.0] - 2018-6-25
 ### Added
 - Add classic login mutation. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add classic login mutation. 
+
+### Changed
+- Refact auth resolver. 
 
 ## [2.7.2] - 2018-6-20
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -131,10 +131,29 @@ type Mutation {
   createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
   setPlaceholder(fields: PlaceholderInput): Boolean
 
-  """ Auth """
-  sendEmailVerification(email: String): Boolean
-  accessKeySignIn(email: String, code: String): Boolean
-  classicSignIn(email: String, password: String): Boolean
+  """ Send access key to user email """
+  sendEmailVerification(
+    """ User email"""
+    email: String
+  ): Boolean
+
+  """  Access key sign in mode """
+  accessKeySignIn(
+    """ User email"""
+    email: String, 
+    """ Access key that was received """
+    code: String
+  ): Boolean
+
+  """  Classic sign in mode """
+  classicSignIn(
+    """ User email"""
+    email: String, 
+    """ User password """
+    password: String
+  ): Boolean
+
+  """ Invalidate VtexIdclientAutCookie """
   logout: Boolean
 
   """ Document """

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -134,24 +134,24 @@ type Mutation {
   """ Send access key to user email """
   sendEmailVerification(
     """ User email"""
-    email: String
+    email: String!
   ): Boolean
 
   """  Access key sign in mode """
   accessKeySignIn(
     """ User email"""
-    email: String, 
+    email: String!, 
     """ Access key that was received """
-    code: String
-  ): Boolean
+    code: String!
+  ): String
 
   """  Classic sign in mode """
   classicSignIn(
     """ User email"""
-    email: String, 
+    email: String!, 
     """ User password """
-    password: String
-  ): Boolean
+    password: String!
+  ): String
 
   """ Invalidate VtexIdclientAutCookie """
   logout: Boolean

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -133,7 +133,8 @@ type Mutation {
 
   """ Auth """
   sendEmailVerification(email: String): Boolean
-  accessKeySignIn(fields: AuthInput): Boolean
+  accessKeySignIn(email: String, code: String): Boolean
+  classicSignIn(email: String, password: String): Boolean
   logout: Boolean
 
   """ Document """

--- a/graphql/types/Auth.graphql
+++ b/graphql/types/Auth.graphql
@@ -1,9 +1,0 @@
-"""
-Input needed to authentication by access key
-"""
-input AuthInput {
-  """ User email """
-  email: String, 
-  """ Access key that user received by email """
-  code: String, 
-}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -15,64 +15,55 @@ const makeRequest = async (ctx, url) => {
   return await http.request(await configRequest(ctx, url))
 }
 
+const getSessionToken = async ioContext => {
+  const { data, status } = await makeRequest(ioContext, paths.getTemporaryToken(ioContext.account, ioContext.account))
+  if (!data.authenticationToken) {
+    throw new ResolverError(`ERROR ${data}`, status)
+  }
+  return data.authenticationToken
+}
+
+const setVtexIdAuthCookie = (headers, ioContext, response) => {
+  const authAccount = `VtexIdclientAutCookie_${ioContext.account}`
+  const authCookie = parse(headers['set-cookie'].find(checkAuth => {
+    return checkAuth.includes(authAccount)
+  }))
+  response.set('Set-Cookie', serialize(authAccount, authCookie[authAccount], {
+    httpOnly: true,
+    path: '/',
+    maxAge: new Date(authCookie['expires']).getTime(),
+    secure: true
+  }))
+}
+
 export const mutations = {
   sendEmailVerification: async (_, args, { vtex: ioContext, response }) => {
-    const { data, status } = await makeRequest(ioContext, paths.getTemporaryToken(ioContext.account, ioContext.account))
-    if (!data.authenticationToken) {
-      throw new ResolverError(`ERROR ${data}`, status)
-    }
-    await makeRequest(ioContext, paths.sendEmailVerification(args.email, data.authenticationToken))
-    response.set('Set-Cookie', serialize('VtexTemporarySession', data.authenticationToken, { httpOnly: true, secure: true, path: '/' }))
+    const VtexSessionToken = await getSessionToken(ioContext)
+    await makeRequest(ioContext, paths.sendEmailVerification(args.email, VtexSessionToken))
+    response.set('Set-Cookie', serialize('VtexSessionToken', VtexSessionToken, { httpOnly: true, secure: true, path: '/' }))
     return true
   },
 
   accessKeySignIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
-    const { VtexTemporarySession } = (parse(cookie))
-    if (!VtexTemporarySession) {
-      throw new ResolverError(`ERROR VtexTemporarySession is null`, 400)
+    const { VtexSessionToken } = (parse(cookie))
+    if (!VtexSessionToken) {
+      throw new ResolverError(`ERROR VtexSessionToken is null`, 400)
     }
-    const { email, code } = args
-    const authAccount = `VtexIdclientAutCookie_${ioContext.account}`
-    const { headers } = await makeRequest(ioContext, paths.accessKeySignIn(email, VtexTemporarySession, code))
-    const authCookie = parse(headers['set-cookie'].find(checkAuth => {
-      return checkAuth.includes(authAccount)
-    }))
-    response.set('Set-Cookie',
-      serialize(authAccount, authCookie[authAccount],
-        {
-          httpOnly: true,
-          path: '/',
-          maxAge: new Date(authCookie['expires']).getTime(),
-          secure: true
-        }),
-    )
+    const { headers } = await makeRequest(ioContext, paths.accessKeySignIn(VtexSessionToken, args.email, args.code))
+    setVtexIdAuthCookie(headers, ioContext, response);
     return true
   },
+
   classicSignIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
-    const { data, status } = await makeRequest(ioContext, paths.getTemporaryToken(ioContext.account, ioContext.account))
-    if (!data.authenticationToken) {
-      throw new ResolverError(`ERROR ${data}`, status)
-    }
-    const { email, password } = args
-    const authAccount = `VtexIdclientAutCookie_${ioContext.account}`
-    const { headers } = await makeRequest(ioContext, paths.classicSignIn(email, data.authenticationToken, password))
-    const authCookie = parse(headers['set-cookie'].find(checkAuth => {
-      return checkAuth.includes(authAccount)
-    }))
-    response.set('Set-Cookie',
-      serialize(authAccount, authCookie[authAccount],
-        {
-          httpOnly: true,
-          path: '/',
-          maxAge: new Date(authCookie['expires']).getTime(),
-          secure: true
-        }),
-    )
+    const VtexSessionToken = await getSessionToken(ioContext)
+    const { headers } = await makeRequest(ioContext, paths.classicSignIn(VtexSessionToken, args.email, args.password))
+    setVtexIdAuthCookie(headers, ioContext, response);
     return true
   },
+
   /** TODO: When VTEX ID have an endpoint that expires the VtexIdclientAutCookie, update this mutation. 
    * 13-06-2018 - @brunojdo */
-  logout: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
+  logout: async (_, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
     const authAccount = `VtexIdclientAutCookie_${ioContext.account}`
     response.set('Set-Cookie',
       serialize(authAccount, '', { path: '/', maxAge: 0, })

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -16,49 +16,58 @@ const makeRequest = async (ctx, url) => {
 }
 
 const getSessionToken = async ioContext => {
-  const { data, status } = await makeRequest(ioContext, paths.getTemporaryToken(ioContext.account, ioContext.account))
+  const { data, status } = await makeRequest(ioContext, paths.sessionToken(ioContext.account, ioContext.account))
   if (!data.authenticationToken) {
     throw new ResolverError(`ERROR ${data}`, status)
   }
   return data.authenticationToken
 }
 
-const setVtexIdAuthCookie = (headers, ioContext, response) => {
-  const authAccount = `VtexIdclientAutCookie_${ioContext.account}`
-  const authCookie = parse(headers['set-cookie'].find(checkAuth => {
-    return checkAuth.includes(authAccount)
-  }))
-  response.set('Set-Cookie', serialize(authAccount, authCookie[authAccount], {
-    httpOnly: true,
-    path: '/',
-    maxAge: new Date(authCookie['expires']).getTime(),
-    secure: true
-  }))
+const setVtexIdAuthCookie = (ioContext, response, headers, authStatus) => {
+  if (authStatus === 'Success') {
+    const authAccount = `VtexIdclientAutCookie_${ioContext.account}`
+    const authCookie = parse(headers['set-cookie'].find(checkAuth => {
+      return checkAuth.includes(authAccount)
+    }))
+    const VTEXID_EXPIRES = Math.round((new Date(authCookie['expires']).getTime() - Date.now()) / 1000)
+    response.set('Set-Cookie', serialize(authAccount, authCookie[authAccount], {
+      httpOnly: true,
+      path: '/',
+      maxAge: VTEXID_EXPIRES,
+      secure: true
+    }))
+  }
+  return authStatus
 }
 
 export const mutations = {
   sendEmailVerification: async (_, args, { vtex: ioContext, response }) => {
+    // VtexSessionToken is valid for 10 minutes
+    const SESSION_TOKEN_EXPIRES = 600
     const VtexSessionToken = await getSessionToken(ioContext)
     await makeRequest(ioContext, paths.sendEmailVerification(args.email, VtexSessionToken))
-    response.set('Set-Cookie', serialize('VtexSessionToken', VtexSessionToken, { httpOnly: true, secure: true, path: '/' }))
+    response.set('Set-Cookie', serialize('VtexSessionToken', VtexSessionToken, {
+      httpOnly: true,
+      path: '/',
+      secure: true,
+      maxAge: SESSION_TOKEN_EXPIRES
+    }))
     return true
   },
 
   accessKeySignIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
-    const { VtexSessionToken } = (parse(cookie))
+    const { VtexSessionToken } = parse(cookie)
     if (!VtexSessionToken) {
       throw new ResolverError(`ERROR VtexSessionToken is null`, 400)
     }
-    const { headers } = await makeRequest(ioContext, paths.accessKeySignIn(VtexSessionToken, args.email, args.code))
-    setVtexIdAuthCookie(headers, ioContext, response);
-    return true
+    const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.accessKeySignIn(VtexSessionToken, args.email, args.code))
+    return setVtexIdAuthCookie(ioContext, response, headers, authStatus);
   },
 
-  classicSignIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
+  classicSignIn: async (_, args, { vtex: ioContext, response }) => {
     const VtexSessionToken = await getSessionToken(ioContext)
-    const { headers } = await makeRequest(ioContext, paths.classicSignIn(VtexSessionToken, args.email, args.password))
-    setVtexIdAuthCookie(headers, ioContext, response);
-    return true
+    const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.classicSignIn(VtexSessionToken, args.email, args.password))
+    return setVtexIdAuthCookie(ioContext, response, headers, authStatus);
   },
 
   /** TODO: When VTEX ID have an endpoint that expires the VtexIdclientAutCookie, update this mutation. 

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -1,5 +1,5 @@
 import { map, merge } from 'ramda'
-import {headers, withAuthToken} from '../headers'
+import { headers, withAuthToken } from '../headers'
 import httpResolver from '../httpResolver'
 import paths from '../paths'
 import paymentTokenResolver from './paymentTokenResolver'
@@ -21,7 +21,7 @@ const convertIntToFloat = int => int * 0.01
 
 export const queries = {
   orderForm: httpResolver({
-    data: {expectedOrderFormSections: ['items']},
+    data: { expectedOrderFormSections: ['items'] },
     merge: (bodyData, responseData) => ({
       ...responseData,
       value: convertIntToFloat(responseData.value),
@@ -45,9 +45,9 @@ export const queries = {
   }),
 
   shipping: httpResolver({
-    data: ({items, postalCode, country}) => ({
-      items, 
-      postalCode, 
+    data: ({ items, postalCode, country }) => ({
+      items,
+      postalCode,
       country
     }),
     headers: withAuthToken(headers.json),
@@ -80,7 +80,7 @@ export const mutations = {
   }),
 
   createPaymentSession: httpResolver({
-    headers: withAuthToken({...headers.json}),
+    headers: withAuthToken({ ...headers.json }),
     method: 'POST',
     enableCookies: true,
     secure: true,

--- a/node/resolvers/headers.ts
+++ b/node/resolvers/headers.ts
@@ -14,7 +14,6 @@ export const headers = {
 }
 
 export const withAuthToken = (currentHeaders = {}) => (ioContext, cookie = null) => {
-  let VtexIdclientAutCookie
   let ans = { ...currentHeaders }
   if (cookie) {
     const parsedCookie = cookies.parse(cookie)

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -65,6 +65,7 @@ const paths = {
   getTemporaryToken: (scope, account) => `${paths.vtexId()}/authentication/start?appStart=true&scope=${scope}&accountName=${account}`,
   sendEmailVerification: (email, token) => `${paths.vtexId()}/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
   accessKeySignIn: (email, token, code) => `${paths.vtexId()}/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
+  classicSignIn: (email, token, password) => `${paths.vtexId()}/authentication/classic/validate?authenticationToken=${token}&login=${email}&password=${password}`,
 
   /** Master Data API v1
    * Docs: https://documenter.getpostman.com/view/164907/masterdata-api-v102/2TqWsD

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -62,7 +62,7 @@ const paths = {
   /** VTEX ID API */
   vtexId: () => `http://vtexid.vtex.com.br/api/vtexid/pub`,
   identity: (account, { token }) => `${paths.vtexId()}/authenticated/user?authToken=${encodeURIComponent(token)}`,
-  getTemporaryToken: (scope, account) => `${paths.vtexId()}/authentication/start?appStart=true&scope=${scope}&accountName=${account}`,
+  sessionToken: (scope, account) => `${paths.vtexId()}/authentication/start?appStart=true&scope=${scope}&accountName=${account}`,
   sendEmailVerification: (email, token) => `${paths.vtexId()}/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
   accessKeySignIn: (token, email, code) => `${paths.vtexId()}/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
   classicSignIn: (token, email, password) => `${paths.vtexId()}/authentication/classic/validate?authenticationToken=${token}&login=${email}&password=${password}`,

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -64,8 +64,8 @@ const paths = {
   identity: (account, { token }) => `${paths.vtexId()}/authenticated/user?authToken=${encodeURIComponent(token)}`,
   getTemporaryToken: (scope, account) => `${paths.vtexId()}/authentication/start?appStart=true&scope=${scope}&accountName=${account}`,
   sendEmailVerification: (email, token) => `${paths.vtexId()}/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
-  accessKeySignIn: (email, token, code) => `${paths.vtexId()}/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
-  classicSignIn: (email, token, password) => `${paths.vtexId()}/authentication/classic/validate?authenticationToken=${token}&login=${email}&password=${password}`,
+  accessKeySignIn: (token, email, code) => `${paths.vtexId()}/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
+  classicSignIn: (token, email, password) => `${paths.vtexId()}/authentication/classic/validate?authenticationToken=${token}&login=${email}&password=${password}`,
 
   /** Master Data API v1
    * Docs: https://documenter.getpostman.com/view/164907/masterdata-api-v102/2TqWsD


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add classic login in auth resolver

**Secondary** Refact the resolver to be more reusable.

#### How should this be manually tested?
You need to have a classic login in your account.

```
mutation classic{
  classicSignIn(email:"bruno.dias@vtex.com", password:"")
}

```

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
