### PR TITLE
Fix usage of updateOrderFormShipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.31.7] - 2018-10-02
 ### Fixed
 - `updateOrderformShipping` passing of props in resolver and dataSource 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `updateOrderformShipping` passing of props in resolver and dataSource 
 
 ## [2.31.6] - 2018-10-02
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.31.6",
+  "version": "2.31.7",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/dataSources/checkout.ts
+++ b/node/dataSources/checkout.ts
@@ -80,7 +80,7 @@ export class CheckoutDataSource extends RESTDataSource<ColossusContext> {
     `/pub/orderForm/${orderFormId}/attachments/shippingData`,
     {
       expectedOrderFormSections: ['items'],
-      ...address,
+      address,
     }
   )
 

--- a/node/dataSources/checkout.ts
+++ b/node/dataSources/checkout.ts
@@ -76,11 +76,11 @@ export class CheckoutDataSource extends RESTDataSource<ColossusContext> {
     }
   )
 
-  public updateOrderFormShipping = (orderFormId: string, address: any) => this.post(
+  public updateOrderFormShipping = (orderFormId: string, shipping: any) => this.post(
     `/pub/orderForm/${orderFormId}/attachments/shippingData`,
     {
       expectedOrderFormSections: ['items'],
-      ...address,
+      ...shipping,
     }
   )
 

--- a/node/dataSources/checkout.ts
+++ b/node/dataSources/checkout.ts
@@ -80,7 +80,7 @@ export class CheckoutDataSource extends RESTDataSource<ColossusContext> {
     `/pub/orderForm/${orderFormId}/attachments/shippingData`,
     {
       expectedOrderFormSections: ['items'],
-      address,
+      ...address,
     }
   )
 

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -133,6 +133,6 @@ export const mutations: Record<string, Resolver> = {
   },
 
   updateOrderFormShipping: (root, {orderFormId, address}, {dataSources: {checkout}}) => {
-    return checkout.updateOrderFormShipping(orderFormId, address)
+    return checkout.updateOrderFormShipping(orderFormId, {address})
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Resolve a quirk in updateOrderFormShipping. I double checked if there is any code using this already, and no, so it should not be a breaking change, more like fixing what's broken

#### What problem is this solving?
The method `updateOrderFormShipping` in `node/dataSources/checkout.ts` is spreading the shipping object into the POST request. I had to get the address object that is being received and passed it to the datasource inside another object, that way when someone needs to add a feature to it, they just need to append it there. I renamed the dataSource object to make more sense (it was called address before, but it could have other objects like logisticsInfo, not just addres).

#### How should this be manually tested?
- Access the graphiQL url below
- Execute the orderForm query
- Get the orderFormId from the query result, and paste it into the query variables
- Execute the updateOrderFormShipping mutation with your id
- If it works, it should return the number provided in the variables
- Double check by requerying the orderForm query and see if the orderForm address persisted

#### Screenshots or example usage
[GraphiQL](https://fixspread--delivery.myvtex.com/_v/vtex.store-graphql@2.31.3/graphiql/v1?operationName=orderForm&query=query%20orderForm%20%7B%0A%20%20orderForm%20%7B%0A%20%20%20%20orderFormId%0A%20%20%20%20value%0A%20%20%20%20shippingData%20%7B%0A%20%20%20%20%20%20address%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20userId%0A%20%20%20%20%20%20%20%20street%0A%20%20%20%20%20%20%20%20number%0A%20%20%20%20%20%20%20%20receiverName%0A%20%20%20%20%20%20%20%20complement%0A%20%20%20%20%20%20%20%20neighborhood%0A%20%20%20%20%20%20%20%20country%0A%20%20%20%20%20%20%20%20state%0A%20%20%20%20%20%20%20%20geoCoordinate%0A%20%20%20%20%20%20%20%20postalCode%0A%20%20%20%20%20%20%20%20city%0A%20%20%20%20%20%20%20%20reference%0A%20%20%20%20%20%20%20%20addressName%0A%20%20%20%20%20%20%20%20addressType%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A%0Amutation%20updateOrderFormShipping(%24orderFormId%3A%20String%2C%20%24address%3A%20OrderFormAddressInput)%20%7B%0A%20%20updateOrderFormShipping(orderFormId%3A%20%24orderFormId%2C%20address%3A%20%24address)%20%7B%0A%20%20%20%20orderFormId%0A%20%20%20%20shippingData%20%7B%0A%20%20%20%20%20%20address%20%7B%0A%20%20%20%20%20%20%20%20number%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%0A%20%20%22orderFormId%22%3A%225bad94278e1249bd8e107462bef46a47%22%2C%0A%20%20%22address%22%3A%20%7B%0A%20%20%20%20%22postalCode%22%3A%2222250-040%22%2C%0A%09%20%20%20%20%22country%22%3A%22BRA%22%2C%0A%09%20%20%20%20%22city%22%3A%22Rio%20de%20Janeiro%22%2C%0A%09%20%20%20%20%22state%22%3A%22RJ%22%2C%0A%09%20%20%20%20%22street%22%3A%22Praia%20de%20Botafogo%22%2C%0A%09%20%20%20%20%22number%22%3A%22300%22%2C%0A%09%20%20%20%20%22neighborhood%22%3A%22Botafogo%22%2C%0A%20%20%20%20%09%22complement%22%3A%22apt%20208%22%2C%0A%09%20%20%20%20%22addressType%22%3A%22residential%22%0A%20%20%7D%0A%7D)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
