### PR TITLE
Replace http to https in item imageUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replace `http` to `https` in item `imageUrl` property.
 
 ## [2.17.0] - 2018-08-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.18.0] - 2018-08-08
 ### Changed
 - Replace `http` to `https` in item `imageUrl` property.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/fieldsResolver.ts
+++ b/node/resolvers/catalog/fieldsResolver.ts
@@ -1,5 +1,5 @@
 import { IOContext } from 'colossus'
-import { compose, juxt, last, map, omit, prop, split, toPairs } from 'ramda'
+import { compose, juxt, last, map, omit, prop, split, toPairs, replace } from 'ramda'
 import * as slugify from 'slugify'
 
 import { resolveBuy, resolveView } from './recommendationsResolver'
@@ -67,12 +67,21 @@ const resolvers = {
       sku.attachments || []
     )
   },
+  images: sku => {
+    return map(
+      image => ({
+        ...image,
+        imageUrl: replace('http', 'https', image.imageUrl),
+      }),
+      sku.images || []
+    )
+  },
 
   items: product => {
     return map(sku => {
-      const resolveFields = juxt([resolvers.variations, resolvers.attachments])
-      const [variations, attachments] = resolveFields(sku)
-      return { ...sku, attachments, variations }
+      const resolveFields = juxt([resolvers.variations, resolvers.attachments, resolvers.images])
+      const [variations, attachments, images] = resolveFields(sku)
+      return { ...sku, attachments, variations, images }
     }, product.items || [])
   },
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Now, all images of the product will return with `https.`

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Fix this issue ![screen shot 2018-08-08 at 18 31 43](https://user-images.githubusercontent.com/8000984/43865573-58e7cc52-9b39-11e8-83d5-63dd8d63761d.png)

#### Screenshots or example usage
[query](https://graphql--storecomponents.myvtex.com/_v/vtex.store-graphql@2.17.0/graphiql/v1?query=query%20product%20%7B%20%0A%09product%20(slug%3A%20%22tenis-mizuno-wave-viper-3-masculino%22)%20%7B%0A%20%20%20%20productId%0A%20%20%20%20productName%0A%20%20%20%20items%7B%0A%20%20%20%20%20%20images%7B%0A%20%20%20%20%20%20%20%20imageId%0A%20%20%20%20%20%20%20%20imageUrl%0A%20%20%20%20%20%20%20%20imageText%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=product)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
