### PR TITLE
SKU Items of the Benefit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- List of SKU Item IDs in the Benefit Resolver to indicate what SKU Items are taking part in the benefit.
 
 ## [2.25.0] - 2018-08-29
 ### Added

--- a/graphql/types/Benefits.graphql
+++ b/graphql/types/Benefits.graphql
@@ -15,6 +15,8 @@ type Benefit {
 type BenefitItem {
   """ Product itself """
   benefitProduct: Product
+  """ IDs of the SKU Items that are taking part in the benefit """
+  benefitSKUIds: [String]
   """ Discount applied to the benefit product """
   discount: Float
   """ Minimum quantity of the benefit product that is required to validate the benefit """

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { flatten } from 'ramda'
+import { flatten, indexOf } from 'ramda'
 
 import { resolveLocalProductFields } from '../catalog/fieldsResolver'
 import { queries as checkoutQueries } from '../checkout'
@@ -59,11 +59,22 @@ const resolveBenefitsData = async (benefitsData, { vtex: ioContext }) => {
               const discount = effectsParameters[index].value
               const products = await resolveProducts(skuIds, ioContext)
 
-              return products.map(product => ({
-                discount,
-                benefitProduct: product,
-                minQuantity: minimumQuantity,
-              }))
+              return products.map(product => {
+                let benefitSKUIds = []
+                
+                product.items.map(item => {
+                  if (indexOf(item.itemId, skuIds) > -1) {
+                    benefitSKUIds.push(item.itemId)
+                  }
+                })
+
+                return {
+                  discount,
+                  benefitSKUIds,
+                  benefitProduct: product,
+                  minQuantity: minimumQuantity,
+                }
+              })
             })
           )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
When a benefit is created it is created based on the SKU's which composes the benefits itself.
The data provided by the Benefit Resolver now contains a list of the SKU IDs that composes the Benefit. 

#### What problem is this solving?
The data provided by the Benefit Resolver has no information about what SKU must be in the benefit.

#### How should this be manually tested?

#### Screenshots or example usage
Workspace: https://gugabribeiro--storecomponents.myvtex.com/_v/vtex.store-graphql@2.25.0/graphiql/v1

```gql
query Product($slug: String) {
  product(slug: $slug) {
    benefits {
      items {
        benefitProduct {
          productName
          productId
          items {
            name
            itemId
          }
        }
        benefitSKUIds
      }
    }
  }
}
```
```json
{
  "slug": "porsche-911"
}
```
#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
