### PR TITLE
Add session query and remove initializeSession mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add session query and remove initializeSession mutation.
 
 ## [2.25.4] - 2018-09-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.26.0] - 2018-09-05
 ### Added
 - Add session query and remove initializeSession mutation.
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -257,15 +257,10 @@ type Mutation {
   impersonate(
     """ The email which will be used to impersonate a user """
     email: String!,
-    """ orderFormId that will be used to update clientProfileData in orderForm """
-    orderFormId: String!
   ): Session
 
   """ Depersonify a customer """
-  depersonify(
-    """ orderFormId that will be used to remove clientProfileData in orderForm """
-    orderFormId: String!
-  ): Boolean
+  depersonify: Boolean
 
   """ Document """
   createDocument(acronym: String!, document: DocumentInput): DocumentResponse

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -153,6 +153,9 @@ type Query {
 
   """ Get logistics information about the store """
   logistics: LogisticsData
+  
+  """ Get profile information to session users """
+  getSession: Session @cacheControl(scope: PRIVATE)
 }
 
 type Mutation {
@@ -249,9 +252,6 @@ type Mutation {
 
   """ Invalidate VtexIdclientAutCookie """
   logout: Boolean
-
-  """ Initialize Session to users with telemarketing profile access """
-  initializeSession: Session
 
   """ Impersonate a customer """
   impersonate(

--- a/graphql/types/Session.graphql
+++ b/graphql/types/Session.graphql
@@ -16,8 +16,6 @@ type Session {
 
 """ Basic information that is displayed when is a impersonated session """
 type ImpersonatedUser {
-  """ Id of impersonated customer """
-  storeUserId: String,
-  """ Email of impersonated customer """
-  storeUserEmail: String
+  """ Profile information of impersonated user """
+  profile: SessionProfile
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/graphql/index.ts
+++ b/node/graphql/index.ts
@@ -5,7 +5,7 @@ import { mutations as checkoutMutations, queries as checkoutQueries } from '../r
 import { mutations as profileMutations, queries as profileQueries, rootResolvers as profileRootResolvers } from '../resolvers/profile'
 import { mutations as authMutations, queries as authQueries } from '../resolvers/auth'
 import { mutations as documentMutations, queries as documentQueries } from '../resolvers/document'
-import { mutations as sessionMutations } from '../resolvers/session'
+import { mutations as sessionMutations, queries as sessionQueries } from '../resolvers/session'
 import { queries as logisticsQueries } from '../resolvers/logistics'
 
 // tslint:disable-next-line:no-var-requires
@@ -22,7 +22,8 @@ export const resolvers = {
     ...checkoutQueries,
     ...documentQueries,
     ...authQueries,
-    ...logisticsQueries
+    ...logisticsQueries,
+    ...sessionQueries
   },
   Mutation: {
     ...profileMutations,

--- a/node/resolvers/session/index.ts
+++ b/node/resolvers/session/index.ts
@@ -60,16 +60,12 @@ export const mutations = {
   impersonate: async (_, args, config) => {
     await makeRequest(_, args, config, paths.session, impersonateData(args.email), 'PATCH')
 
-    const { data } = await makeRequest(_, args, config, paths.getSession)
-
-    const { profile } = merge({ expectedOrderFormSections: ['items'] }, sessionFields(data))
-    await makeRequest(_, args, config, paths.orderFormProfile, profile, 'POST')
-
     config.response.set('Set-Cookie', serialize(IMPERSONATED_EMAIL, args.email, {
       path: '/',
       maxAge: VTEXID_EXPIRES,
       encode: identity
     }))
+    const { data } = await makeRequest(_, args, config, paths.getSession)
     return sessionFields(data)
   },
 
@@ -79,7 +75,6 @@ export const mutations = {
    */
   depersonify: async (_, args, config) => {
     await makeRequest(_, args, config, paths.session, impersonateData(''), 'PATCH')
-    await makeRequest(_, args, config, paths.changeToAnonymousUser)
 
     config.response.set('Set-Cookie', serialize(IMPERSONATED_EMAIL, '', {
       path: '/',

--- a/node/resolvers/session/index.ts
+++ b/node/resolvers/session/index.ts
@@ -39,7 +39,7 @@ const impersonateData = email => {
   }
 }
 
-// Disclaimer: These queries and mutations assume that vtex_session is passing in cookies.
+// Disclaimer: These queries and mutations assume that vtex_session was passed in cookies.
 export const queries = {
   /**
    * Get user session

--- a/node/resolvers/session/sessionResolver.ts
+++ b/node/resolvers/session/sessionResolver.ts
@@ -4,32 +4,34 @@ import { path, toLower } from 'ramda'
 const convertToBool = str => toLower(str) === 'true'
 
 const profileFields = profile => ({
-    isAuthenticatedAsCustomer: convertToBool(path(['isAuthenticated', 'value'], profile)),
-    id: path(['id', 'value'], profile),
-    firstName: path(['firstName', 'value'], profile),
-    lastName: path(['lastName', 'value'], profile),
-    email: path(['email', 'value'], profile),
-    document: path(['document', 'value'], profile),
-    phone: path(['phone', 'value'], profile)
+  isAuthenticatedAsCustomer: convertToBool(path(['isAuthenticated', 'value'], profile)),
+  id: path(['id', 'value'], profile),
+  firstName: path(['firstName', 'value'], profile),
+  lastName: path(['lastName', 'value'], profile),
+  email: path(['email', 'value'], profile),
+  document: path(['document', 'value'], profile),
+  phone: path(['phone', 'value'], profile)
 })
 
-const authenticationFields = impersonate => ({
-    storeUserId: path(['storeUserId', 'value'], impersonate),
-    storeUserEmail: path(['storeUserEmail', 'value'], impersonate),
-})
+const setProfileData = (profile, user) => (
+  path(['storeUserId', 'value'], user) &&
+  {
+    profile: {
+      ...profileFields(profile)
+    }
+  }
+)
 
 export const sessionFields = session => {
-    const { namespaces } = session
-    return namespaces ? {
-        id: session.id,
-        impersonable: convertToBool(namespaces.impersonate.canImpersonate.value),
-        adminUserId: path(['adminUserId', 'value'], namespaces.authentication),
-        adminUserEmail: path(['adminUserEmail', 'value'], namespaces.authentication),
-        impersonate: {
-            ...authenticationFields(namespaces.impersonate)
-        },
-        profile: {
-            ...profileFields(namespaces.profile)
-        }
-    } : {}
+  const { namespaces } = session
+  return namespaces ? {
+    id: session.id,
+    impersonable: convertToBool(namespaces.impersonate.canImpersonate.value),
+    adminUserId: path(['adminUserId', 'value'], namespaces.authentication),
+    adminUserEmail: path(['adminUserEmail', 'value'], namespaces.authentication),
+    impersonate: {
+      ...setProfileData(namespaces.profile, namespaces.impersonate)
+    },
+    ...setProfileData(namespaces.profile, namespaces.authentication)
+  } : {}
 }


### PR DESCRIPTION
Sign in as a user in store (use login app). 
And [access here](https://login--storecomponents.myvtex.com/_v/vtex.store-graphql@2.23.2/graphiql/v1?query=query%20session%20%7B%0A%20%20getSession%20%7B%0A%20%20%20%20profile%20%7B%0A%20%20%20%20%20%20firstName%0A%20%20%20%20%20%20lastName%0A%20%20%20%20%20%20email%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0Amutation%20impersonate%20%7B%0A%20%20impersonate%20(email%3A%22contato%40diasbruno.com%22%2C%20orderFormId%3A%22d0c6f4ed760343adbac7e87999ba5400%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20adminUserId%0A%20%20%20%20impersonable%0A%20%20%20%20impersonate%20%7B%0A%20%20%20%20%20%20storeUserId%0A%20%20%20%20%20%20storeUserEmail%0A%20%20%20%20%7D%0A%20%20%20%20profile%20%7B%0A%20%20%20%20%20%20firstName%0A%20%20%20%20%20%20lastName%0A%20%20%20%20%20%20email%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=session)
#### Screenshots or example usage
Execute this query
```
query session {
  getSession {
    profile {
      firstName
      lastName
      email
    }
  }
}
```
#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
