### PR TITLE
Add default value for custom fields on updateProfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Update profile` mutation without custom fields.
 
 ## [2.15.0] - 2018-07-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.15.1] - 2018-07-27
 ### Fixed
 - `Update profile` mutation without custom fields.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -95,7 +95,7 @@ export const mutations = {
   updateAddress: async (_, args, config) => addressPatch(_, args, config),
 
   updateProfile: async (_, args, { vtex: { account, authToken }, request: { headers: { cookie } } }) => {
-    const customFieldsStr = customFieldsFromGraphQLInput(args.customFields)
+    const customFieldsStr = customFieldsFromGraphQLInput(args.customFields || [])
     const oldData = await getClientData(account, authToken, cookie, customFieldsStr)
     const newData = reduce(addFieldsToObj, args.fields, args.customFields || [])
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This pull request fixes a problem where the `updateProfile` mutation would crash if no custom fields were provided as argument.

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
