### PR TITLE
Fix creation of VtexIdAutCookie header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Creation of `VtexIdClientAutCookie` header
 
 ## [2.31.8] - 2018-10-03
 ### Fixed

--- a/node/resolvers/headers.ts
+++ b/node/resolvers/headers.ts
@@ -17,7 +17,9 @@ export const withAuthToken = (currentHeaders = {}) => (ioContext, cookie = null)
   let ans = { ...currentHeaders }
   if (cookie) {
     const parsedCookie = cookies.parse(cookie)
-    ans['VtexIdclientAutCookie'] = parsedCookie.VtexIdclientAutCookie
+    if (parsedCookie.VtexIdclientAutCookie) {
+      ans['VtexIdclientAutCookie'] = parsedCookie.VtexIdclientAutCookie
+    }
   }
   return {
     ...ans,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix a bug in `withAuthToken`

#### What problem is this solving?
When the `VtexIdClientAutCookie` cookie doesn't exist (e.g: in public routes), it shouldn't create a header with that name

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
