### PR TITLE
Fix /start path of VTEX ID API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `/start` path of VTEX ID API. 
+### Changed
+- Refact the auth mutations to make `POST` instead `GET` requests in API.
 
 ## [2.25.3] - 2018-08-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.25.4] - 2018-09-04
 ### Fixed
 - Fix `/start` path of VTEX ID API. 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.25.3",
+  "version": "2.25.4",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -5,18 +5,18 @@ import { withAuthToken, headers } from '../headers'
 import ResolverError from '../../errors/resolverError'
 
 
-const makeRequest = async (ctx, url, vtexIdVersion='store-graphql') => {
+const makeRequest = async (ctx, url, method='POST', vtexIdVersion='store-graphql') => {
   const configRequest = async (ctx, url, vtexIdVersion) => ({
     headers: withAuthToken({...headers.profile, 'vtex-ui-id-version': vtexIdVersion})(ctx),
     enableCookies: true,
-    method: 'GET',
+    method,
     url,
   })
   return await http.request(await configRequest(ctx, url, vtexIdVersion))
 }
 
 const getSessionToken = async (ioContext, redirectUrl?) => {
-  const { data, status } = await makeRequest(ioContext, paths.sessionToken(ioContext.account, ioContext.account, redirectUrl))
+  const { data, status } = await makeRequest(ioContext, paths.sessionToken(ioContext.account, ioContext.account, redirectUrl), 'GET')
   if (!data.authenticationToken) {
     throw new ResolverError(`ERROR ${data}`, status)
   }
@@ -58,7 +58,7 @@ export const queries = {
         showClassicAuthentication,
         showAccessKeyAuthentication
       } } = await makeRequest(ioContext,
-      paths.sessionToken(ioContext.account, ioContext.account)
+      paths.sessionToken(ioContext.account, ioContext.account), 'GET'
     )
     return {
       providers: oauthProviders,

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -64,7 +64,8 @@ const paths = {
   /** VTEX ID API */
   vtexId: `http://vtexid.vtex.com.br/api/vtexid/pub`,
   identity: (account, { token }) => `${paths.vtexId}/authenticated/user?authToken=${encodeURIComponent(token)}`,
-  sessionToken: (scope, account, redirect = '/') => `${paths.vtexId}/authentication/start?appStart=true&scope=${scope}&accountName=${account}${redirect && `&callbackUrl=${redirect}/`}`,
+  sessionToken: (scope, account, redirect = '/', returnUrl = '/'
+    ) => `${paths.vtexId}/authentication/start?appStart=true&scope=${scope}&accountName=${account}${redirect && `&callbackUrl=${redirect}`}${returnUrl && `&returnUrl=${returnUrl}`}`,
   sendEmailVerification: (email, token) => `${paths.vtexId}/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
   accessKeySignIn: (token, email, code) => `${paths.vtexId}/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
   classicSignIn: (token, email, password) => `${paths.vtexId}/authentication/classic/validate?authenticationToken=${token}&login=${email}&password=${password}`,


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
*Secondary: Refact the auth mutations to make `POST` instead `GET` requests in API.*
#### How should this be manually tested?
Use login app -> https://auth--storecomponents.myvtex.com/

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
