### PR TITLE
Benefit Product carrying only one SKU item.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Benefits Resolver creating the benefit product objects with only one item, the item specified by the benefit itself.
 
 ## [2.23.3] - 2018-08-28
 ### Removed

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -59,11 +59,20 @@ const resolveBenefitsData = async (benefitsData, { vtex: ioContext }) => {
               const discount = effectsParameters[index].value
               const products = await resolveProducts(skuIds, ioContext)
 
-              return products.map(product => ({
-                discount,
-                benefitProduct: product,
-                minQuantity: minimumQuantity,
-              }))
+              return skuIds.map(skuId => {
+                for (let product of products) {
+                  for (let item of product.items) {
+                    if (item.itemId === skuId) {
+                      const benefitProduct = { ...product, items: [item] }
+                      return {
+                        discount,
+                        benefitProduct,
+                        minQuantity: minimumQuantity,
+                      }
+                    }
+                  }
+                }
+              })
             })
           )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
When a benefit is created it is created based on the SKU's which composes the benefits itself. Every SKU belongs to exactly one Product, so, for each SKU of the benefit a Benefit Product is created with all the informations of the Product that the SKU belongs to, the only difference is that the Benefit Product will carry only one SKU Item (even if the Product has more than one) being this the exactly SKU specified above.

#### What problem is this solving?
The data provided by the Benefit Resolver has no information about what SKU must be in the benefit.

#### How should this be manually tested?

#### Screenshots or example usage
Workspace: https://productkit--storecomponents.myvtex.com/_v/vtex.store-graphql@2.23.3/graphiql/v1

- Product Query
```gql
query Product($slug: String) {
  product(slug: $slug) {
    benefits {
      items {
        benefitProduct {
          productName
          items {
            name
          }
        }
        discount
        minQuantity
      }
    }
  }
}
```
```json
{ 
"slug": "porsche-911" 
}
```
- Benefit Query
```gql
query Benefits($items: [ShippingItem]) {
  benefits(items: $items) {
    items {
      benefitProduct {
        productName
        items {
          name
        }
      }
      discount
      minQuantity
    }
  }
}
```
```json
{
"items": [
    {
      "id": "2",
      "quantity": "1",
      "seller": "1"
    }
  ]
}
```

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
