### PR TITLE
Add vary x-vtex-segment to prevent wrong cached responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add vary x-vtex-segment to prevent wrong cached responses.
 
 ## [2.32.0] - 2018-10-05
 ### Added
@@ -13,11 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.31.8] - 2018-10-03
 ### Fixed
-- Add a regex in brand slug to remove special characters. 
+- Add a regex in brand slug to remove special characters.
 
 ## [2.31.7] - 2018-10-02
 ### Fixed
-- `updateOrderformShipping` passing of props in resolver and dataSource 
+- `updateOrderformShipping` passing of props in resolver and dataSource
 
 ## [2.31.6] - 2018-10-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.32.1] - 2018-10-5
 ### Fixed
 - Add vary x-vtex-segment to prevent wrong cached responses.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.32.0",
+  "version": "2.32.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -71,13 +71,13 @@ export const queries = {
   },
 
   facets: (_, { facets }, ctx) => {
-    ctx.vary('cookie')
+    ctx.vary('x-vtex-segment')
     const { dataSources: { catalog } } = ctx
     return catalog.facets(facets)
   },
 
   product: async (_, { slug }, ctx) => {
-    ctx.vary('cookie')
+    ctx.vary('x-vtex-segment')
     const { dataSources: { catalog } } = ctx
     const products = await catalog.product(slug)
 
@@ -92,7 +92,7 @@ export const queries = {
   },
 
   products: async (_, args, ctx) => {
-    ctx.vary('cookie')
+    ctx.vary('x-vtex-segment')
     const { dataSources: { catalog } } = ctx
     const queryTerm = args.query
     if (queryTerm == null || test(/[\?\&\[\]\=\,]/, queryTerm)) {
@@ -120,7 +120,7 @@ export const queries = {
   categories: async (_, { treeLevel }, { dataSources: { catalog } }) => catalog.categories(treeLevel),
 
   search: async (_, args, ctx: ColossusContext) => {
-    ctx.vary('cookie')
+    ctx.vary('x-vtex-segment')
     const { map: mapParams, query, rest } = args
 
     if (query == null || mapParams == null) {

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -1,6 +1,6 @@
 import { ApolloError } from 'apollo-server-errors'
 import { ColossusContext } from 'colossus'
-import { compose, equals, find, head, last, map, prop, split, test, path } from 'ramda'
+import { compose, equals, find, head, last, map, path, prop, split, test } from 'ramda'
 import ResolverError from '../../errors/resolverError'
 
 import { resolvers as brandResolvers } from './brand'
@@ -10,7 +10,7 @@ import { resolvers as offerResolvers } from './offer'
 import { resolvers as productResolvers } from './product'
 import { resolvers as recommendationResolvers } from './recommendation'
 import { resolvers as skuResolvers } from './sku'
-import { Slugify } from './slug';
+import { Slugify } from './slug'
 
 /**
  * It will extract the slug from the HREF in the item
@@ -70,9 +70,15 @@ export const queries = {
     }
   },
 
-  facets: (_, { facets }, { dataSources: { catalog } }) => catalog.facets(facets),
+  facets: (_, { facets }, ctx) => {
+    ctx.vary('cookie')
+    const { dataSources: { catalog } } = ctx
+    return catalog.facets(facets)
+  },
 
-  product: async (_, { slug }, { dataSources: { catalog } }) => {
+  product: async (_, { slug }, ctx) => {
+    ctx.vary('cookie')
+    const { dataSources: { catalog } } = ctx
     const products = await catalog.product(slug)
 
     if (products.length > 0) {
@@ -85,7 +91,9 @@ export const queries = {
     )
   },
 
-  products: async (_, args, { dataSources: { catalog } }) => {
+  products: async (_, args, ctx) => {
+    ctx.vary('cookie')
+    const { dataSources: { catalog } } = ctx
     const queryTerm = args.query
     if (queryTerm == null || test(/[\?\&\[\]\=\,]/, queryTerm)) {
       throw new ResolverError(
@@ -112,6 +120,7 @@ export const queries = {
   categories: async (_, { treeLevel }, { dataSources: { catalog } }) => catalog.categories(treeLevel),
 
   search: async (_, args, ctx: ColossusContext) => {
+    ctx.vary('cookie')
     const { map: mapParams, query, rest } = args
 
     if (query == null || mapParams == null) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add vary x-vtex-segment to prevent wrong cached responses

#### What problem is this solving?
We can deliver wrong cached responses that should vary by vtex_segment cookie

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
