### PR TITLE
Add initializeSession, impersonate, depersonify mutations to telemarketing app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.21.0] - 2018-08-23
 ### Added 
 - Add `initializeSession`, `impersonate`, `depersonify` mutations to telemarketing app.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- Add `initializeSession`, `impersonate`, `depersonify` mutations to telemarketing app.
 
 ## [2.20.2] - 2018-08-22
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -240,12 +240,17 @@ type Mutation {
 
   """ Impersonate a customer """
   impersonate(
-    """ The email which will be used to impersonate a user. """
-    email: String!
+    """ The email which will be used to impersonate a user """
+    email: String!,
+    """ orderFormId that will be used to update clientProfileData in orderForm """
+    orderFormId: String!
   ): Session
   
   """ Depersonify a customer """
-  depersonify: Boolean
+  depersonify(
+    """ orderFormId that will be used to remove clientProfileData in orderForm """
+    orderFormId: String!
+  ): Boolean
 
   """ Document """
   createDocument(acronym: String!, document: DocumentInput): DocumentResponse

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -235,8 +235,8 @@ type Mutation {
   """ Invalidate VtexIdclientAutCookie """
   logout: Boolean
 
-  """ Initialize Session to users with telesales profile access """
-  initializeSession: String
+  """ Initialize Session to users with telemarketing profile access """
+  initializeSession: Session
 
   """ Impersonate a customer """
   impersonate(
@@ -245,7 +245,7 @@ type Mutation {
   ): Session
   
   """ Depersonify a customer """
-  depersonify: Session
+  depersonify: Boolean
 
   """ Document """
   createDocument(acronym: String!, document: DocumentInput): DocumentResponse

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -200,7 +200,7 @@ type Mutation {
 
   """ Access key sign in mode """
   accessKeySignIn(
-    """ User email"""
+    """ User email """
     email: String!,
     """ Access key that was received """
     code: String!
@@ -208,7 +208,7 @@ type Mutation {
 
   """ Classic sign in mode """
   classicSignIn(
-    """ User email"""
+    """ User email """
     email: String!,
     """ User password """
     password: String!
@@ -224,7 +224,7 @@ type Mutation {
 
   """ To recovery password you need to get your email, password and access code """
   recoveryPassword(
-    """ User email"""
+    """ User email """
     email: String!,
     """ User password """
     newPassword: String!,
@@ -234,6 +234,18 @@ type Mutation {
 
   """ Invalidate VtexIdclientAutCookie """
   logout: Boolean
+
+  """ Initialize Session to users with telesales profile access """
+  initializeSession: String
+
+  """ Impersonate a customer """
+  impersonate(
+    """ The email which will be used to impersonate a user. """
+    email: String!
+  ): Session
+  
+  """ Depersonify a customer """
+  depersonify: Session
 
   """ Document """
   createDocument(acronym: String!, document: DocumentInput): DocumentResponse

--- a/graphql/types/Session.graphql
+++ b/graphql/types/Session.graphql
@@ -1,6 +1,5 @@
 type Session {
   id: ID,
-  cartId: String,
   impersonate: Boolean,
   adminUserId: String,
   adminUserEmail: String,

--- a/graphql/types/Session.graphql
+++ b/graphql/types/Session.graphql
@@ -1,10 +1,18 @@
 type Session {
   id: ID,
-  accountId: ID,
-  accountName: String,
-  canImpersonate: Boolean,
+  cartId: String,
+  impersonate: Boolean,
   adminUserId: String,
   adminUserEmail: String,
-  inpersonateCustomer: String,
-  profile: Profile
+  profile: CustomerProfile
+}
+
+type CustomerProfile {
+  isAuthenticatedAsCustomer: Boolean,
+  id: ID,
+  firstName: String,
+  lastName: String,
+  email: String,
+  document: String,
+  phone: Int
 }

--- a/graphql/types/Session.graphql
+++ b/graphql/types/Session.graphql
@@ -1,0 +1,10 @@
+type Session {
+  id: ID,
+  accountId: ID,
+  accountName: String,
+  canImpersonate: Boolean,
+  adminUserId: String,
+  adminUserEmail: String,
+  inpersonateCustomer: String,
+  profile: Profile
+}

--- a/manifest.json
+++ b/manifest.json
@@ -95,6 +95,13 @@
       }
     },
     {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "{{account}}.vtexcommercestable.com.br",
+        "path": "/api/sessions/*"
+      }
+    },
+    {
       "name": "POWER_USER_DS"
     }
   ]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.20.2",
+  "version": "2.21.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,7 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "{{account}}.vtexcommercestable.com.br",
+        "host": "{{account}}.vtexcommercebeta.com.br",
         "path": "/api/sessions/*"
       }
     },

--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,7 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "{{account}}.vtexcommercebeta.com.br",
+        "host": "{{account}}.vtexcommercestable.com.br",
         "path": "/api/sessions/*"
       }
     },

--- a/node/graphql/index.ts
+++ b/node/graphql/index.ts
@@ -5,7 +5,7 @@ import { mutations as checkoutMutations, queries as checkoutQueries } from '../r
 import { mutations as profileMutations, queries as profileQueries, rootResolvers as profileRootResolvers } from '../resolvers/profile'
 import { mutations as authMutations, queries as authQueries } from '../resolvers/auth'
 import { mutations as documentMutations, queries as documentQueries } from '../resolvers/document'
-
+import { mutations as sessionMutations } from '../resolvers/session'
 // tslint:disable-next-line:no-var-requires
 Promise = require('bluebird')
 Promise.config({ longStackTraces: true })
@@ -26,5 +26,6 @@ export const resolvers = {
     ...checkoutMutations,
     ...authMutations,
     ...documentMutations,
+    ...sessionMutations
   },
 }

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -52,21 +52,21 @@ export const rootResolvers = {
       return !root.kitItems
         ? []
         : Promise.all(
-            root.kitItems.map(async kitItem => {
-              const url = paths.productBySku(ioContext.account, {
-                id: kitItem.itemId,
-              })
-              const { data: products } = await axios.get(url, {
-                headers: withAuthToken()(ioContext),
-              })
-              const { items: skus, ...product } = head(products) || {}
-              const sku = find(
-                ({ itemId }) => itemId === kitItem.itemId,
-                skus || []
-              )
-              return { ...kitItem, product, sku }
+          root.kitItems.map(async kitItem => {
+            const url = paths.productBySku(ioContext.account, {
+              id: kitItem.itemId,
             })
-          )
+            const { data: products } = await axios.get(url, {
+              headers: withAuthToken()(ioContext),
+            })
+            const { items: skus, ...product } = head(products) || {}
+            const sku = find(
+              ({ itemId }) => itemId === kitItem.itemId,
+              skus || []
+            )
+            return { ...kitItem, product, sku }
+          })
+        )
     },
   },
 }
@@ -122,7 +122,7 @@ export const queries = {
     }
 
     throw new ResolverError(
-      `No product was found with the correspondant slug '${data.slug}'`,
+      `No product was found with the correspondent slug '${data.slug}'`,
       404
     )
   },

