### PR TITLE
Add enableCookies on checkout mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `ClientProfile` in `OrderForm` type. 
+
+### Changed 
+- Add `enableCookies: true` on checkout mutations.
 
 ## [2.19.1] - 2018-08-13
-# Fixed
+### Fixed
 - Return profile on address delete
 
 ## [2.19.0] - 2018-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.20.0] - 2018-08-15
 ### Added
 - Add `ClientProfile` in `OrderForm` type. 
 

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -14,6 +14,7 @@ type OrderForm {
   userType: String
   ignoreProfileData: Boolean
   totalizers: [Totalizer]
+  clientProfileData: ClientProfile
 }
 
 type OrderFormItem {
@@ -40,6 +41,21 @@ type Totalizer {
   id: ID
   name: String
   value: Float
+}
+
+type ClientProfile {
+  email: String
+  firstName: String
+  lastName: String
+  phone: String
+  isCorporate: Boolean
+  corporateDocument: String
+  corporateName: String
+  corporatePhone: String
+  document: String
+  documentType: String
+  stateInscription: String
+  tradeName: String
 }
 
 input OrderFormItemInput {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -63,8 +63,8 @@ export const mutations = {
       expectedOrderFormSections: ['items'],
       orderItems: items,
     }),
-    enableCookies: true,
     headers: withAuthToken(headers.json),
+    enableCookies: true,
     merge: (bodyData, responseData) => ({
       ...responseData,
       cacheId: responseData.orderFormId
@@ -77,17 +77,17 @@ export const mutations = {
 
   cancelOrder: httpResolver({
     data: ({ reason }) => ({ reason }),
+    headers: withAuthToken(headers.json),
     enableCookies: true,
     merge: () => ({ success: true }),
     method: 'POST',
-    headers: withAuthToken(headers.json),
     url: paths.cancelOrder,
   }),
 
   createPaymentSession: httpResolver({
     headers: withAuthToken(headers.json),
-    method: 'POST',
     enableCookies: true,
+    method: 'POST',
     secure: true,
     url: paths.gatewayPaymentSession,
   }),
@@ -95,6 +95,7 @@ export const mutations = {
   createPaymentTokens: httpResolver({
     data: ({ payments }) => payments,
     headers: withAuthToken(headers.json),
+    enableCookies: true,
     method: 'POST',
     url: paths.gatewayTokenizePayment,
   }),
@@ -105,6 +106,7 @@ export const mutations = {
       value,
     }),
     headers: withAuthToken(headers.json),
+    enableCookies: true,
     merge: (bodyData, responseData) => ({
       ...responseData,
       cacheId: responseData.orderFormId
@@ -118,8 +120,8 @@ export const mutations = {
       expectedOrderFormSections: ['items'],
       orderItems: items,
     }),
-    enableCookies: true,
     headers: withAuthToken(headers.json),
+    enableCookies: true,
     merge: (bodyData, responseData) => ({
       ...responseData,
       cacheId: responseData.orderFormId
@@ -133,6 +135,7 @@ export const mutations = {
       expectedOrderFormSections: ['items'],
       ignoreProfileData,
     }),
+    enableCookies: true,
     headers: withAuthToken(headers.json),
     merge: (bodyData, responseData) => ({
       ...responseData,
@@ -145,6 +148,7 @@ export const mutations = {
   updateOrderFormPayment: httpResolver({
     data: ({ payments }) => merge({ expectedOrderFormSections: ['items'] }, { payments }),
     headers: withAuthToken(headers.json),
+    enableCookies: true,
     merge: (bodyData, responseData) => ({
       ...responseData,
       cacheId: responseData.orderFormId
@@ -156,6 +160,7 @@ export const mutations = {
   updateOrderFormProfile: httpResolver({
     data: ({ fields }) => merge({ expectedOrderFormSections: ['items'] }, fields),
     headers: withAuthToken(headers.json),
+    enableCookies: true,
     merge: (bodyData, responseData) => ({
       ...responseData,
       cacheId: responseData.orderFormId
@@ -167,6 +172,7 @@ export const mutations = {
   updateOrderFormShipping: httpResolver({
     data: data => merge({ expectedOrderFormSections: ['items'] }, data),
     headers: withAuthToken(headers.json),
+    enableCookies: true,
     merge: (bodyData, responseData) => ({
       ...responseData,
       cacheId: responseData.orderFormId


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add enableCookies on checkout mutations

#### Screenshots or example usage
[access here](https://graphql--storecomponents.myvtex.com/_v/vtex.store-graphql@2.19.1/graphiql/v1?operationName=getOrderForm&query=mutation%20profileOrderForm%20(%24fields%3A%20OrderFormProfileInput)%7B%0A%20%20updateOrderFormProfile(orderFormId%3A%20%22%22%2C%20fields%3A%20%24fields%20)%20%7B%0A%20%20%20%20orderFormId%0A%20%20%7D%0A%7D%0A%0Aquery%20getOrderForm%7B%0A%20%20orderForm%20%7B%0A%20%20%20%20orderFormId%0A%20%20%20%20clientProfileData%20%7B%0A%20%20%20%20%20%20email%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%0A%20%20%22fields%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22email%22%3A%20%22bruno.dias%40vtex.com.br%22%2C%20%0A%20%20%20%20%20%20%20%20%22firstName%22%3A%20%22Bruno%22%2C%0A%20%20%20%20%20%20%20%20%22lastName%22%3A%20%22Dias%22%2C%0A%09%7D%0A%7D)
#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
