### PR TITLE
Fix profileUpdate for customFields only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.15.4] - 2018-08-02
 ### Fixed
 - `ProfileUpdate` mutation works when customFields only are provided
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `ProfileUpdate` mutation works when customFields only are provided
 
 ## [2.15.3] - 2018-07-30
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -97,7 +97,7 @@ export const mutations = {
   updateProfile: async (_, args, { vtex: { account, authToken }, request: { headers: { cookie } } }) => {
     const customFieldsStr = customFieldsFromGraphQLInput(args.customFields || [])
     const oldData = await getClientData(account, authToken, cookie, customFieldsStr)
-    const newData = reduce(addFieldsToObj, args.fields, args.customFields || [])
+    const newData = reduce(addFieldsToObj, args.fields || {}, args.customFields || [])
 
     return await makeRequest(
       paths.profile(account).profile(oldData.id), authToken, newData, 'PATCH'


### PR DESCRIPTION
#### What is the purpose of this pull request?
When a `mutation profileUpdate` is made with customFields only, an `undefined` error is thrown. This pr solves this issue

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
