### PR TITLE
Add PriceRanges to facets graphql type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- PriceRanges to facets graphql type
 
 ## [2.9.3] - 2018-7-2
 ### Fixed

--- a/graphql/types/Facets.graphql
+++ b/graphql/types/Facets.graphql
@@ -3,6 +3,7 @@ type Facets {
 	Brands: [Facet]
 	SpecificationFilters: [Filter]
 	CategoriesTrees: [Facet]
+	PriceRanges: [Facet]
 }
 
 type Facet {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Add PriceRanges to facets graphql type

#### Screenshots or example usage

[graphiql query example](https://pricerange--storecomponents.myvtex.com/_v/vtex.store-graphql/graphiql/v1?query=query%20facets%20%7B%0A%20%20facets(facets%3A%20%22eletronics%3Fmap%3Dc%22)%20%7B%0A%20%20%20%20PriceRanges%20%7B%0A%20%20%20%20%20%20Quantity%0A%20%20%20%20%20%20Name%0A%20%20%20%20%20%20Link%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=facets)

[graphiql link](https://pricerange--storecomponents.myvtex.com)
```
query facets {
  facets(facets: "eletronics?map=c") {
    PriceRanges {
      Quantity
      Name
      Link
    }
  }
}
```

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
