### PR TITLE
Adds Masterdata's attachment upload API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- UploadAttachment resolver
+- UpdateProfilePicture to allow replacing existing profile picture
+
+### Changed
+- UploadProfilePicture uses upload attachment resolver
 
 ## [2.18.1] - 2018-08-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.19.0] - 2018-08-13
 ### Added
 - UploadAttachment resolver
 - UpdateProfilePicture to allow replacing existing profile picture

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -142,7 +142,7 @@ type Query {
 
   """ Get the options available to authenticate users """
   loginOptions: LoginOptions
-  
+
   """ Get the IDs for the provided search context slugs """
   searchContextFromParams(
     brand: String,
@@ -160,10 +160,14 @@ type Mutation {
 
   """ Profile """
   updateProfile(fields: ProfileInput, customFields: [ProfileCustomFieldInput!]): Profile
-  uploadProfilePicture(file: Upload!, field: String!): ProfileCustomField
   updateAddress(id: String, fields: AddressInput): Profile
   createAddress(fields: AddressInput): Profile
   deleteAddress(id: String): Boolean
+
+  """ Uploads the Profile Picture by ereasing the old ones """
+  updateProfilePicture(file: Upload!, field: String!): ProfileCustomField
+  """ Uploads the Profile Picture by appending to the existing ones """
+  uploadProfilePicture(file: Upload!, field: String!): ProfileCustomField
 
   """ Order Form """
   updateOrderFormProfile(orderFormId: String, fields: OrderFormProfileInput): OrderForm
@@ -224,4 +228,5 @@ type Mutation {
   """ Document """
   createDocument(acronym: String, document: DocumentInput): DocumentResponse
   updateDocument(acronym: String, document: DocumentInput): DocumentResponse
+  uploadAttachment(acronym: String, documentId: ID!, field: String, file: Upload!): AttachmentResponse
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -164,10 +164,20 @@ type Mutation {
   createAddress(fields: AddressInput): Profile
   deleteAddress(id: String): Boolean
 
-  """ Uploads the Profile Picture by ereasing the old ones """
-  updateProfilePicture(file: Upload!, field: String!): ProfileCustomField
+  """ Updates the Profile Picture by erasing the old ones """
+  updateProfilePicture(
+    """ File being uploaded """
+    file: Upload!,
+    """ Attachment's field name (ex. ProfilePicture) """
+    field: String!
+  ): ProfileCustomField
   """ Uploads the Profile Picture by appending to the existing ones """
-  uploadProfilePicture(file: Upload!, field: String!): ProfileCustomField
+  uploadProfilePicture(
+    """ File being uploaded """
+    file: Upload!,
+    """ Attachment's field name (ex. ProfilePicture) """
+    field: String!
+  ): ProfileCustomField
 
   """ Order Form """
   updateOrderFormProfile(orderFormId: String, fields: OrderFormProfileInput): OrderForm
@@ -226,7 +236,7 @@ type Mutation {
   logout: Boolean
 
   """ Document """
-  createDocument(acronym: String, document: DocumentInput): DocumentResponse
-  updateDocument(acronym: String, document: DocumentInput): DocumentResponse
-  uploadAttachment(acronym: String, documentId: ID!, field: String, file: Upload!): AttachmentResponse
+  createDocument(acronym: String!, document: DocumentInput): DocumentResponse
+  updateDocument(acronym: String!, document: DocumentInput): DocumentResponse
+  uploadAttachment(acronym: String!, documentId: ID!, field: String!, file: Upload!): AttachmentResponse
 }

--- a/graphql/types/Document.graphql
+++ b/graphql/types/Document.graphql
@@ -18,6 +18,11 @@ type DocumentResponse {
   documentId: String
 }
 
+type AttachmentResponse {
+  filename: String
+  mimetype: String
+}
+
 input FieldInput {
   key: String,
   value: String

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/document/attachment.ts
+++ b/node/resolvers/document/attachment.ts
@@ -3,8 +3,8 @@ import fetch from 'node-fetch'
 import ResolverError from '../../errors/resolverError'
 import paths from '../paths'
 
-export const uploadAttachment = async (args, IOContext) => {
-  const {authToken, account} = IOContext
+export const uploadAttachment = async (args, ioContext) => {
+  const {authToken, account} = ioContext
   const {acronym, documentId, field, file} = args
 
   const {stream, filename, mimetype} = await file

--- a/node/resolvers/document/attachment.ts
+++ b/node/resolvers/document/attachment.ts
@@ -1,0 +1,39 @@
+import FormData from 'form-data'
+import fetch from 'node-fetch'
+import ResolverError from '../../errors/resolverError'
+import paths from '../paths'
+
+export const uploadAttachment = async (args, IOContext) => {
+  const {authToken, account} = IOContext
+  const {acronym, documentId, field, file} = args
+
+  const {stream, filename, mimetype} = await file
+  const buffer = await new Promise((resolve, reject) => {
+    const bufs = []
+    stream.on('data', d => bufs.push(d))
+    stream.on('end', () => {
+      resolve(Buffer.concat(bufs))
+    })
+    stream.on('error', reject)
+  }) as Buffer
+
+  const formData = new FormData()
+
+  formData.append(field, buffer, {filename, contentType: mimetype, knownLength: buffer.byteLength})
+
+  const response = await fetch(paths.attachment(account, acronym, documentId, field), {
+    body: formData,
+    headers: {
+      'Proxy-Authorization': authToken,
+      'VtexIdclientAutCookie': authToken,
+      ...formData.getHeaders(),
+    },
+    method: 'POST',
+  }).then(res => res.text())
+
+  if (response) {
+    throw new ResolverError(response, 500)
+  }
+
+  return {filename, mimetype}
+}

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -1,7 +1,9 @@
 import http from 'axios'
+import { mergeAll, union, zipObj } from 'ramda'
+import ResolverError from '../../errors/resolverError';
+import { withAuthToken, withMDPagination } from '../headers'
 import paths from '../paths'
-import { zipObj, mergeAll, union } from 'ramda'
-import { withAuthToken, withMDPagination, headers } from '../headers'
+import { uploadAttachment } from './attachment';
 
 /**
  * Map a document object to a list of {key: 'property', value: 'propertyValue'}.
@@ -72,4 +74,6 @@ export const mutations = {
     )
     return { cacheId: DocumentId, id: Id, href: Href, documentId: DocumentId }
   },
+
+  uploadAttachment: async (root, args, {vtex: IOContext}, info) => uploadAttachment(args, IOContext)
 }

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -74,5 +74,5 @@ export const mutations = {
     return { cacheId: DocumentId, id: Id, href: Href, documentId: DocumentId }
   },
 
-  uploadAttachment: async (root, args, {vtex: IOContext}, info) => uploadAttachment(args, IOContext)
+  uploadAttachment: async (root, args, {vtex: ioContext}, info) => uploadAttachment(args, ioContext)
 }

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -1,9 +1,8 @@
 import http from 'axios'
 import { mergeAll, union, zipObj } from 'ramda'
-import ResolverError from '../../errors/resolverError';
 import { withAuthToken, withMDPagination } from '../headers'
 import paths from '../paths'
-import { uploadAttachment } from './attachment';
+import { uploadAttachment } from './attachment'
 
 /**
  * Map a document object to a list of {key: 'property', value: 'propertyValue'}.

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -79,6 +79,7 @@ const paths = {
   documents: (account, acronym) => `http://api.vtex.com/${account}/dataentities/${acronym}/documents`,
   document: (account, acronym, id) => `${paths.documents(account, acronym)}/${id}`,
   documentFields: (account, acronym, fields = "_all", id) => `${paths.document(account, acronym, id)}?_fields=${fields}`,
+  attachment: (account, acronym, id, field, filename?) => `${paths.document(account, acronym, id)}/${field}/attachments${filename ? `/${filename}` : ''}`,
 
   profile: account => ({
     address: (id) => `http://api.vtex.com/${account}/dataentities/AD/documents/${id}`,

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -1,9 +1,8 @@
 import http from 'axios'
 import {parse as parseCookie} from 'cookie'
-import FormData from 'form-data'
-import fetch from 'node-fetch'
 import {find, head, pickBy, pipe, prop, reduce, values} from 'ramda'
 import ResolverError from '../../errors/resolverError'
+import { uploadAttachment } from '../document/attachment'
 import { headers, withAuthAsVTEXID } from '../headers'
 import httpResolver from '../httpResolver'
 import paths from '../paths'
@@ -108,41 +107,36 @@ export const mutations = {
     }).catch(returnOldOnNotChanged(oldData))
   },
 
+  updateProfilePicture: async (root, {file, field}, ctx, info) => {
+    const {vtex: {account, authToken}, request: {headers: {cookie}}} = ctx
+    const {id} = await getClientData(account, authToken, cookie)
+
+    // Should delete the field before uploading new profilePicture
+    await makeRequest(paths.profile(account).profile(id), authToken, {[field]: ''}, 'PATCH')
+
+    const {filename} = await uploadAttachment({
+      acronym: 'CL',
+      documentId: id,
+      field,
+      file
+    }, ctx.vtex)
+
+    return {
+      key: field,
+      value: filename
+    }
+  },
+
   uploadProfilePicture: async (root, {file, field}, ctx, info) => {
     const {vtex: {account, authToken}, request: {headers: {cookie}}} = ctx
     const {id} = await getClientData(account, authToken, cookie)
-    const {stream, filename, mimetype} = await file
 
-    const url = paths.profile(account).attachments(id, field)
-
-    const buffer = await new Promise((resolve, reject) => {
-      const bufs = []
-      stream.on('data', d => bufs.push(d))
-      stream.on('end', () => {
-        resolve(Buffer.concat(bufs))
-      })
-      stream.on('error', reject)
-    }) as Buffer
-
-    const formData = new FormData()
-
-    formData.append(field, buffer, {filename, contentType: mimetype, knownLength: buffer.byteLength})
-
-    const options: any = {
-      body: formData,
-      headers: {
-        'Proxy-Authorization': authToken,
-        'VtexIdclientAutCookie': authToken,
-        ...formData.getHeaders(),
-      },
-      method: 'POST',
-    }
-
-    const response = await fetch(url, options).then(res => res.text())
-
-    if (response) {
-      throw new ResolverError(response, 500)
-    }
+    const {filename} = await uploadAttachment({
+      acronym: 'CL',
+      documentId: id,
+      field,
+      file
+    }, ctx.vtex)
 
     return {
       key: field,


### PR DESCRIPTION
This adds masterdata's attachment API and uses it for uploading profile picture. Also, this PR adds to modes to upload profile picture:
- UploadProfilePicture: appends profile picture to previous ones
- UpdateProfilePicture: replaces previous profile pictures with new one

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
