### PR TITLE
Add recoveryPassword mutation in auth resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.0] - 2018-6-26
 ### Added 
 - Add `recoveryPassword` mutation in auth resolver.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- Add `recoveryPassword` mutation in auth resolver.
 
 ## [2.8.0] - 2018-6-25
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -153,6 +153,15 @@ type Mutation {
     password: String!
   ): String
 
+  recoveryPassword(
+    """ User email"""
+    email: String!, 
+    """ User password """
+    newPassword: String!
+    """ Access Code """
+    code: String!
+    ) : String
+
   """ Invalidate VtexIdclientAutCookie """
   logout: Boolean
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -137,7 +137,7 @@ type Mutation {
     email: String!
   ): Boolean
 
-  """  Access key sign in mode """
+  """ Access key sign in mode """
   accessKeySignIn(
     """ User email"""
     email: String!, 
@@ -145,22 +145,22 @@ type Mutation {
     code: String!
   ): String
 
-  """  Classic sign in mode """
+  """ Classic sign in mode """
   classicSignIn(
     """ User email"""
     email: String!, 
     """ User password """
     password: String!
   ): String
-
+  """ To recovery password you need to get your email, password and access code """
   recoveryPassword(
     """ User email"""
     email: String!, 
     """ User password """
-    newPassword: String!
+    newPassword: String!,
     """ Access Code """
     code: String!
-    ) : String
+    ): String
 
   """ Invalidate VtexIdclientAutCookie """
   logout: Boolean

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -41,6 +41,10 @@ const setVtexIdAuthCookie = (ioContext, response, headers, authStatus) => {
 }
 
 export const mutations = {
+  /**
+   * Send access key to user email and set VtexSessionToken in response cookies
+   * @return Boolean 
+   */
   sendEmailVerification: async (_, args, { vtex: ioContext, response }) => {
     // VtexSessionToken is valid for 10 minutes
     const SESSION_TOKEN_EXPIRES = 600
@@ -54,7 +58,10 @@ export const mutations = {
     }))
     return true
   },
-
+  /**
+   * Get email and access code in args and set VtexIdAuthCookie in response cookies. 
+   * @return authStatus that show if user is logged or something wrong happens.
+   */
   accessKeySignIn: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
     const { VtexSessionToken } = parse(cookie)
     if (!VtexSessionToken) {
@@ -63,10 +70,25 @@ export const mutations = {
     const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.accessKeySignIn(VtexSessionToken, args.email, args.code))
     return setVtexIdAuthCookie(ioContext, response, headers, authStatus);
   },
-
+  /**
+   * Get email and password in args and set VtexIdAuthCookie in response cookies. 
+   * @return authStatus that show if user is logged or something wrong happens.
+   */
   classicSignIn: async (_, args, { vtex: ioContext, response }) => {
     const VtexSessionToken = await getSessionToken(ioContext)
     const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.classicSignIn(VtexSessionToken, args.email, args.password))
+    return setVtexIdAuthCookie(ioContext, response, headers, authStatus);
+  },
+
+  /** Set a new password for an user. 
+   * @return authStatus that show if password was created and user is logged or something wrong happens.
+    */
+  recoveryPassword: async (_, args, { vtex: ioContext, request: { headers: { cookie } }, response }) => {
+    const { VtexSessionToken } = parse(cookie)
+    if (!VtexSessionToken) {
+      throw new ResolverError(`ERROR VtexSessionToken is null`, 400)
+    }
+    const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.recoveryPassword(VtexSessionToken, args.email, args.newPassword, args.code))
     return setVtexIdAuthCookie(ioContext, response, headers, authStatus);
   },
 

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -97,7 +97,7 @@ export const mutations = {
     if (!VtexSessionToken) {
       throw new ResolverError('ERROR VtexSessionToken is null', 400)
     }
-    if (!checkPasswordFormat(args.password)) {
+    if (!checkPasswordFormat(args.newPassword)) {
       throw new ResolverError('Password does not follow specific format', 400)
     }
     const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.recoveryPassword(VtexSessionToken, args.email, args.newPassword, args.code))

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -68,7 +68,7 @@ export const mutations = {
       throw new ResolverError(`ERROR VtexSessionToken is null`, 400)
     }
     const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.accessKeySignIn(VtexSessionToken, args.email, args.code))
