### PR TITLE
Added cacheId to return types of root fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.2] - 2018-7-2
 ### Added
 - Added cacheId field to root types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Benefits resolver.
+- Added cacheId field to root types.
 
 ## [2.9.1] - 2018-6-27
 ### Fixed

--- a/graphql/types/Brand.graphql
+++ b/graphql/types/Brand.graphql
@@ -1,4 +1,6 @@
 type Brand {
+  """ slug is used as cacheId """
+  cacheId: ID
   name: String
   slug: String
   id: Int

--- a/graphql/types/Category.graphql
+++ b/graphql/types/Category.graphql
@@ -1,4 +1,6 @@
 type Category {
+  """ id is used as cacheId """
+  cacheId: ID
   href: String
   slug: String
   name: String

--- a/graphql/types/Document.graphql
+++ b/graphql/types/Document.graphql
@@ -11,6 +11,7 @@ type Field {
 }
 
 type DocumentResponse {
+  """ documentId is used as cacheId """
   cacheId: ID
   id: String,
   href: String,

--- a/graphql/types/Document.graphql
+++ b/graphql/types/Document.graphql
@@ -1,4 +1,6 @@
 type Document {
+  """ id is used as cacheId """
+  cacheId: ID
   id: String
   fields: [Field]
 }
@@ -9,6 +11,7 @@ type Field {
 }
 
 type DocumentResponse {
+  cacheId: ID
   id: String,
   href: String,
   documentId: String

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -1,4 +1,6 @@
 type OrderForm {
+  """ orderFormId is used as cacheId """
+  cacheId: ID
   orderFormId: String
   value: Float
   items: [OrderFormItem]

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -1,5 +1,7 @@
 type Product {
   brand: String
+  """ linkText is used as cacheId """
+  cacheId: ID
   categoryId: ID
   categories: [String]
   categoriesIds: [String]

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -1,4 +1,6 @@
 type Profile {
+  """ email is used as cacheId """
+  cacheId: ID
   id: String,
   userId: String,
   firstName: String,

--- a/graphql/types/Suggestions.graphql
+++ b/graphql/types/Suggestions.graphql
@@ -1,4 +1,6 @@
 type Suggestions {
+  """ searchTerm from Query autocomplete is used as cacheId """
+  cacheId: ID
   itemsReturned: [Items]
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vtex.store-graphql",
   "dependencies": {
-    "axios": "0.16.2",
+    "axios": "^0.18.0",
     "bluebird": "^3.5.0",
     "co-body": "^5.1.1",
     "cookie": "^0.3.1",

--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vtex.store-graphql",
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "0.16.2",
     "bluebird": "^3.5.0",
     "co-body": "^5.1.1",
     "cookie": "^0.3.1",

--- a/node/resolvers/catalog/fieldsResolver.ts
+++ b/node/resolvers/catalog/fieldsResolver.ts
@@ -50,12 +50,12 @@ const resolvers = {
 
   properties: product => {
     const { allSpecifications = [] } = product
-    return map(name => ({ name, values: product[name] }), allSpecifications)
+    return map((name: string) => ({ name, values: product[name] }), allSpecifications)
   },
 
   variations: sku => {
     const { variations = [] } = sku
-    return map(name => ({ name, values: sku[name] }), variations)
+    return map((name: string) => ({ name, values: sku[name] }), variations)
   },
 
   attachments: sku => {
@@ -125,6 +125,7 @@ export const resolveProductFields = async (
   fields: any
 ) => {
   const resolvedProduct = resolveLocalProductFields(product)
+  resolvedProduct.cacheId = resolvedProduct.linkText
   if (!fields.recommendations) {
     return resolvedProduct
   }
@@ -155,10 +156,12 @@ export const resolveCategoryFields = category => ({
     : [],
   name: category.name,
   id: category.id,
+  cacheId: category.id,
   hasChildren: category.hasChildren,
 })
 
 export const resolveBrandFields = brand => ({
+  cacheId: brand.slug,
   id: brand.id,
   name: brand.name,
   active: brand.isActive,

--- a/node/resolvers/catalog/fieldsResolver.ts
+++ b/node/resolvers/catalog/fieldsResolver.ts
@@ -110,6 +110,7 @@ export const resolveLocalProductFields = product => {
   ] = resolveFields(product)
   return {
     ...product,
+    cacheId: product.linkText,
     clusterHighlights,
     items,
     properties,
@@ -125,7 +126,6 @@ export const resolveProductFields = async (
   fields: any
 ) => {
   const resolvedProduct = resolveLocalProductFields(product)
-  resolvedProduct.cacheId = resolvedProduct.linkText
   if (!fields.recommendations) {
     return resolvedProduct
   }
@@ -160,10 +160,13 @@ export const resolveCategoryFields = category => ({
   hasChildren: category.hasChildren,
 })
 
-export const resolveBrandFields = brand => ({
-  cacheId: brand.slug,
-  id: brand.id,
-  name: brand.name,
-  active: brand.isActive,
-  slug: slugify(brand.name, { lower: true }),
-})
+export const resolveBrandFields = brand => {
+  const slu = slugify(brand.name, { lower: true })
+  return ({
+    active: brand.isActive,
+    cacheId: slu,
+    id: brand.id,
+    name: brand.name,
+    slug: slu
+  })
+}

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -56,6 +56,7 @@ export const queries = {
       headers: withAuthToken()(ioContext),
     })
     return {
+      cacheId: args.searchTerm,
       itemsReturned: map(
         item => ({
           ...item,
@@ -110,7 +111,7 @@ export const queries = {
     const resolvedProducts = await Promise.map(products, product =>
       resolveProductFields(ioContext, product, fields)
     )
-
+    
     return resolvedProducts
   },
 

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -111,7 +111,7 @@ export const queries = {
     const resolvedProducts = await Promise.map(products, product =>
       resolveProductFields(ioContext, product, fields)
     )
-    
+  
     return resolvedProducts
   },
 

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -47,8 +47,8 @@ export const queries = {
 
   shipping: httpResolver({
     data: ({ items, postalCode, country }) => ({
-      items, 
-      postalCode, 
+      items,
+      postalCode,
       country
     }),
     headers: withAuthToken(headers.json),

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -24,6 +24,7 @@ export const queries = {
     data: { expectedOrderFormSections: ['items'] },
     merge: (bodyData, responseData) => ({
       ...responseData,
+      cacheId: responseData.orderFormId,
       value: convertIntToFloat(responseData.value),
       items: map((item) => ({
         ...item,
@@ -46,8 +47,8 @@ export const queries = {
 
   shipping: httpResolver({
     data: ({ items, postalCode, country }) => ({
-      items,
-      postalCode,
+      items, 
+      postalCode, 
       country
     }),
     headers: withAuthToken(headers.json),
@@ -64,6 +65,10 @@ export const mutations = {
     }),
     enableCookies: true,
     headers: withAuthToken(headers.json),
+    merge: (bodyData, responseData) => ({
+      ...responseData,
+      cacheId: responseData.orderFormId
+    }),
     method: 'POST',
     url: paths.addItem,
   }),
@@ -100,6 +105,10 @@ export const mutations = {
       value,
     }),
     headers: withAuthToken(headers.json),
+    merge: (bodyData, responseData) => ({
+      ...responseData,
+      cacheId: responseData.orderFormId
+    }),
     method: 'PUT',
     url: paths.orderFormCustomData,
   }),
@@ -110,8 +119,12 @@ export const mutations = {
       orderItems: items,
     }),
     enableCookies: true,
-    method: 'POST',
     headers: withAuthToken(headers.json),
+    merge: (bodyData, responseData) => ({
+      ...responseData,
+      cacheId: responseData.orderFormId
+    }),
+    method: 'POST',
     url: paths.updateItems,
   }),
 
@@ -121,6 +134,10 @@ export const mutations = {
       ignoreProfileData,
     }),
     headers: withAuthToken(headers.json),
+    merge: (bodyData, responseData) => ({
+      ...responseData,
+      cacheId: responseData.orderFormId
+    }),
     method: 'PATCH',
     url: paths.orderFormIgnoreProfile,
   }),
@@ -128,6 +145,10 @@ export const mutations = {
   updateOrderFormPayment: httpResolver({
     data: ({ payments }) => merge({ expectedOrderFormSections: ['items'] }, { payments }),
     headers: withAuthToken(headers.json),
+    merge: (bodyData, responseData) => ({
+      ...responseData,
+      cacheId: responseData.orderFormId
+    }),
     method: 'POST',
     url: paths.orderFormPayment,
   }),
@@ -135,6 +156,10 @@ export const mutations = {
   updateOrderFormProfile: httpResolver({
     data: ({ fields }) => merge({ expectedOrderFormSections: ['items'] }, fields),
     headers: withAuthToken(headers.json),
+    merge: (bodyData, responseData) => ({
+      ...responseData,
+      cacheId: responseData.orderFormId
+    }),
     method: 'POST',
     url: paths.orderFormProfile,
   }),
@@ -142,6 +167,10 @@ export const mutations = {
   updateOrderFormShipping: httpResolver({
     data: data => merge({ expectedOrderFormSections: ['items'] }, data),
     headers: withAuthToken(headers.json),
+    merge: (bodyData, responseData) => ({
+      ...responseData,
+      cacheId: responseData.orderFormId
+    }),
     method: 'POST',
     url: paths.orderFormShipping,
   }),

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -26,8 +26,9 @@ export const queries = {
     const url = paths.searchDocument(ioContext.account, acronym, fieldsWithId)
     const { data } = await http.get(url, { headers: withMDPagination()(ioContext, cookie)(page, pageSize) })
     return data.map(document => ({
-      id: document.id,
+      cacheId: document.id,
       fields: mapKeyValues(document),
+      id: document.id,
     }))
   },
 
@@ -35,7 +36,7 @@ export const queries = {
     const { acronym, fields, id } = args
     const url = paths.documentFields(ioContext.account, acronym, fields, id)
     const { data } = await http.get(url, { headers: withAuthToken()(ioContext, cookie) })
-    return { id: data.id, fields: mapKeyValues(data) }
+    return { cacheId: data.id, id: data.id, fields: mapKeyValues(data) }
   },
 }
 
@@ -53,7 +54,7 @@ export const mutations = {
         },
       },
     )
-    return { id: Id, href: Href, documentId: DocumentId }
+    return { cacheId: DocumentId, id: Id, href: Href, documentId: DocumentId }
   },
 
   updateDocument: async (_, args, { vtex: ioContext, request: { headers: { cookie } } }) => {
@@ -69,6 +70,6 @@ export const mutations = {
         },
       },
     )
-    return { id: Id, href: Href, documentId: DocumentId }
+    return { cacheId: DocumentId, id: Id, href: Href, documentId: DocumentId }
   },
 }

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -84,7 +84,7 @@ export const mutations = {
     
     return await makeRequest(
       paths.profile(account).profile(profileId), authToken, args.fields, 'PATCH'
-    ).then(() => getClientData(account, authToken, cookie))
+    ).then(() => getClientData(account, authToken, cookie)).then((obj)=>({...obj, cacheId: obj.email}))
   },
 }
 

--- a/node/resolvers/profile/profileResolver.ts
+++ b/node/resolvers/profile/profileResolver.ts
@@ -31,9 +31,10 @@ const profile = (ctx) => async (data) => {
     const addressURL = paths.profile(ctx.account).filterAddress(profileData.id)
     const address = profileData && await http.get(addressURL, config).then(prop('data'))
 
-    return merge({ address }, profileData)
+    return merge({ address, cacheId: user }, profileData)
   }
   return {
+    cacheId: user,
     email: user
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -134,11 +134,11 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-axios@0.16.2:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.16.2.tgz#ba4f92f17167dfbab40983785454b9ac149c3c6d"
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
   dependencies:
-    follow-redirects "^1.2.3"
+    follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
 
 babel-code-frame@^6.22.0:
@@ -258,9 +258,9 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-follow-redirects@^1.2.3:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"
+follow-redirects@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
   dependencies:
     debug "^3.1.0"
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
The purpose is to add an ID to all cacheable root fields.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Client cannot cache data since they do not have an uniform cache ID.


#### How should this be manually tested?
Link -> Open GraphiQL -> try changed queries/mutations

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