--- a/node/resolvers/checkout/paymentTokenResolver.ts
+++ b/node/resolvers/checkout/paymentTokenResolver.ts
@@ -1,5 +1,5 @@
 import http from 'axios'
-import {last, merge, propEq, reject} from 'ramda'
+import { last, merge, propEq, reject } from 'ramda'
 import paths from '../paths'
 
 const createClient = (account, orderFormId, authToken) => {
@@ -12,32 +12,32 @@ const createClient = (account, orderFormId, authToken) => {
 
   return {
     addToken: (paymentToken) => {
-      const payload = {paymentToken, expectedOrderFormSections: ['items', 'paymentData']}
-      const url = paths.orderFormPaymentToken(account, {orderFormId})
+      const payload = { paymentToken, expectedOrderFormSections: ['items', 'paymentData'] }
+      const url = paths.orderFormPaymentToken(account, { orderFormId })
 
-      return http.put(url, payload, {headers})
+      return http.put(url, payload, { headers })
     },
 
     removeToken: (tokenId) => {
-      const url = paths.orderFormPaymentTokenId(account, {orderFormId, tokenId})
-      return http.delete(url, {headers, data: {expectedOrderFormSections: ['items']}})
+      const url = paths.orderFormPaymentTokenId(account, { orderFormId, tokenId })
+      return http.delete(url, { headers, data: { expectedOrderFormSections: ['items'] } })
     },
   }
 }
 
 export default async (body, ioContext) => {
-  const {data: {orderFormId, paymentToken}} = body
+  const { data: { orderFormId, paymentToken } } = body
   const checkout = createClient(ioContext.account, orderFormId, ioContext.authToken)
 
   const response = await checkout.addToken(paymentToken)
 
-  const {data: {paymentData: {availableTokens}}} = response
+  const { data: { paymentData: { availableTokens } } } = response
   const tokensToRemove = reject(propEq('tokenId', paymentToken.tokenId), availableTokens)
 
   if (tokensToRemove.length === 0) {
-    return {data: merge(body.data, response.data)}
+    return { data: merge(body.data, response.data) }
   }
 
-  const lastDeleteResponse = await Promise.mapSeries(tokensToRemove, ({tokenId}) => checkout.removeToken(tokenId)).then<any>(last)
-  return {data: merge(body.data, lastDeleteResponse.data)}
+  const lastDeleteResponse = await Promise.mapSeries(tokensToRemove, ({ tokenId }) => checkout.removeToken(tokenId)).then<any>(last)
+  return { data: merge(body.data, lastDeleteResponse.data) }
 }

--- a/node/resolvers/httpResolver.ts
+++ b/node/resolvers/httpResolver.ts
@@ -3,7 +3,7 @@ import { ColossusContext, IOContext } from 'colossus'
 import { prop } from 'ramda'
 import * as parse from 'url-parse'
 
-const defaultMerge = (bodyData, resData) => resData
+const defaultMerge = (bodyData, resData, resResponse) => resData
 
 export type URLBuilder = (account: string, data: any, root: any) => string
 
@@ -11,7 +11,7 @@ export type DataBuilder = (data: any) => any
 
 export type HeadersBuider = (ioContext: IOContext) => Record<string, string>
 
-export type ResponseMerger = (bodyData: any, responseData: any) => any
+export type ResponseMerger = (bodyData: any, responseData: any, response?: any) => any
 
 export interface HttpResolverOptions {
   method?: string
@@ -48,6 +48,6 @@ export default (options: HttpResolverOptions) => {
         response.set('Set-Cookie', setCookie)
       }
     }
-    return merge(args, vtexResponse.data)
+    return merge(args, vtexResponse.data, vtexResponse)
   }
 }

