### PR TITLE
Feature/profile picture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `profilePicture` query
+
+### Changed
+- Arguments and return type of `uploadProfilePicture` mutation and its `update` sibling
 
 ## [2.24.0] - 2018-08-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.25.0] - 2018-08-29
 ### Added
 - `profilePicture` query
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -171,16 +171,16 @@ type Mutation {
   updateProfilePicture(
     """ File being uploaded """
     file: Upload!,
-    """ Attachment's field name (ex. ProfilePicture) """
-    field: String!
-  ): ProfileCustomField
+    """ Attachment's field name """
+    field: String! = "profilePicture"
+  ): Profile
   """ Uploads the Profile Picture by appending to the existing ones """
   uploadProfilePicture(
     """ File being uploaded """
     file: Upload!,
-    """ Attachment's field name (ex. ProfilePicture) """
-    field: String!
-  ): ProfileCustomField
+    """ Attachment's field name """
+    field: String! = "profilePicture"
+  ): Profile
 
   """ Order Form """
   updateOrderFormProfile(orderFormId: String, fields: OrderFormProfileInput): OrderForm

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -171,15 +171,15 @@ type Mutation {
   updateProfilePicture(
     """ File being uploaded """
     file: Upload!,
-    """ Attachment's field name """
-    field: String! = "profilePicture"
+    """ Attachment's field name (default: profilePicture) """
+    field: String
   ): Profile
   """ Uploads the Profile Picture by appending to the existing ones """
   uploadProfilePicture(
     """ File being uploaded """
     file: Upload!,
-    """ Attachment's field name """
-    field: String! = "profilePicture"
+    """ Attachment's field name (default: profilePicture) """
+    field: String
   ): Profile
 
   """ Order Form """

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -7,6 +7,8 @@ type Profile {
   firstName: String,
   """ User last name """
   lastName: String,
+  """ User's profile picture (only fetched if saved as 'profilePicture')"""
+  profilePicture: String,
   """ User email """
   email: String,
   """ Document identification. E.g. CPF, SSN, Driver License """

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -3,36 +3,51 @@ type Profile {
   cacheId: ID
   """ profile ID """
   id: ID,
-  """ User first name """
+  """ User's first name """
   firstName: String,
-  """ User last name """
+  """ User's last name """
   lastName: String,
   """ User's profile picture (only fetched if saved as 'profilePicture')"""
   profilePicture: String,
-  """ User email """
+  """ User's email """
   email: String,
   """ Document identification. E.g. CPF, SSN, Driver License """
   document: String,
-  """ User phone number """
+  """ User's phone number """
   phone: String
-  """ user ID """
+  """ User's ID """
   userId: String
+  """ User's birth date """
   birthDate: String
+  """ User's gender (plain unvalidated string) """
   gender: String
+  """ User' personal phone """
   homePhone: String
+  """ User's business phone """
   businessPhone: String
+  """ Collection of user's address """
   address: [Address]
+  """ User's company trade name """
   tradeName: String
+  """ User's company corporate name """
   corporateName: String
+  """ User's company corporate document (e.g. CNPJ)"""
   corporateDocument: String
+  """ User's company state registration """
   stateRegistration: String
+  """ Collection of user's payment data """
   payments: [PaymentProfile]
+  """ Other fields to query """
   customFields: [ProfileCustomField]
 }
 
+""" Custom fields to add to query """
 type ProfileCustomField {
+  """ Id used for caching """
   cacheId: ID
+  """ Name of the custom field """
   key: String
+  """ Value of the custom field """
   value: String
 }
 """ Profile information that is receive in session """
@@ -75,23 +90,31 @@ input ProfileCustomFieldInput {
 }
 
 input ProfileInput {
-  """ User first name """
+  """ User's first name """
   firstName: String,
-  """ User last name """
+  """ User's last name """
   lastName: String,
-  """ User email """
+  """ User's email """
   email: String,
   """ Document identification. E.g. CPF, SSN, Driver License """
   document: String,
-  """ User phone number """
+  """ User's phone number """
   phone: String
+  """ User's birth date """
   birthDate: String
+  """ User's gender (plain unvalidated string) """
   gender: String
+  """ User' personal phone """
   homePhone: String
+  """ User's business phone """
   businessPhone: String
+  """ User's company trade name """
   tradeName: String
+  """ User's company corporate name """
   corporateName: String
+  """ User's company corporate document (e.g. CNPJ)"""
   corporateDocument: String
+  """ User's company state registration """
   stateRegistration: String
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -93,7 +93,7 @@ const paths = {
     address: (id) => `http://api.vtex.com/${account}/dataentities/AD/documents/${id}`,
     attachments: (id, field) => `http://api.vtex.com/${account}/dataentities/CL/documents/${id}/${field}/attachments`,
     filterAddress: (id) => `http://api.vtex.com/${account}/dataentities/AD/search?userId=${id}&_fields=userId,id,receiverName,complement,neighborhood,country,state,number,street,postalCode,city,reference,addressName,addressType,geoCoordinate`,
-    filterUser: (email, customFields?) => join(',', [`http://api.vtex.com/${account}/dataentities/CL/search?email=${email}&_fields=userId,id,firstName,lastName,birthDate,gender,homePhone,businessPhone,document,email,tradeName,corporateName,stateRegistration,corporateDocument`, customFields]),
+    filterUser: (email, customFields?) => join(',', [`http://api.vtex.com/${account}/dataentities/CL/search?email=${email}&_fields=userId,id,firstName,lastName,birthDate,gender,homePhone,businessPhone,document,email,tradeName,corporateName,stateRegistration,corporateDocument,profilePicture`, customFields]),
     profile: (id) => `http://api.vtex.com/${account}/dataentities/CL/documents/${id}`,
     payments: (id) => `http://${account}.vtexcommercestable.com.br/api/profile-system/pvt/profiles/${id}/vcs-checkout`
   }),

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -111,41 +111,28 @@ export const mutations = {
       }).catch(returnOldOnNotChanged(oldData))
   },
 
