### PR TITLE
Add a regex in brand slug to remove special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add a regex in brand slug to remove special characters. 
 
 ## [2.31.7] - 2018-10-02
 ### Fixed

--- a/node/resolvers/catalog/brand.ts
+++ b/node/resolvers/catalog/brand.ts
@@ -1,14 +1,13 @@
 import { prop } from 'ramda'
 import * as slugify from 'slugify'
 
+const Slugify = name => slugify(name, { lower: true, remove: /[*+~.()'"!:@]/g }),
+
 export const resolvers = {
   Brand: {
     active: prop('isActive'),
-
-    cacheId: brand => slugify(brand.name, { lower: true }),
-
-    slug: brand => slugify(brand.name, { lower: true }),
-
+    cacheId: brand => Slugify(brand.name),
+    slug: brand => Slugify(brand.name),
     titleTag: prop('title'),
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add a regex in brand slug to remove special characters
#### Screenshots or example usage
[Access here](https://bruno--boticario.myvtex.com/_v/vtex.store-graphql@2.31.7/graphiql/v1?query=query%20brand%20%7B%0A%20%20brand(id%3A%202000001)%20%7B%0A%20%20%20%20name%0A%20%20%20%20slug%0A%20%20%20%20titleTag%0A%20%20%20%20metaTagDescription%0A%20%20%7D%0A%7D&operationName=brand)
#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
