### PR TITLE
Adding extensible profile info so apps can use CL entity correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Possibility to extend profile info according to masterdata CL entity
 
 ## [2.11.1] - 2018-7-6
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -4,7 +4,7 @@ type Query {
     """ Product slug """
     slug: String
   ): Product @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
-  
+
   """ Product search filtered and ordered """
   products(
     """ Terms that is used in search e.g.: eletronics/samsung """
@@ -73,12 +73,15 @@ type Query {
   orders: [Order]
 
   """ Get user profile details """
-  profile: Profile
+  profile(
+    """ Comma separated fields """
+    customFields: String
+  ): Profile
 
   """ Get auto complete suggestions in search """
   autocomplete(
     """ Number of items that is returned """
-    maxRows: Int = 12, 
+    maxRows: Int = 12,
     """ Terms that is used in search e.g.: iphone """
     searchTerm: String
   ): Suggestions
@@ -86,21 +89,21 @@ type Query {
   """ Search documents """
   documents(
     """ Schema name. e.g.: CL, AD"""
-    acronym: String, 
+    acronym: String,
     """ Fields that will be returned by document. e.g.: _fields=email,firstName,document """
-    fields: [String], 
+    fields: [String],
     """ Pagination. Default: 1 """
-    page: Int = 1, 
+    page: Int = 1,
     """ Items returned in the page. Default: 15"""
-    pageSize: Int = 15  
+    pageSize: Int = 15
   ): [Document]
 
   """ Get document """
   document(
     """ Schema name. e.g.: CL, AD"""
-    acronym: String, 
+    acronym: String,
     """ Fields that will be returned in document. e.g.: _fields=email,firstName,document """
-    fields: [String], 
+    fields: [String],
     """ Document id """
     id: String
   ): Document
@@ -119,7 +122,7 @@ type Mutation {
   updateItems(orderFormId: String, items: [OrderFormItemInput]): OrderForm
 
   """ Profile """
-  updateProfile(fields: ProfileInput): Profile
+  updateProfile(fields: ProfileInput, customFields: [CustomFieldInput!]): Profile
   updateAddress(id: String, fields: AddressInput): Profile
   createAddress(fields: AddressInput): Profile
   deleteAddress(id: String): Boolean
@@ -131,7 +134,7 @@ type Mutation {
   updateOrderFormIgnoreProfile(orderFormId: String, ignoreProfileData: Boolean): OrderForm
   addOrderFormPaymentToken(orderFormId: String, paymentToken: OrderFormPaymentTokenInput): OrderForm
   setOrderFormCustomData(orderFormId: String, appId: String, field: String, value: String): OrderForm
-  
+
   """ Payment """
   createPaymentSession: PaymentSession
   createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
@@ -146,7 +149,7 @@ type Mutation {
   """ Access key sign in mode """
   accessKeySignIn(
     """ User email"""
-    email: String!, 
+    email: String!,
     """ Access key that was received """
     code: String!
   ): String
@@ -154,7 +157,7 @@ type Mutation {
   """ Classic sign in mode """
   classicSignIn(
     """ User email"""
-    email: String!, 
+    email: String!,
     """ User password """
     password: String!
   ): String
@@ -162,15 +165,15 @@ type Mutation {
   """ OAuth to login with Social Account """
   oAuth(
     """ The OAuth Provider, e.g: Google, Facebook """
-    provider: String, 
+    provider: String,
     """ The URL to be redirected after authentication """
     redirectUrl: String
   ): String
-  
+
   """ To recovery password you need to get your email, password and access code """
   recoveryPassword(
     """ User email"""
-    email: String!, 
+    email: String!,
     """ User password """
     newPassword: String!,
     """ Access Code """

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -16,6 +16,12 @@ type Profile {
   corporateName: String,
   corporateDocument: String,
   stateRegistration: String,
+  customFields: [CustomField]
+}
+
+type CustomField {
+  key: String
+  value: String
 }
 
 input ProfileInput {
@@ -30,6 +36,11 @@ input ProfileInput {
   corporateName: String,
   corporateDocument: String,
   stateRegistration: String,
+}
+
+input CustomFieldInput {
+  key: String
+  value: String
 }
 
 type Address {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -1,6 +1,8 @@
+import {join} from 'ramda'
+
 const paths = {
 
-  /** Catalog API 
+  /** Catalog API
    * Docs: https://documenter.getpostman.com/view/845/catalogsystem-102/Hs44
   */
   catalog: account => `http://${account}.vtexcommercestable.com.br/api/catalog_system`,
@@ -31,7 +33,7 @@ const paths = {
 
   crossSelling: (account, id, type) => `${paths.catalog(account)}/pub/products/crossselling/${type}/${id}`,
 
-  /** Checkout API 
+  /** Checkout API
    * Docs: https://documenter.getpostman.com/view/18468/vtex-checkout-api/6Z2QYJM
   */
   orderForm: account => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orderForm`,
@@ -46,7 +48,7 @@ const paths = {
   updateItems: (account, data) => `${paths.addItem(account, data)}/update`,
 
   shipping: account => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orderForms/simulation`,
-  
+
   skuById: (account, { skuId }) => `${paths.catalog(account)}/pvt/sku/stockkeepingunitbyid/${skuId}`,
 
   orders: account => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orders`,
@@ -82,7 +84,7 @@ const paths = {
   profile: account => ({
     address: (id) => `http://api.vtex.com/${account}/dataentities/AD/documents/${id}`,
     filterAddress: (id) => `http://api.vtex.com/${account}/dataentities/AD/search?userId=${id}&_fields=userId,id,receiverName,complement,neighborhood,state,number,street,postalCode,city,reference,addressName,addressType`,
-    filterUser: (email) => `http://api.vtex.com/${account}/dataentities/CL/search?email=${email}&_fields=userId,id,firstName,lastName,birthDate,gender,homePhone,businessPhone,document,email,tradeName,corporateName,stateRegistration,corporateDocument`,
+    filterUser: (email, customFields?) => join(',', [`http://api.vtex.com/${account}/dataentities/CL/search?email=${email}&_fields=userId,id,firstName,lastName,birthDate,gender,homePhone,businessPhone,document,email,tradeName,corporateName,stateRegistration,corporateDocument`, customFields]),
     profile: (id) => `http://api.vtex.com/${account}/dataentities/CL/documents/${id}`,
   }),
 }

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -1,27 +1,27 @@
 import http from 'axios'
 import {parse as parseCookie} from 'cookie'
-import {head, values, pickBy, pipe, prop, find } from 'ramda'
+import {find, head, merge, pickBy, pipe, prop, reduce, values } from 'ramda'
+import ResolverError from '../../errors/resolverError'
 import { headers, withAuthAsVTEXID } from '../headers'
 import httpResolver from '../httpResolver'
 import paths from '../paths'
-import profileResolver from './profileResolver'
-import ResolverError from '../../errors/resolverError'
+import profileResolver, {customFieldsFromGraphQLInput, pickCustomFieldsFromData} from './profileResolver'
 
 const makeRequest = async (url, token, data?, method='GET') => http.request({
-  url, data, method, headers: { 
+  url, data, method, headers: {
     'Proxy-Authorization': token,
     'VtexIdclientAutCookie': token
   }
 })
 
-const getClientData = async (account, authToken, cookie) => {
+const getClientData = async (account, authToken, cookie, customFields?: string) => {
   const { data: { user } } = await makeRequest(
-    paths.identity(account, { 
-      token: getClientToken(cookie, account) 
+    paths.identity(account, {
+      token: getClientToken(cookie, account)
     }), authToken
   )
   return await makeRequest(
-    paths.profile(account).filterUser(user), authToken
+    paths.profile(account).filterUser(user, customFields), authToken
   ).then(pipe(prop('data'), head))
 }
 
@@ -48,7 +48,7 @@ const addressPatch = async (_, args, config) => {
   const { vtex: { account, authToken }, request: { headers: { cookie } } } = config
   const { userId, id } = await getClientData(account, authToken, cookie)
 
-  if (args.id && !(await isUserAddress(account, id, args.id, authToken))) {  
+  if (args.id && !(await isUserAddress(account, id, args.id, authToken))) {
     throw new ResolverError('Address not found.', 400)
   }
 
@@ -58,8 +58,21 @@ const addressPatch = async (_, args, config) => {
     method: 'PATCH',
     url: account => paths.profile(account).address(args.id || ''),
   })(_, args, config)
-  
+
   return await profileResolver(_, args, config)
+}
+
+const addFieldsToObj = (acc, {key, value}) => {
+  acc[key] = value
+  return acc
+}
+
+const returnOldOnNotChanged = (oldData) => (error) => {
+  if (error.statusCode === 304) {
+    return oldData
+  } else {
+    throw error
+  }
 }
 
 export const mutations = {
@@ -67,8 +80,8 @@ export const mutations = {
 
   deleteAddress: async(_, { id: addressId }, { vtex: { account, authToken }, request: { headers: { cookie } } }) => {
     const { userId, id: clientId } = await getClientData(account, authToken, cookie)
-  
-    if (!(await isUserAddress(account, clientId, addressId, authToken))) {  
+
+    if (!(await isUserAddress(account, clientId, addressId, authToken))) {
       throw new ResolverError('Address not found.', 400)
     }
 
@@ -80,11 +93,17 @@ export const mutations = {
   updateAddress: async (_, args, config) => addressPatch(_, args, config),
 
   updateProfile: async (_, args, { vtex: { account, authToken }, request: { headers: { cookie } } }) => {
-    const { id: profileId } = await getClientData(account, authToken, cookie)
-    
+    const customFieldsStr = customFieldsFromGraphQLInput(args.customFields)
+    const oldData = await getClientData(account, authToken, cookie, customFieldsStr)
+    const newData = reduce(addFieldsToObj, args.fields, args.customFields || [])
+
     return await makeRequest(
-      paths.profile(account).profile(profileId), authToken, args.fields, 'PATCH'
-    ).then(() => getClientData(account, authToken, cookie)).then((obj)=>({...obj, cacheId: obj.email}))
+      paths.profile(account).profile(oldData.id), authToken, newData, 'PATCH'
+    ).then(() => getClientData(account, authToken, cookie, customFieldsStr)).then((obj)=>({...obj, cacheId: obj.email}))
+    .then(obj => {
+      obj.customFields = pickCustomFieldsFromData(customFieldsStr, obj)
+      return obj
+    }).catch(returnOldOnNotChanged(oldData))
   },
 }
 

--- a/node/resolvers/profile/profileResolver.ts
+++ b/node/resolvers/profile/profileResolver.ts
@@ -1,6 +1,6 @@
 import http from 'axios'
 import { parse as parseCookie } from 'cookie'
-import { head, merge, pickBy, pipe, prop, values } from 'ramda'
+import { compose, head, join, mapObjIndexed, merge, pick, pickBy, pipe, pluck, prop, split, values } from 'ramda'
 import ResolverError from '../../errors/resolverError'
 import { headers, withAuthToken } from '../headers'
 import paths from '../paths'
@@ -11,7 +11,18 @@ const configRequest = async (ctx, url) => ({
   url,
 })
 
-const profile = (ctx) => async (data) => {
+export const pickCustomFieldsFromData = (customFields: string, data) => customFields && compose(
+  values,
+  mapObjIndexed((value, key) => ({key, value})),
+  pick(split(',', customFields))
+)(data)
+
+export const customFieldsFromGraphQLInput = (customFieldsInput) => compose(
+  join(','),
+  pluck('key')
+)(customFieldsInput)
+
+const profile = (ctx, {customFields}) => async (data) => {
   if (data === null) {
     return data
   }
@@ -24,8 +35,9 @@ const profile = (ctx) => async (data) => {
     },
   }
 
-  const profileURL = paths.profile(ctx.account).filterUser(user)
+  const profileURL = paths.profile(ctx.account).filterUser(user, customFields)
   const profileData = await http.get(profileURL, config).then<any>(pipe(prop('data'), head))
+  profileData.customFields = pickCustomFieldsFromData(customFields, profileData)
 
   if (profileData && profileData.id) {
     const addressURL = paths.profile(ctx.account).filterAddress(profileData.id)
@@ -49,5 +61,5 @@ export default async (_, args, { vtex: ioContext, request: { headers: { cookie }
     throw new ResolverError('User is not authenticated.', 401)
   }
   const addressRequest = await configRequest(ioContext, paths.identity(account, { token }))
-  return await http.request(addressRequest).then(prop('data')).then(profile(ioContext))
+  return await http.request(addressRequest).then(prop('data')).then(profile(ioContext, args))
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds extensible profile info to schema graphql and implementation

#### What problem is this solving?
Today, devs can not use their own fields in CL entities in masterdata. This PR solves this problem

#### How should this be manually tested?
1. Link this PR, open graphiql
2. login with login mutations
3. make the updateProfile mutation with custom fields to profile entity
4. retrieve than with profile query

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
