### PR TITLE
`Benefits Resolver` using only public endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Benefits resolver is now using only public endpoints.
 
 ## [2.20.2] - 2018-08-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.21.1] - 2018-08-23
 ### Fixed
 - Benefits resolver is now using only public endpoints.
 

--- a/graphql/types/Benefits.graphql
+++ b/graphql/types/Benefits.graphql
@@ -13,7 +13,10 @@ type Benefit {
 }
 
 type BenefitItem {
+  """ Product itself """
   benefitProduct: Product
+  """ Discount applied to the benefit product """
   discount: Float
+  """ Minimum quantity of the benefit product that is required to validate the benefit """
   minQuantity: Int
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -19,10 +19,9 @@ const DEFAULT_QUANTITY = '1'
  */
 const resolveProducts = async (skuIds, ioContext) => {
   const requestUrl = paths.productBySku(ioContext.account, { skuIds })
-  const requestHeaders = {
+  const { data: products = [] } = await axios.get(requestUrl, {
     headers: withAuthToken()(ioContext),
-  }
-  const { data: products = [] } = await axios.get(requestUrl, requestHeaders)
+  })
   return await Promise.all(
     products.map(product => resolveLocalProductFields(product))
   )
@@ -60,13 +59,11 @@ const resolveBenefitsData = async (benefitsData, { vtex: ioContext }) => {
               const discount = effectsParameters[index].value
               const products = await resolveProducts(skuIds, ioContext)
 
-              return await Promise.all(
-                products.map(async product => ({
-                  discount,
-                  benefitProduct: product,
-                  minQuantity: minimumQuantity,
-                }))
-              )
+              return products.map(product => ({
+                discount,
+                benefitProduct: product,
+                minQuantity: minimumQuantity,
+              }))
             })
           )
 

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -1,110 +1,111 @@
 import axios from 'axios'
-import paths from '../paths'
 import { flatten } from 'ramda'
-import { withAuthToken } from '../headers'
+
 import { resolveLocalProductFields } from '../catalog/fieldsResolver'
+import { queries as checkoutQueries } from '../checkout'
+import { withAuthToken } from '../headers'
+import paths from '../paths'
 
-/**
- * Default values for Shipping Items
- */
-const DEFAULT_QUANTITY = '1'
+const SKU_SEPARATOR = ','
+const CATALOG = 'Catalog'
 const DEFAULT_SELLER = '1'
+const DEFAULT_QUANTITY = '1'
 
 /**
- * Retrieve a list of SKU Items.
- * @param skuIds List of the skuIds of the skus that must be retrieved.
- * @param ioContext VTEX ioContext which contains the informations of the application.
+ * Receives an Array of SKU Ids and returns an Array of the Products that each SKU Belongs.
+ *
+ * @param skuIds Array of SKU Ids which will be used to retrieve all the products that each SKU belongs.
+ * @param ioContext Helper object which holds the account and the authentication headers.
  */
