### PR TITLE
Feature: shippingData query and address mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add OrderFormShippingData schema type
+
+### Fixed
+- Bug in updateOrderFormShipping resolver
 
 ## [2.31.1] - 2018-09-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.31.2] - 2018-09-28
 ### Added
 - Add OrderFormShippingData schema type
 

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -76,7 +76,6 @@ input OrderFormAddressInput {
   addressType: String
   postalCode: String
   country: String
-  addressType: String
   receiverName: String
   city: String
   state: String

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -15,6 +15,7 @@ type OrderForm {
   ignoreProfileData: Boolean
   totalizers: [Totalizer]
   clientProfileData: ClientProfile
+  shippingData: OrderFormShippingData
 }
 
 type OrderFormItem {
@@ -56,6 +57,12 @@ type ClientProfile {
   documentType: String
   stateInscription: String
   tradeName: String
+}
+
+type OrderFormShippingData {
+  address: Address
+  availableAddresses: [Address]!
+  selectedAddresses: [Address]!
 }
 
 input OrderFormItemInput {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.31.1",
+  "version": "2.31.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -133,6 +133,6 @@ export const mutations: Record<string, Resolver> = {
   },
 
   updateOrderFormShipping: (root, {orderFormId, address}, {dataSources: {checkout}}) => {
-    return checkout.updateOrderFormProfile(orderFormId, address)
+    return checkout.updateOrderFormShipping(orderFormId, address)
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Enable querying of shippingData on the orderForm object, and fixes the resolver of the updateOrderFormShipping mutation

#### What problem is this solving?
For the app `address-locator` and `delivery-dreamstore`, we need to be able to read and update the shippingData, with the purpose of changing the delivery address.

#### How should this be manually tested?
Use graphiQL to query shippingData on the orderForm query, and use the updateOrderFormShipping mutation to change the address. Sample address variable (replace `{{orderFormId}}` with the id from a previous query):
```json
{ "orderFormId": "{{orderFormId}}", "address": { "street": "Praia de Botafogo", "number":"300", "postalCode": "22250-040" } }
```

#### Screenshots or example usage
Workspace: https://updateorderformshipping--delivery.myvtex.com/_v/vtex.store-graphql@2.31.1/graphiql/v1

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
