### PR TITLE
Update product query (change property product to benefitProduct)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Property name of productQuery benefits.items.product to benefits.items.benefitProduct
 
 ## [2.12.3] - 2018-07-17
 ### Fixed

--- a/graphql/types/Benefits.graphql
+++ b/graphql/types/Benefits.graphql
@@ -13,7 +13,7 @@ type Benefit {
 }
 
 type BenefitItem {
-  product: Product
+  benefitProduct: Product
   discount: Float
   minQuantity: Int
 }

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -50,10 +50,10 @@ const getBenefitsWithSKUItems = async (benefits, ioContext) => {
 
       const benefitItems = await Promise.all(skuList.map(async sku => {
         const slug = sku.DetailUrl.split('/')[1]
-        const product = await getProduct(slug, ioContext)
+        const benefitProduct = await getProduct(slug, ioContext)
 
         return {
-          product,
+          benefitProduct,
           discount,
           minQuantity
         }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Changed Property name of productQuery benefits.items.product to benefits.items.benefitProduct

#### What problem is this solving?
- When executing the query Product with the attribute benefits.items.product, cause a circular request query.

#### How should this be manually tested?
[workspace](https://claudivan--storecomponents.myvtex.com)

1 - Go to Home Page
2 - Click in a product, the Product Page must be rendered without errors

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