-const getSKUItems = async (skuIds, ioContext) => {
-  return await Promise.all(skuIds.map(async skuId => {
-    const { data } = await axios.get(paths.skuById(ioContext.account, { skuId }), { headers: { Authorization: ioContext.authToken }})
-    return data
-  }))
+const resolveProducts = async (skuIds, ioContext) => {
+  const requestUrl = paths.productBySku(ioContext.account, { skuIds })
+  const requestHeaders = {
+    headers: withAuthToken()(ioContext),
+  }
+  const { data: products = [] } = await axios.get(requestUrl, requestHeaders)
+  return await Promise.all(
+    products.map(product => resolveLocalProductFields(product))
+  )
 }
 
 /**
- * Retrieve a product without benefits.
- * @param slug Slug of the product that must be retrieved.
- * @param ioContext VTEX ioContext which contains the informations of the application.
+ * Receives an array of Rates and Benefits data and returns an Array of Benefits.
+ *
+ * @param benefitsData Array of Rates and Benefits data.
+ * @param ioContext Helper object which holds the account and the authentication headers.
  */
-const getProduct = async (slug, ioContext) => {
-  const { data: [ product ] } = await axios.get(paths.product(ioContext.account, { slug }), { headers: withAuthToken()(ioContext) })
-  return resolveLocalProductFields(product)
-}
+const resolveBenefitsData = async (benefitsData, { vtex: ioContext }) => {
+  let resolvedBenefits = []
 
-/**
- * Resolve the SKU Items of a list of benefits associated with a product.
- * @param benefits Benefits which contains the SKU Ids.
- * @param ioContext VTEX ioContext which contains the informations of the application.
- */
-const getBenefitsWithSKUItems = async (benefits, ioContext) => {
-  return Promise.all(benefits.map(async benefit => {    
-    const { parameters: conParams, minimumQuantity } = benefit.conditions
-    const effParams = benefit.effects.parameters
-  
-    const skuList = await Promise.all(conParams.map(async (conParam, index) => {
-      const skuIds = conParam.value.split(',')
-      const skuList = await getSKUItems(skuIds, ioContext)
-      const discount = effParams[index].value
-      const minQuantity = index ? 1 : minimumQuantity
+  if (benefitsData.ratesAndBenefitsData) {
+    const {
+      ratesAndBenefitsData: { teaser: benefits = [] },
+    } = benefitsData
 
-      const benefitItems = await Promise.all(skuList.map(async sku => {
-        const slug = sku.DetailUrl.split('/')[1]
-        const benefitProduct = await getProduct(slug, ioContext)
+    resolvedBenefits = await Promise.all(
+      benefits.map(async benefit => {
+        const { id, featured, name, teaserType, conditions, effects } = benefit
 
-        return {
-          benefitProduct,
-          discount,
-          minQuantity
+        if (teaserType === CATALOG) {
+          const {
+            parameters: conditionsParameters,
+            minimumQuantity = parseInt(DEFAULT_QUANTITY),
+          } = conditions
+
+          const { parameters: effectsParameters } = effects
+
+          const benefitProducts = await Promise.all(
+            conditionsParameters.map(async (conditionsParameter, index) => {
+              const skuIds = conditionsParameter.value.split(SKU_SEPARATOR)
+              const discount = effectsParameters[index].value
+              const products = await resolveProducts(skuIds, ioContext)
+
+              return await Promise.all(
+                products.map(async product => ({
+                  discount,
+                  benefitProduct: product,
+                  minQuantity: minimumQuantity,
+                }))
+              )
+            })
+          )
+
+          const products = flatten(benefitProducts)
+
+          return {
+            id,
+            featured,
+            name,
+            teaserType,
+            items: products,
+          }
         }
-      }))
-      return benefitItems
-    }))
-    
-    const { featured, id, name, teaserType } = benefit
-    const items = flatten(skuList)
-    return {
-      featured,
-      id,
-      name,
-      items,
-      teaserType
-    }
-  }))
+      })
+    )
+  }
+
+  return resolvedBenefits
 }
 
 export const queries = {
   /**
    * There are two ways to make the request data
-   * First of them is passing the graphql args with the items property which is an array of Shipping Items. 
+   * First of them is passing the graphql args with the items property which is an array of Shipping Items.
    * Second is passing just the id of the product itself as a graphql argument.
    */
-  benefits: async (_, args, { vtex: ioContext }) => {
-    let requestBody
-    if (args.items) {
-      requestBody = { items: args.items }
-    } else {
-      requestBody = {
-        items: [
-          { 
-            id: args.id,
-            quantity: DEFAULT_QUANTITY,
-            seller: DEFAULT_SELLER
-          }
-        ]
-      }
+  benefits: async (_, args, config) => {
+    const requestBody = {
+      items: args.items
+        ? args.items
+        : [
+            {
+              id: args.id,
+              quantity: DEFAULT_QUANTITY,
+              seller: DEFAULT_SELLER,
+            },
+          ],
     }
-
-    const url = paths.shipping(ioContext.account)
-    const { data } = await axios.post(url, requestBody, 
-      { headers: { Authorization: ioContext.authToken } 
-    })
-
-    if (data && data.ratesAndBenefitsData && data.ratesAndBenefitsData.teaser) {
-      const benefits = data.ratesAndBenefitsData.teaser
-      return getBenefitsWithSKUItems(benefits, ioContext)
-    }
-
-    return []
+    const benefitsData = await checkoutQueries.shipping(_, requestBody, config)
+    return await resolveBenefitsData(benefitsData, config)
   },
 }

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -8,13 +8,7 @@ import ResolverError from '../../errors/resolverError'
 import { queries as benefitsQueries } from '../benefits'
 import { withAuthToken } from '../headers'
 import paths from '../paths'
-import {
-  resolveBrandFields,
-  resolveCategoryFields,
-  resolveFacetFields,
-  resolveProductFields,
-} from './fieldsResolver'
-import ResolverError from '../../errors/resolverError'
+import { resolveBrandFields, resolveCategoryFields, resolveFacetFields, resolveProductFields } from './fieldsResolver'
 
 /**
  * It will extract the slug from the HREF in the item
@@ -54,7 +48,7 @@ export const rootResolvers = {
         : Promise.all(
             root.kitItems.map(async kitItem => {
               const url = paths.productBySku(ioContext.account, {
-                id: kitItem.itemId,
+                skuIds: [ kitItem.itemId ],
               })
               const { data: products } = await axios.get(url, {
                 headers: withAuthToken()(ioContext),

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -11,7 +11,8 @@ const paths = {
   productByEan: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=alternateIds_Ean=${id}`,
   productById: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=productId:${id}`,
   productByReference: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=alternateIds_RefId=${id}`,
-  productBySku: (account, { id }) => `${paths.catalog(account)}/pub/products/search?fq=skuId:${id}`,
+  productBySku: (account, { skuIds }) => `${paths.catalog(account)}/pub/products/search?${skuIds.map(skuId => `fq=skuId:${skuId}`).join('&')}`,
+
   products: (account, {
     query = '',
     category = '',
@@ -47,8 +48,6 @@ const paths = {
   updateItems: (account, data) => `${paths.addItem(account, data)}/update`,
 
   shipping: account => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orderForms/simulation`,
-
-  skuById: (account, { skuId }) => `${paths.catalog(account)}/pvt/sku/stockkeepingunitbyid/${skuId}`,
 
   orders: account => `http://${account}.vtexcommercestable.com.br/api/checkout/pub/orders`,
   cancelOrder: (account, { orderFormId }) => `${paths.orders(account)}/${orderFormId}/user-cancel-request`,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Ensure that the `Benefits Resolver` will only use public endpoints to retrieve the data that is needed.

#### What problem is this solving?
The Benefits Resolver was using private endpoints to retrieve the data thas is needed. In the case that the user is not logged the data provided by the resolver will not be retrieved.

#### How should this be manually tested?

#### Screenshots or example usage

<a href="https://public-benefits--storecomponents.myvtex.com/_v/vtex.store-graphql@2.20.2/graphiql/v1" target="_blank">Workspace</a>

```gql
query Benefit($items: [ShippingItem]) {
  benefits(items: $items) {
    id
    featured
    name
    items {
      benefitProduct {
        productId
        productName
        items {
          itemId
          name
        }
      }
      discount
      minQuantity
    }
    teaserType
  }
}
```

```json
{
  "items": [
    {
      "id": "1",
      "quantity": "1",
      "seller": "1"
    }
  ]
}
```

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
