### PR TITLE
Update facets fields to include slug and id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.22.2] - 2018-08-23
 ### Changed
 - Added optional fields `Id` and `Slug` to the `Facets` type.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added optional fields `Id` and `Slug` to the `Facets` type.
 
 ## [2.22.1] - 2018-08-23
 

--- a/graphql/types/Facets.graphql
+++ b/graphql/types/Facets.graphql
@@ -1,19 +1,21 @@
 type Facets {
-	Departments: [Facet]
-	Brands: [Facet]
-	SpecificationFilters: [Filter]
-	CategoriesTrees: [Facet]
-	PriceRanges: [Facet]
+  Departments: [Facet]
+  Brands: [Facet]
+  SpecificationFilters: [Filter]
+  CategoriesTrees: [Facet]
+  PriceRanges: [Facet]
 }
 
 type Facet {
-	Quantity: Int
-	Name: String
-	Link: String
-	Children: [Facet]
+  Id: Int
+  Name: String!
+  Quantity: Int!
+  Link: String!
+  Slug: String
+  Children: [Facet]
 }
 
 type Filter {
-	name: String
-	facets: [Facet]
+  name: String
+  facets: [Facet]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Include the new optional fields `Slug` and `Id` to the facets type.

#### What problem is this solving?
On some fields, you needed to rely on parsing the `Link` string to retrieve the appropriate slug. Now, you can get the value directly from the `Slug` (in the case of the price ranges) or the `Id` (in the case of the categories).

#### Types of changes
- [x] New feature (a non-breaking change which adds functionality)