### PR TITLE
Fix/add country to address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `country` field to `address` query
 ### Fixed
 - Circular benefit query.
 
@@ -43,30 +45,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed bug in `logout` mutation that didn't log out correctly.
 
 ## [2.9.0] - 2018-6-26
-### Added 
+### Added
 - Add `recoveryPassword` mutation in auth resolver.
 
 ## [2.8.0] - 2018-6-25
 ### Added
-- Add classic login mutation. 
+- Add classic login mutation.
 
 ### Changed
-- Refact auth resolver. 
+- Refact auth resolver.
 
 ## [2.7.2] - 2018-6-20
 
-### Fixed 
+### Fixed
 - Fix products search query only adding a category if there is not a search term.
 
 ## [2.7.1] - 2018-6-20
 ### Fixed
-- Fix `vtexId` use on `paths.ts`. 
+- Fix `vtexId` use on `paths.ts`.
 
 ## [2.7.0] - 2018-6-19
 ### Added
-- Add documentation in `graphql` files. 
+- Add documentation in `graphql` files.
 
-### Changed 
+### Changed
 - Refact paths and organize API docs.
 - Profile Query will return the user email in case of data not found.
 
@@ -74,12 +76,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix `profile resolver` to use ioContext authToken.
 
 ## [2.6.1] - 2018-6-15
-### Fixed 
+### Fixed
 - Set the `maxAge` received from VTEXID to `VtexIdclientAutCookie_${account}` in `accessKeySigIn` mutation.
 
 ## [2.6.0] - 2018-6-15
 
-### Added 
+### Added
 - Create the logout mutation.
 
 ## [2.5.2] - 2018-6-14
@@ -90,10 +92,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Remove `VtexTemporarySession` to AuthInput.
 
-## [2.5.0] - 2018-6-8 
+## [2.5.0] - 2018-6-8
 
 ### Added
-- Sets cache hints to schema root fields 
+- Sets cache hints to schema root fields
 
 ### Fixed
 - Fix profile query to reflect changes that were made in auth resolver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.12.1] - 2018-07-16
 ### Added
 - `country` field to `address` query
 ### Fixed

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -1,76 +1,76 @@
 type Profile {
   """ email is used as cacheId """
-  cacheId: ID,
-  id: String,
-  userId: String,
-  firstName: String,
-  lastName: String,
-  birthDate: String,
-  gender: String,
-  homePhone: String,
-  businessPhone: String,
-  document: String,
-  email: String,
-  address: [Address],
-  tradeName: String,
-  corporateName: String,
-  corporateDocument: String,
-  stateRegistration: String,
-  customFields: [CustomField],
+  cacheId: ID
+  id: String
+  userId: String
+  firstName: String
+  lastName: String
+  birthDate: String
+  gender: String
+  homePhone: String
+  businessPhone: String
+  document: String
+  email: String
+  address: [Address]
+  tradeName: String
+  corporateName: String
+  corporateDocument: String
+  stateRegistration: String
+  customFields: [CustomField]
 }
 
 type CustomField {
-  key: String,
-  value: String,
+  key: String
+  value: String
 }
 
 input ProfileInput {
-  firstName: String,
-  lastName: String,
-  birthDate: String,
-  gender: String,
-  homePhone: String,
-  businessPhone: String,
-  document: String,
-  tradeName: String,
-  corporateName: String,
-  corporateDocument: String,
-  stateRegistration: String,
+  firstName: String
+  lastName: String
+  birthDate: String
+  gender: String
+  homePhone: String
+  businessPhone: String
+  document: String
+  tradeName: String
+  corporateName: String
+  corporateDocument: String
+  stateRegistration: String
 }
 
 input CustomFieldInput {
-  key: String,
-  value: String,
+  key: String
+  value: String
 }
 
 type Address {
-  id: String,
-  userId: String,
-  receiverName: String,
-  complement: String,
-  neighborhood: String,
-  country: String,
-  state: String,
-  number: String,
-  street: String,
-  postalCode: String,
-  city: String,
-  reference: String,
-  addressName: String,
-  addressType: String,
+  id: String
+  userId: String
+  receiverName: String
+  complement: String
+  neighborhood: String
+  country: String
+  state: String
+  number: String
+  street: String
+  postalCode: String
+  city: String
+  reference: String
+  addressName: String
+  addressType: String
 }
 
 input AddressInput {
-  receiverName: String,
-  complement: String,
-  neighborhood: String,
-  country: String,
-  state: String,
-  number: String,
-  street: String,
-  postalCode: String,
-  city: String,
-  reference: String,
-  addressName: String,
-  addressType: String,
+  receiverName: String
+  complement: String
+  neighborhood: String
+  country: String
+  state: String
+  number: String
+  street: String
+  postalCode: String
+  city: String
+  reference: String
+  addressName: String
+  addressType: String
 }

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -1,6 +1,6 @@
 type Profile {
   """ email is used as cacheId """
-  cacheId: ID
+  cacheId: ID,
   id: String,
   userId: String,
   firstName: String,
@@ -16,12 +16,12 @@ type Profile {
   corporateName: String,
   corporateDocument: String,
   stateRegistration: String,
-  customFields: [CustomField]
+  customFields: [CustomField],
 }
 
 type CustomField {
-  key: String
-  value: String
+  key: String,
+  value: String,
 }
 
 input ProfileInput {
@@ -39,8 +39,8 @@ input ProfileInput {
 }
 
 input CustomFieldInput {
-  key: String
-  value: String
+  key: String,
+  value: String,
 }
 
 type Address {
@@ -49,6 +49,7 @@ type Address {
   receiverName: String,
   complement: String,
   neighborhood: String,
+  country: String,
   state: String,
   number: String,
   street: String,
@@ -63,6 +64,7 @@ input AddressInput {
   receiverName: String,
   complement: String,
   neighborhood: String,
+  country: String,
   state: String,
   number: String,
   street: String,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -84,7 +84,7 @@ const paths = {
   profile: account => ({
     address: (id) => `http://api.vtex.com/${account}/dataentities/AD/documents/${id}`,
     attachments: (id, field) => `http://api.vtex.com/${account}/dataentities/CL/documents/${id}/${field}/attachments`,
-    filterAddress: (id) => `http://api.vtex.com/${account}/dataentities/AD/search?userId=${id}&_fields=userId,id,receiverName,complement,neighborhood,state,number,street,postalCode,city,reference,addressName,addressType`,
+    filterAddress: (id) => `http://api.vtex.com/${account}/dataentities/AD/search?userId=${id}&_fields=userId,id,receiverName,complement,neighborhood,country,state,number,street,postalCode,city,reference,addressName,addressType`,
     filterUser: (email, customFields?) => join(',', [`http://api.vtex.com/${account}/dataentities/CL/search?email=${email}&_fields=userId,id,firstName,lastName,birthDate,gender,homePhone,businessPhone,document,email,tradeName,corporateName,stateRegistration,corporateDocument`, customFields]),
     profile: (id) => `http://api.vtex.com/${account}/dataentities/CL/documents/${id}`,
   }),


### PR DESCRIPTION
#### What is the purpose of this pull request?
This pull request adds a 'country' field to the 'address' query, which is already served by the API but wasn't included in the GraphQL schema until now. I also took a moment to remove a few commas from `Profile.graphql` in order to follow the code style from other files.