### PR TITLE
Enable querying of googleMapsKey on LogisticsData type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `googleMapsKey` field on `LogisticsData` type
 
 ## [2.31.5] - 2018-10-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.31.6] - 2018-10-02
 ### Added
 - `googleMapsKey` field on `LogisticsData` type
 

--- a/graphql/types/Logistics.graphql
+++ b/graphql/types/Logistics.graphql
@@ -1,5 +1,6 @@
 type LogisticsData {
   """ countries this store ships to """
   shipsTo: [String]
+  """ Google Maps Geolocation API key """
   googleMapsKey: String
 }

--- a/graphql/types/Logistics.graphql
+++ b/graphql/types/Logistics.graphql
@@ -1,4 +1,5 @@
 type LogisticsData {
   """ countries this store ships to """
   shipsTo: [String]
+  googleMapsKey: String
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.31.5",
+  "version": "2.31.6",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Be able to query googleMapsKey from the logistics API

#### How should this be manually tested?
Use the workspace link below and execute the query, it should return the same key from Google Maps that is configured in Logistics at https://delivery.myvtex.com/admin/logistics/#/config

#### Screenshots or example usage
Workspace: https://prgooglemaps--delivery.myvtex.com/_v/vtex.store-graphql@2.31.5/graphiql/v1?query=query%20logistics%20%7B%0A%20%20logistics%20%7B%0A%20%20%20%20googleMapsKey%0A%20%20%7D%0A%7D&operationName=logistics

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
