### PR TITLE
Fix updateProfile mutation to update information of new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `updateProfile` mutation to update information of new users.
 
 ## [2.29.0] - 2018-9-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.29.1] - 2018-09-19
 ### Fixed
 - Fix `updateProfile` mutation to update information of new users.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -21,9 +21,11 @@ const getClientData = async (account, authToken, cookie, customFields?: string) 
       token: getClientToken(cookie, account)
     }), authToken
   )
-  return await makeRequest(
+  const profileData = await makeRequest(
     paths.profile(account).filterUser(user, customFields), authToken
   ).then(pipe(prop('data'), head))
+
+  return profileData ? profileData : { id: '', email: user }
 }
 
 const getClientToken = (cookie, account) => {


### PR DESCRIPTION
#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The `updateProfile` mutation don't update profileData when was a new user.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