-  updateProfilePicture: async (root, { file, field }, ctx, info) => {
+  updateProfilePicture: async (root, args, ctx, info) => {
+    const file = args.file
+    const field = args.field || 'profilePicture'
     const { vtex: { account, authToken }, request: { headers: { cookie } } } = ctx
     const { id } = await getClientData(account, authToken, cookie)
 
     // Should delete the field before uploading new profilePicture
     await makeRequest(paths.profile(account).profile(id), authToken, { [field]: '' }, 'PATCH')
+    await uploadAttachment({ acronym: 'CL', documentId: id, field, file }, ctx.vtex)
 
-    const { filename } = await uploadAttachment({
-      acronym: 'CL',
-      documentId: id,
-      field,
-      file
-    }, ctx.vtex)
-
-    return {
-      key: field,
-      value: filename
-    }
+    return await profileResolver(root, args, ctx)
   },
 
-  uploadProfilePicture: async (root, { file, field }, ctx, info) => {
+  uploadProfilePicture: async (root, args, ctx, info) => {
+    const file = args.file
+    const field = args.field || 'profilePicture'
     const { vtex: { account, authToken }, request: { headers: { cookie } } } = ctx
     const { id } = await getClientData(account, authToken, cookie)
 
-    const { filename } = await uploadAttachment({
-      acronym: 'CL',
-      documentId: id,
-      field,
-      file
-    }, ctx.vtex)
+    await uploadAttachment({ acronym: 'CL', documentId: id, field, file }, ctx.vtex)
 
-    return {
-      key: field,
-      value: filename
-    }
+    return await profileResolver(root, args, ctx)
   }
 }
 

--- a/node/resolvers/profile/profileResolver.ts
+++ b/node/resolvers/profile/profileResolver.ts
@@ -41,6 +41,9 @@ const profile = (ctx, {customFields}) => async (data) => {
   if (profileData && profileData.id) {
     profileData.customFields = pickCustomFieldsFromData(customFields, profileData)
 
+    profileData.profilePicture = profileData.profilePicture
+      && `//api.vtex.com/${ctx.account}/dataentities/CL/documents/${profileData.id}/profilePicture/attachments/${profileData.profilePicture}`
+
     const addressURL = paths.profile(ctx.account).filterAddress(profileData.id)
     const address = profileData && await http.get(addressURL, config).then(prop('data'))
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This pull request enhances the profile-picture-related functionality. It adds a default field name (`profilePicture`) to the upload and update mutations, and changes their return type to be a complete `Profile` object, so the consuming application can benefit from `react-apollo`'s caching features.

It also adds a new `profilePicture` field to the `Profile` object. This field returns the complete URL to that picture instead of just the filename.

For now, stores must create the `profilePicture` field in their Masterdata panel prior to using these mutations or they will throw errors (the query will simply return null in those cases) but we will add it to the CL general schema soon.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
