### PR TITLE
should not pass an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Argument type mismatch in url generation
 
 ## [2.26.0] - 2018-09-05
 ### Added

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -283,9 +283,7 @@ export const queries = {
     }
 
     if (args.department) {
-      const urlCategories = paths.categories(ioContext.account, {
-        treeLevel: 2,
-      })
+      const urlCategories = paths.categories(ioContext.account, 2)
       const { data: departments }: { data: Category[] } = await axios.get(
         urlCategories,
         {


### PR DESCRIPTION
#### What is the purpose of this pull request?
There is a type mismatch between the function and the argument making the final url to be something like`/api/catalog_system/pub/tree/[Object]/`

#### How should this be manually tested?
Link boticario store with an older version to notice the bug in the store-graphql logs

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
