### PR TITLE
Fix/delete address return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+# Fixed
+- Return profile on address delete
 
 ## [2.19.0] - 2018-08-13
 ### Added
@@ -17,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.18.1] - 2018-08-09
 ### Fixed
-- Fix replace `http` to `https` to match only `http://`. 
+- Fix replace `http` to `https` to match only `http://`.
 
 ## [2.18.0] - 2018-08-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.19.1] - 2018-08-13
 # Fixed
 - Return profile on address delete
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -162,7 +162,7 @@ type Mutation {
   updateProfile(fields: ProfileInput, customFields: [ProfileCustomFieldInput!]): Profile
   updateAddress(id: String, fields: AddressInput): Profile
   createAddress(fields: AddressInput): Profile
-  deleteAddress(id: String): Boolean
+  deleteAddress(id: String): Profile
 
   """ Updates the Profile Picture by erasing the old ones """
   updateProfilePicture(

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -79,16 +79,20 @@ const returnOldOnNotChanged = (oldData) => (error) => {
 export const mutations = {
   createAddress: async (_, args, config) => addressPatch(_, args, config),
 
-  deleteAddress: async(_, { id: addressId }, { vtex: { account, authToken }, request: { headers: { cookie } } }) => {
+  deleteAddress: async(_, args, config) => {
+    const { id: addressId } = args
+    const { vtex: { account, authToken }, request: { headers: { cookie } } } = config
     const { userId, id: clientId } = await getClientData(account, authToken, cookie)
 
     if (!(await isUserAddress(account, clientId, addressId, authToken))) {
       throw new ResolverError('Address not found.', 400)
     }
 
-    return await makeRequest(
+    await makeRequest(
       paths.profile(account).address(addressId), authToken, null, 'DELETE'
     )
+
+    return await profileResolver(_, args, config)
   },
 
   updateAddress: async (_, args, config) => addressPatch(_, args, config),


### PR DESCRIPTION
#### What is the purpose of this pull request?
This pull requests modifies the `deleteAddress` mutation to return a complete profile object instead of a boolean value, as the other address mutations already do, to keep a standard and optimize caching in the graphQL client.

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
