### PR TITLE
`Benefits Resolver` using only public endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Benefits resolver using only public endpoints.
+
 ## [2.19.1] - 2018-08-13
 # Fixed
 - Return profile on address delete

--- a/graphql/types/Benefits.graphql
+++ b/graphql/types/Benefits.graphql
@@ -1,19 +1,20 @@
 """ Benefit of a Product """
 type Benefit {
+  """ ID of the benefit"""
+  id: String
   """ Flag which indicates if the benefit is featured or not """
   featured: Boolean
-  """ Id of the product which the benefit is associated """
-  id: String
   """ Name of the benefit """
   name: String
-  """ Items of the benefit """
-  items: [BenefitItem]
-  """ Type of benefit """
-  teaserType: String
+  """ Products which composes the benefit """
+  products: [BenefitProduct]
 }
 
-type BenefitItem {
-  benefitProduct: Product
+type BenefitProduct {
+  """ Product itself """
+  product: Product
+  """ Discount applied to the product """
   discount: Float
-  minQuantity: Int
+  """ Minimum quantity of the product which is required to validate the benefit """
+  minimumQuantity: Int
 }

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -17,7 +17,7 @@ const DEFAULT_QUANTITY = '1'
  * @param ioContext Helper object which holds the account and the authentication headers.
  */
 const resolveProducts = async (skuIds, ioContext) => {
-  const requestUrl = paths.productBySkus(ioContext.account, { skuIds })
+  const requestUrl = paths.productsBySkus(ioContext.account, { skuIds })
   const requestHeaders = {
     headers: withAuthToken()(ioContext),
   }

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -5,8 +5,8 @@ import { compose, equals, find, head, map, prop, split, test } from 'ramda'
 import * as slugify from 'slugify'
 
 import ResolverError from '../../errors/resolverError'
-import { withAuthToken } from '../headers'
 import { queries as benefitsQueries } from '../benefits'
+import { withAuthToken } from '../headers'
 import paths from '../paths'
 import { resolveBrandFields, resolveCategoryFields, resolveFacetFields, resolveProductFields } from './fieldsResolver'
 
@@ -92,18 +92,22 @@ export const queries = {
 
   product: async (_, data, config, info) => {
     const { vtex: ioContext }: ColossusContext = config
+    
     const url = paths.product(ioContext.account, data)
+    
     const { data: product } = await axios.get(url, {
       headers: withAuthToken()(ioContext),
     })
+
     const resolvedProduct = await resolveProductFields(
       ioContext,
       head(product),
       graphqlFields(info),
     )
-    const resolvedBenefits = await benefitsQueries.benefits(_, { id: resolvedProduct.productId }, config)
 
-    return { ...resolvedProduct, benefits: resolvedBenefits }
+    const benefits = await benefitsQueries.benefits(_, { id: resolvedProduct.productId }, config)
+
+    return { ...resolvedProduct, benefits }
   },
 
   products: async (_, data, { vtex: ioContext }: ColossusContext, info) => {

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -12,8 +12,7 @@ const paths = {
   productById: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=productId:${id}`,
   productByReference: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=alternateIds_RefId=${id}`,
   productBySku: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=skuId:${id}`,
-  
-  productBySkus: (account, { skuIds }) => `${paths.catalog(account)}/pub/products/search?${skuIds.map(skuId => `fq=skuId:${skuId}`).join('&')}`,
+  productsBySkus: (account, { skuIds }) => `${paths.catalog(account)}/pub/products/search?${skuIds.map(skuId => `fq=skuId:${skuId}`).join('&')}`,
   
   products: (account, {
     query = '',

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -12,6 +12,9 @@ const paths = {
   productById: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=productId:${id}`,
   productByReference: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=alternateIds_RefId=${id}`,
   productBySku: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=skuId:${id}`,
+  
+  productBySkus: (account, { skuIds }) => `${paths.catalog(account)}/pub/products/search?${skuIds.map(skuId => `fq=skuId:${skuId}`).join('&')}`,
+  
   products: (account, {
     query = '',
     category = '',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Ensure that the `Benefits Resolver` will only use public endpoints to retrieve the data needed.

#### What problem is this solving?
The Benefits Resolver was using private endpoints to retrieve the data needed. In the case that the user is not logged the data provided by the resolver will be not valid.

#### How should this be manually tested?

#### Screenshots or example usage

<a href="https://gugabribeiro--storecomponents.myvtex.com/_v/vtex.store-graphql@2.19.1/graphiql/v1" target="_blank">Workspace</a>

```gql
query Benefit($items: [ShippingItem]) {
  benefits(items: $items) {
    id
    featured
    name
    products {
      product {
        productName
        items {
          name
        }
      }
      discount
      minimumQuantity
    }
  }
}
```

```json
{
  "items": [
    {
      "id": "1",
      "quantity": "2",
      "seller": "1"
    }
  ]
}
```

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
