### PR TITLE
Add local fields resolver to benefits resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Support for product retrievement into benefits resolver.
 
+### Fixed
+- Resolve null fields of product data in benefits resolver.
+
 ## [2.10.0] - 2018-7-4
 ### Added
 - PriceRanges to facets graphql type

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import paths from '../paths'
 import { flatten } from 'ramda'
 import { withAuthToken } from '../headers'
+import { resolveLocalProductFields } from '../catalog/fieldsResolver'
 
 /**
  * Default values for Shipping Items
@@ -27,8 +28,8 @@ const getSKUItems = async (skuIds, ioContext) => {
  * @param ioContext VTEX ioContext which contains the informations of the application.
  */
 const getProduct = async (slug, ioContext) => {
-  const { data: [ product, _ ] } = await axios.get(paths.product(ioContext.account, { slug }), { headers: withAuthToken()(ioContext) })
-  return product;
+  const { data: [ product ] } = await axios.get(paths.product(ioContext.account, { slug }), { headers: withAuthToken()(ioContext) })
+  return resolveLocalProductFields(product)
 }
 
 /**


### PR DESCRIPTION
#### What is the purpose of this pull request?
Resolve null fields of product data in benefits resolver.

#### What problem is this solving?
Attributes like `clusterHighlights` and others were come with null values and stay without treatment.

#### Screenshots or example usage

<a href="https://gustavo--storecomponents.myvtex.com/_v/vtex.store-graphql@2.10.0/graphiql/v1">Workspace</a>

```gql
query Query($slug: String) {
  product (slug: $slug) {
    clusterHighlights {
      id
      name
    }
  }
}
```

```json
{
  "slug": "porsche-911"
}
```

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