-    return setVtexIdAuthCookie(ioContext, response, headers, authStatus);
+    return setVtexIdAuthCookie(ioContext, response, headers, authStatus)
   },
   /**
    * Get email and password in args and set VtexIdAuthCookie in response cookies. 
@@ -77,7 +77,7 @@ export const mutations = {
   classicSignIn: async (_, args, { vtex: ioContext, response }) => {
     const VtexSessionToken = await getSessionToken(ioContext)
     const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.classicSignIn(VtexSessionToken, args.email, args.password))
-    return setVtexIdAuthCookie(ioContext, response, headers, authStatus);
+    return setVtexIdAuthCookie(ioContext, response, headers, authStatus)
   },
 
   /** Set a new password for an user. 
@@ -89,7 +89,7 @@ export const mutations = {
       throw new ResolverError(`ERROR VtexSessionToken is null`, 400)
     }
     const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.recoveryPassword(VtexSessionToken, args.email, args.newPassword, args.code))
-    return setVtexIdAuthCookie(ioContext, response, headers, authStatus);
+    return setVtexIdAuthCookie(ioContext, response, headers, authStatus)
   },
 
   /** TODO: When VTEX ID have an endpoint that expires the VtexIdclientAutCookie, update this mutation. 

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -61,11 +61,12 @@ const paths = {
 
   /** VTEX ID API */
   vtexId: () => `http://vtexid.vtex.com.br/api/vtexid/pub`,
-  identity: (account, { token }) => `${paths.vtexId()}/authenticated/user?authToken=${encodeURIComponent(token)}`,
-  sessionToken: (scope, account) => `${paths.vtexId()}/authentication/start?appStart=true&scope=${scope}&accountName=${account}`,
-  sendEmailVerification: (email, token) => `${paths.vtexId()}/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
-  accessKeySignIn: (token, email, code) => `${paths.vtexId()}/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
-  classicSignIn: (token, email, password) => `${paths.vtexId()}/authentication/classic/validate?authenticationToken=${token}&login=${email}&password=${password}`,
+  identity: (account, { token }) => `${paths.vtexId}/authenticated/user?authToken=${encodeURIComponent(token)}`,
+  sessionToken: (scope, account) => `${paths.vtexId}/authentication/start?appStart=true&scope=${scope}&accountName=${account}`,
+  sendEmailVerification: (email, token) => `${paths.vtexId}/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
+  accessKeySignIn: (token, email, code) => `${paths.vtexId}/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
+  classicSignIn: (token, email, password) => `${paths.vtexId}/authentication/classic/validate?authenticationToken=${token}&login=${email}&password=${password}`,
+  recoveryPassword: (token, email, password, code) => `${paths.vtexId}/authentication/classic/setpassword?authenticationToken=${token}&login=${email}&newPassword=${password}&accessKey=${code}`,
 
   /** Master Data API v1
    * Docs: https://documenter.getpostman.com/view/164907/masterdata-api-v102/2TqWsD

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -60,7 +60,7 @@ const paths = {
   autocomplete: (account, { maxRows, searchTerm }) => `http://portal.vtexcommercestable.com.br/buscaautocomplete/?an=${account}&maxRows=${maxRows}&productNameContains=${encodeURIComponent(searchTerm)}`,
 
   /** VTEX ID API */
-  vtexId: () => `http://vtexid.vtex.com.br/api/vtexid/pub`,
+  vtexId: `http://vtexid.vtex.com.br/api/vtexid/pub`,
   identity: (account, { token }) => `${paths.vtexId}/authenticated/user?authToken=${encodeURIComponent(token)}`,
   sessionToken: (scope, account) => `${paths.vtexId}/authentication/start?appStart=true&scope=${scope}&accountName=${account}`,
   sendEmailVerification: (email, token) => `${paths.vtexId}/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Now, its possible create a password for an user. ✨ 

#### How should this be manually tested?
```
mutation sendEmail {
  sendEmailVerification(email:"email@vtex.com")
}

mutation recoveryPassword{
  recoveryPassword(email:"email@vtex.com", newPassword:"", code: "")
}
# Test if your newPassword works!
mutation classicSignIn{
  classicSignIn(email:"email@vtex.com", password:"")
}
```
#### Screenshots or example usage
[Access here](https://login--storecomponents.myvtex.com/_v/vtex.store-graphql/graphiql/v1?operationName=recoveryPassword&query=mutation%20sendEmail%20%7B%0A%20%20sendEmailVerification(email%3A%22email%40vtex.com%22)%0A%7D%0A%0Amutation%20recoveryPassword%7B%0A%20%20recoveryPassword(email%3A%22email%40vtex.com%22%2C%20newPassword%3A%22%22%2C%20code%3A%20%22%22)%0A%7D%0A%23%20Test%20if%20your%20newPassword%20works!%0Amutation%20classicSignIn%7B%0A%20%20classicSignIn(email%3A%22email%40vtex.com%22%2C%20password%3A%22%22)%0A%7D)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