--- a/node/resolvers/httpResolver.ts
+++ b/node/resolvers/httpResolver.ts
@@ -3,7 +3,7 @@ import { ColossusContext, IOContext } from 'colossus'
 import { prop } from 'ramda'
 import * as parse from 'url-parse'
 
-const defaultMerge = (bodyData, resData, resResponse) => resData
+const defaultMerge = (bodyData, resData, response) => resData
 
 export type URLBuilder = (account: string, data: any, root: any) => string
 

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -72,6 +72,9 @@ const paths = {
   recoveryPassword: (token, email, password, code) => `${paths.vtexId}/authentication/classic/setpassword?authenticationToken=${token}&login=${email}&newPassword=${password}&accessKey=${code}`,
   oAuth: (authenticationToken, providerName) => `${paths.vtexId}/authentication/oauth/redirect?authenticationToken=${authenticationToken}&providerName=${providerName}`,
 
+  /** Sessions API */
+  session: account => `http://${account}.vtexcommercestable.com.br/api/sessions`,
+  getSession: account => `${paths.session(account)}?items=*`,
   /** Master Data API v1
    * Docs: https://documenter.getpostman.com/view/164907/masterdata-api-v102/2TqWsD
    */

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -77,7 +77,7 @@ const paths = {
    * The path session can initialize Session, impersonate and depersonify
    * an user according to the body data that is passed to it.
    */
-  session: account => `http://${account}.vtexcommercestable.com.br/api/sessions`,
+  session: account => `http://${account}.vtexcommercebeta.com.br/api/sessions`,
   getSession: account => `${paths.session(account)}?items=*`,
 
   /** Master Data API v1

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -73,8 +73,13 @@ const paths = {
   oAuth: (authenticationToken, providerName) => `${paths.vtexId}/authentication/oauth/redirect?authenticationToken=${authenticationToken}&providerName=${providerName}`,
 
   /** Sessions API */
+  /** 
+   * The path session can initialize Session, impersonate and depersonify
+   * an user according to the body data that is passed to it.
+   */
   session: account => `http://${account}.vtexcommercestable.com.br/api/sessions`,
   getSession: account => `${paths.session(account)}?items=*`,
+
   /** Master Data API v1
    * Docs: https://documenter.getpostman.com/view/164907/masterdata-api-v102/2TqWsD
    */

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -45,8 +45,8 @@ const paths = {
   orderFormCustomData: (account, { orderFormId, appId, field }) => `${paths.orderForm(account)}/${orderFormId}/customData/${appId}/${field}`,
   addItem: (account, { orderFormId }) => `${paths.orderForm(account)}/${orderFormId}/items`,
   updateItems: (account, data) => `${paths.addItem(account, data)}/update`,
-
   shipping: account => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orderForms/simulation`,
+  changeToAnonymousUser: (account, { orderFormId }) => `http://${account}.vtexcommercestable.com.br/checkout/changeToAnonymousUser/${orderFormId}`,
 
   skuById: (account, { skuId }) => `${paths.catalog(account)}/pvt/sku/stockkeepingunitbyid/${skuId}`,
 

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -77,7 +77,7 @@ const paths = {
    * The path session can initialize Session, impersonate and depersonify
    * an user according to the body data that is passed to it.
    */
-  session: account => `http://${account}.vtexcommercebeta.com.br/api/sessions`,
+  session: account => `http://${account}.vtexcommercestable.com.br/api/sessions`,
   getSession: account => `${paths.session(account)}?items=*`,
 
   /** Master Data API v1

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -1,14 +1,14 @@
 import http from 'axios'
-import {parse as parseCookie} from 'cookie'
-import {find, head, pickBy, pipe, prop, reduce, values} from 'ramda'
+import { parse as parseCookie } from 'cookie'
+import { find, head, pickBy, pipe, prop, reduce, values } from 'ramda'
 import ResolverError from '../../errors/resolverError'
 import { uploadAttachment } from '../document/attachment'
 import { headers, withAuthAsVTEXID } from '../headers'
 import httpResolver from '../httpResolver'
 import paths from '../paths'
-import profileResolver, {customFieldsFromGraphQLInput, pickCustomFieldsFromData} from './profileResolver'
+import profileResolver, { customFieldsFromGraphQLInput, pickCustomFieldsFromData } from './profileResolver'
 
-const makeRequest = async (url, token, data?, method='GET') => http.request({
+const makeRequest = async (url, token, data?, method = 'GET') => http.request({
   url, data, method, headers: {
     'Proxy-Authorization': token,
     'VtexIdclientAutCookie': token
@@ -63,7 +63,7 @@ const addressPatch = async (_, args, config) => {
   return await profileResolver(_, args, config)
 }
 
-const addFieldsToObj = (acc, {key, value}) => {
+const addFieldsToObj = (acc, { key, value }) => {
   acc[key] = value
   return acc
 }
@@ -79,7 +79,7 @@ const returnOldOnNotChanged = (oldData) => (error) => {
 export const mutations = {
   createAddress: async (_, args, config) => addressPatch(_, args, config),
 
-  deleteAddress: async(_, args, config) => {
+  deleteAddress: async (_, args, config) => {
     const { id: addressId } = args
     const { vtex: { account, authToken }, request: { headers: { cookie } } } = config
     const { userId, id: clientId } = await getClientData(account, authToken, cookie)
@@ -104,21 +104,21 @@ export const mutations = {
 
     return await makeRequest(
       paths.profile(account).profile(oldData.id), authToken, newData, 'PATCH'
-    ).then(() => getClientData(account, authToken, cookie, customFieldsStr)).then((obj)=>({...obj, cacheId: obj.email}))
-    .then(obj => {
-      obj.customFields = pickCustomFieldsFromData(customFieldsStr, obj)
-      return obj
-    }).catch(returnOldOnNotChanged(oldData))
+    ).then(() => getClientData(account, authToken, cookie, customFieldsStr)).then((obj) => ({ ...obj, cacheId: obj.email }))
+      .then(obj => {
+        obj.customFields = pickCustomFieldsFromData(customFieldsStr, obj)
+        return obj
+      }).catch(returnOldOnNotChanged(oldData))
   },
 
-  updateProfilePicture: async (root, {file, field}, ctx, info) => {
-    const {vtex: {account, authToken}, request: {headers: {cookie}}} = ctx
-    const {id} = await getClientData(account, authToken, cookie)
+  updateProfilePicture: async (root, { file, field }, ctx, info) => {
+    const { vtex: { account, authToken }, request: { headers: { cookie } } } = ctx
+    const { id } = await getClientData(account, authToken, cookie)
 
     // Should delete the field before uploading new profilePicture
-    await makeRequest(paths.profile(account).profile(id), authToken, {[field]: ''}, 'PATCH')
+    await makeRequest(paths.profile(account).profile(id), authToken, { [field]: '' }, 'PATCH')
 
-    const {filename} = await uploadAttachment({
+    const { filename } = await uploadAttachment({
       acronym: 'CL',
       documentId: id,
       field,
@@ -131,11 +131,11 @@ export const mutations = {
     }
   },
 
-  uploadProfilePicture: async (root, {file, field}, ctx, info) => {
-    const {vtex: {account, authToken}, request: {headers: {cookie}}} = ctx
-    const {id} = await getClientData(account, authToken, cookie)
+  uploadProfilePicture: async (root, { file, field }, ctx, info) => {
+    const { vtex: { account, authToken }, request: { headers: { cookie } } } = ctx
+    const { id } = await getClientData(account, authToken, cookie)
 
-    const {filename} = await uploadAttachment({
+    const { filename } = await uploadAttachment({
       acronym: 'CL',
       documentId: id,
       field,

--- a/node/resolvers/session/index.ts
+++ b/node/resolvers/session/index.ts
@@ -1,4 +1,5 @@
-import { serialize } from 'cookie'
+import { serialize, parse } from 'cookie'
+import { prop, map, path, filter, concat } from 'ramda'
 
 import paths from '../paths'
 import { sessionFields } from './sessionResolver'
@@ -11,67 +12,78 @@ const IMPERSONATED_EMAIL = 'vtex-impersonated-customer-email'
 const VTEXID_EXPIRES = 86400
 
 const makeRequest = async (_, args, config, url, data?, method?, enableCookies = true) => {
-    return await httpResolver({
-        url,
-        data,
-        method,
-        enableCookies,
-        headers: withAuthToken(headers.json),
-        merge: (bodyData, responseData, response) => {
-            return { ...response }
-        },
-    })(_, args, config)
+  return await httpResolver({
+    url,
+    data,
+    method,
+    enableCookies,
+    headers: withAuthToken(headers.json),
+    merge: (bodyData, responseData, response) => {
+      return { ...response }
+    },
+  })(_, args, config)
 }
 
 const impersonateData = email => {
-    return {
-        public: {
-            "vtex-impersonated-customer-email": {
-                value: email
-            }
-        }
+  return {
+    public: {
+      "vtex-impersonated-customer-email": {
+        value: email
+      }
     }
+  }
+}
+
+const formatRequestCookie = (key, cookies) => {
+  return `;${key}=${map(prop(key), filter(path([key]), cookies)).toString()}`
+}
+
+const errorHandler = res => {
+  if (res.status > 400) {
+    throw new ResolverError('ERROR', res.data)
+  }
 }
 
 export const mutations = {
-    initializeSession: async (_, args, config) => {
-        const initSession = await makeRequest(_, args, config, paths.session, '{}', 'POST')
-        if (initSession.status === '408') {
-            throw new ResolverError('ERROR', initSession.data)
-        }
-        const session = await makeRequest(_, args, config, paths.getSession)
-        if (session.status === '408') {
-            throw new ResolverError('ERROR', session.data)
-        }
-        return sessionFields(session.data)
-    },
+  initializeSession: async (_, args, config) => {
+    const initSession = await makeRequest(_, args, config, paths.session, '{}', 'POST')
+    errorHandler(initSession)
+    // Set session cookies to request GET session
+    const parsedCookies = map(parse, prop('set-cookie', initSession.headers))
+    const sessionCookies = `${formatRequestCookie('vtex_session', parsedCookies)}${formatRequestCookie('vtex_segment', parsedCookies)}`
+    config.headers.cookie = concat(config.headers.cookie, sessionCookies)
 
-    impersonate: async (_, args, config) => {
-        const impersonate = await makeRequest(_, args, config, paths.session, impersonateData(args.email), 'PATCH')
-        if (impersonate.status === '408') {
-            throw new ResolverError('ERROR', impersonate.data)
-        }
-        const session = await makeRequest(_, args, config, paths.getSession)
-        if (session.status === '408') {
-            throw new ResolverError('ERROR', session.data)
-        }
+    const session = await makeRequest(_, args, config, paths.getSession)
+    errorHandler(session)
 
-        config.response.set('Set-Cookie', serialize(IMPERSONATED_EMAIL, args.email, {
-            path: '/',
-            maxAge: VTEXID_EXPIRES
-        }))
-        return sessionFields(session.data)
-    },
+    config.response.set('Set-Cookie', prop('set-cookie', initSession.headers))
+    return sessionFields(session.data)
+  },
 
-    depersonify: async (_, args, config) => {
-        const depersonify = await makeRequest(_, args, config, paths.session, impersonateData(''), 'PATCH')
-        if (depersonify.status === '408') {
-            throw new ResolverError('ERROR', depersonify.data)
-        }
-        config.response.set('Set-Cookie', serialize(IMPERSONATED_EMAIL, '', {
-            path: '/',
-            maxAge: 0
-        }))
-        return true
-    },
+  impersonate: async (_, args, config) => {
+    const impersonate = await makeRequest(_, args, config, paths.session, impersonateData(args.email), 'PATCH')
+    errorHandler(impersonate)
+
+    const session = await makeRequest(_, args, config, paths.getSession)
+    errorHandler(session)
+
+    // const { profile } = merge({ expectedOrderFormSections: ['items'] }, sessionData)
+    // console.log(profile)
+    // await makeRequest(_, args, config, paths.orderFormProfile )
+    config.response.set('Set-Cookie', serialize(IMPERSONATED_EMAIL, args.email, {
+      path: '/',
+      maxAge: VTEXID_EXPIRES
+    }))
+    return sessionFields(session.data)
+  },
+
+  depersonify: async (_, args, config) => {
+    const depersonify = await makeRequest(_, args, config, paths.session, impersonateData(''), 'PATCH')
+    errorHandler(depersonify)
+    config.response.set('Set-Cookie', serialize(IMPERSONATED_EMAIL, '', {
+      path: '/',
+      maxAge: 0
+    }))
+    return true
+  }
 }

--- a/node/resolvers/session/index.ts
+++ b/node/resolvers/session/index.ts
@@ -1,0 +1,37 @@
+
+import http from 'axios'
+
+import { parse, serialize } from 'cookie'
+// import { withAuthToken } from '../headers'
+import paths from '../paths'
+
+const makeRequest = async (ctx, url, headers, data?, method = 'GET') => {
+    console.log('>>>>>>>> ', setHeaders(headers, ctx))
+    const configRequest = async (ctx, url, data) => ({
+        enableCookies: true,
+        headers: setHeaders(headers, ctx),
+        method,
+        url,
+        data,
+    })
+    return await http.request(await configRequest(ctx, url, data))
+}
+
+const setHeaders = (currentHeaders, ioContext) => {
+    let parsedCookie
+    if (currentHeaders.cookie) {
+        parsedCookie = parse(currentHeaders.cookie)
+    }
+    return {
+        ...currentHeaders,
+        ...parsedCookie.VtexIdclientAutCookie,
+        Authorization: `${ioContext.authToken}`,
+        'Proxy-Authorization': `${ioContext.authToken}`
+    }
+}
+export const mutations = {
+    initializeSession: async (_, args, { vtex: ioContext, request: { headers }, response }, ) => {
+        const data = await makeRequest(ioContext, paths.session(ioContext.account), headers, '{}', 'PATCH')
+        const session = await makeRequest(ioContext, paths.getSession(ioContext.account), headers)
+    },
+}

--- a/node/resolvers/session/sessionResolver.ts
+++ b/node/resolvers/session/sessionResolver.ts
@@ -17,7 +17,7 @@ const profileFields = profile => ({
 
 export const sessionFields = session => {
     const { namespaces } = session
-    return {
+    return namespaces ? {
         id: session.id,
         active: session.active,
         cartId: namespaces.checkout.cartId.value,
@@ -27,5 +27,5 @@ export const sessionFields = session => {
         profile: {
             ...profileFields(namespaces.profile)
         }
-    }
+    } : {}
 }

--- a/node/resolvers/session/sessionResolver.ts
+++ b/node/resolvers/session/sessionResolver.ts
@@ -1,0 +1,31 @@
+
+import { path, toLower } from 'ramda'
+
+const convertToBool = str => {
+    return (toLower(str) === 'true');
+}
+
+const profileFields = profile => ({
+    isAuthenticatedAsCustomer: convertToBool(path(['isAuthenticated', 'value'], profile)),
+    id: path(['id', 'value'], profile),
+    firstName: path(['firstName', 'value'], profile),
+    lastName: path(['lastName', 'value'], profile),
+    email: path(['email', 'value'], profile),
+    document: path(['document', 'value'], profile),
+    phone: path(['phone', 'value'], profile)
+})
+
+export const sessionFields = session => {
+    const { namespaces } = session
+    return {
+        id: session.id,
+        active: session.active,
+        cartId: namespaces.checkout.cartId.value,
+        impersonate: convertToBool(namespaces.impersonate.canImpersonate.value),
+        adminUserId: path(['adminUserId', 'value'], namespaces.authentication),
+        adminUserEmail: path(['adminUserEmail', 'value'], namespaces.authentication),
+        profile: {
+            ...profileFields(namespaces.profile)
+        }
+    }
+}

--- a/node/resolvers/session/sessionResolver.ts
+++ b/node/resolvers/session/sessionResolver.ts
@@ -1,9 +1,7 @@
 
 import { path, toLower } from 'ramda'
 
-const convertToBool = str => {
-    return (toLower(str) === 'true');
-}
+const convertToBool = str => toLower(str) === 'true'
 
 const profileFields = profile => ({
     isAuthenticatedAsCustomer: convertToBool(path(['isAuthenticated', 'value'], profile)),

--- a/node/resolvers/session/sessionResolver.ts
+++ b/node/resolvers/session/sessionResolver.ts
@@ -18,7 +18,6 @@ export const sessionFields = session => {
     return namespaces ? {
         id: session.id,
         active: session.active,
-        cartId: namespaces.checkout.cartId.value,
         impersonate: convertToBool(namespaces.impersonate.canImpersonate.value),
         adminUserId: path(['adminUserId', 'value'], namespaces.authentication),
         adminUserEmail: path(['adminUserEmail', 'value'], namespaces.authentication),


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `initializeSession`, `impersonate`, `depersonify` mutations to telemarketing app.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Change the fetch that `vtex.telemarketing` is doing to mutations.

#### How should this be manually tested?
Set your user at admin of `storecomponents` account with the profile access **Televendas** them execute the mutations in this order: `initializeSession`, `impersonate`, `depersonify`. 
[test here](https://session--storecomponents.myvtex.com/_v/vtex.store-graphql@2.20.2/graphiql/v1?operationName=despersonify&query=mutation%20initSession%20%7B%0A%20%20initializeSession%20%7B%0A%20%20%20%20cartId%0A%20%20%20%20impersonate%0A%20%20%20%20id%0A%20%20%20%20adminUserId%0A%20%20%20%20adminUserEmail%0A%20%20%20%20profile%20%7B%0A%20%20%20%20%20%20isAuthenticatedAsCustomer%0A%20%20%20%20%20%20lastName%0A%20%20%20%20%20%20firstName%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0Amutation%20impersonate%20%7B%0A%20%20impersonate(email%3A%22contato%40diasbruno.com%22%2C%20orderFormId%3A%20%22d0c6f4ed760343adbac7e87999ba5400%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20profile%7B%0A%20%20%20%20%20%20firstName%0A%20%20%20%20%20%20lastName%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A%0A%0Amutation%20despersonify%20%7B%0A%20%20depersonify(orderFormId%3A%20%22d0c6f4ed760343adbac7e87999ba5400%22)%20%0A%7D)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
