### PR TITLE
Benefits Resolver Breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Benefits resolver was breaking with the returned data being null.
 
 ## [2.9.2] - 2018-7-2
 ### Added

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -31,7 +31,7 @@ export const queries = {
         ]
       }
     },
-    merge: (args, data) => data.ratesAndBenefitsData.teaser,
+    merge: (args, data) => data.ratesAndBenefitsData ? data.ratesAndBenefitsData.teaser : [],
     headers: withAuthToken(headers.json),
     url: paths.shipping,
     method: 'POST'


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix breaking in Benefits Resolver.

#### What problem is this solving?
The benefits resolver was breaking with the returned data being null.

#### Screenshots or example usage

<a href="https://gustavo--storecomponents.myvtex.com/_v/vtex.store-graphql/graphiql/v1">Workspace</a>

```gql
query Product($slug: String) {
  product(slug: $slug) {
    benefits {
      name
    }
  }
}
```

```json
{
  "slug": "motorola-moto-x4"
}
```

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
