### PR TITLE
Filter facets in search response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Return filtered facets based on the query and rest on the search resolver.
 
 ## [2.20.0] - 2018-08-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.20.1] - 2018-08-22
 ### Changed
 - Return filtered facets based on the query and rest on the search resolver.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -196,19 +196,19 @@ export const queries = {
     return map(resolveCategoryFields, categories)
   },
 
-  search: async (_, data, colossusContext: ColossusContext, info) => {
+  search: async (_, data, { vtex: ioContext }: ColossusContext, info) => {
     const { map: mapParams, query, rest } = data
     const facetsMap = mapParams.split(',').slice(0, query.split('/').length).join(',')
     const queryWithRest = query + (rest && '/' + rest.replace(/,/g, '/'))
     const facetsValue = query + '?map=' + facetsMap
     const facetsValueWithRest = queryWithRest + '?map=' + mapParams
 
-    const productsPromise = queries.products(_, { ...data, query: queryWithRest }, colossusContext, info)
-    const facetsPromise = queries.facets(_, { facets: facetsValue }, colossusContext)
+    const productsPromise = queries.products(_, { ...data, query: queryWithRest }, { vtex: ioContext }, info)
+    const facetsPromise = queries.facets(_, { facets: facetsValue }, { vtex: ioContext })
     const categoriesPromise = queries.categories(_, {
       treeLevel: query.split('/').length
-    }, colossusContext)
-    const facetsWithRestPromise = queries.facets(_, { facets: facetsValueWithRest }, colossusContext)
+    }, { vtex: ioContext })
+    const facetsWithRestPromise = queries.facets(_, { facets: facetsValueWithRest }, { vtex: ioContext })
 
     const [products, facets, facetsWithRest, categories] = await Promise.all([
       productsPromise, facetsPromise, facetsWithRestPromise, categoriesPromise


### PR DESCRIPTION
#### What is the purpose of this pull request?
Changes the response of the search query to filter the facets based on the query made.

#### What problem is this solving?
There were some inconsistencies in the facets returned in the query, because the values returned didn't include the parameters passed on the `rest` argument.

#### How should this be manually tested?
[Access this workspace](https://specificationfilter--storecomponents.myvtex.com/eletronicos/smartphones?map=c%2Cc).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
