### PR TITLE
Search in Gocommerce catalog when account is Gocommerce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Search in Gocommerce catalog when account is Gocommerce
 
 ## [2.16.0] - 2018-08-06
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -88,6 +88,13 @@
       }
     },
     {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "api.gocommerce.com",
+        "path": "/{{account}}/search/*"
+      }
+    },
+    {
       "name": "POWER_USER_DS"
     }
   ]

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -5,7 +5,7 @@ const paths = {
   /** Catalog API
    * Docs: https://documenter.getpostman.com/view/845/catalogsystem-102/Hs44
   */
-  catalog: account => `http://${account}.vtexcommercestable.com.br/api/catalog_system`,
+  catalog: account => `${account.indexOf('gc_') === 0 ? `https://api.gocommerce.com/${account}/search` : `http://${account}.vtexcommercestable.com.br/api/catalog_system`}`,
 
   product: (account, { slug }) => `${paths.catalog(account)}/pub/products/search/${slug}/p`,
   productByEan: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=alternateIds_Ean=${id}`,

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -5,7 +5,7 @@ const paths = {
   /** Catalog API
    * Docs: https://documenter.getpostman.com/view/845/catalogsystem-102/Hs44
   */
-  catalog: account => `${account.indexOf('gc_') === 0 ? `https://api.gocommerce.com/${account}/search` : `http://${account}.vtexcommercestable.com.br/api/catalog_system`}`,
+  catalog: account => `${account.indexOf('gc_') === 0 || account.indexOf('gc-') === 0 ? `https://api.gocommerce.com/${account}/search` : `http://${account}.vtexcommercestable.com.br/api/catalog_system`}`,
 
   product: (account, { slug }) => `${paths.catalog(account)}/pub/products/search/${slug}/p`,
   productByEan: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=alternateIds_Ean=${id}`,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the API used in the catalog for search in Gocommerce when it's a Gocommerce account or in VTEX catalog when not.

#### What problem is this solving?
The systems has different API for catalog, so the resolver needs to search in the right one.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
