### PR TITLE
Fix custom fields error when profile data is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Profile Resolver` error when profile data returned null.
 
 ## [2.15.2] - 2018-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.15.3] - 2018-07-30
 ### Fixed
 - `Profile Resolver` error when profile data returned null.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/profile/profileResolver.ts
+++ b/node/resolvers/profile/profileResolver.ts
@@ -37,9 +37,10 @@ const profile = (ctx, {customFields}) => async (data) => {
 
   const profileURL = paths.profile(ctx.account).filterUser(user, customFields)
   const profileData = await http.get(profileURL, config).then<any>(pipe(prop('data'), head))
-  profileData.customFields = pickCustomFieldsFromData(customFields, profileData)
 
   if (profileData && profileData.id) {
+    profileData.customFields = pickCustomFieldsFromData(customFields, profileData)
+
     const addressURL = paths.profile(ctx.account).filterAddress(profileData.id)
     const address = profileData && await http.get(addressURL, config).then(prop('data'))
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Modifying the profile data only when isn't undefined.

#### What problem is this solving?
Custom fields error when profile data is null

#### How should this be manually tested?

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
