### PR TITLE
Fixes calculatedAttachments generation of Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `calculatedAttachments` now returns an empty string if the product does not fit the requirements to generate the schema
 
 ## [2.35.1] - 2018-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - `calculatedAttachments` now returns an empty string if the product does not fit the requirements to generate the schema
+- `calculatedAttachments` now returns properly the properties as array or string
 
 ## [2.35.1] - 2018-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `calculatedAttachments` now returns an empty string if the product does not fit the requirements to generate the schema
-- `calculatedAttachments` now returns properly the properties as array or string
+- `calculatedAttachments` now returns an empty JSON if the product does not fit the requirements to generate the schema
+- `calculatedAttachments` now parses properly the properties as array or string
 
 ## [2.35.1] - 2018-11-08
 

--- a/node/resolvers/catalog/calculatedAttachmentsResolver.ts
+++ b/node/resolvers/catalog/calculatedAttachmentsResolver.ts
@@ -250,7 +250,7 @@ export default async (
   })
 
   if (!reducedAttachmentSchema) {
-    return ''
+    return '{}'
   }
 
   const calculatedSchema = { ...schema, ...reducedAttachmentSchema }

--- a/node/resolvers/catalog/calculatedAttachmentsResolver.ts
+++ b/node/resolvers/catalog/calculatedAttachmentsResolver.ts
@@ -249,6 +249,10 @@ export default async (
     }),
   })
 
+  if (!reducedAttachmentSchema) {
+    return ''
+  }
+
   const calculatedSchema = { ...schema, ...reducedAttachmentSchema }
 
   return JSON.stringify(calculatedSchema)

--- a/node/resolvers/catalog/calculatedAttachmentsResolver.ts
+++ b/node/resolvers/catalog/calculatedAttachmentsResolver.ts
@@ -112,7 +112,7 @@ const parseDomainSkus = ({ skusString, getSkuInfo }) => // tslint:disable-line
 const parseDomain = async ({ FieldName, DomainValues, getSkuInfo }) => { // tslint:disable-line
   const [_, minTotalItems, maxTotalItems, skusString] = DomainValues.match(domainValueRegex)
   const required = minTotalItems > 0
-  const multiple = maxTotalItems > minTotalItems
+  const multiple = maxTotalItems > 1
 
   const domainSkus = {
     [FieldName]: await Promise.all(parseDomainSkus({ skusString, getSkuInfo })),


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes calculatedAttachments to return an empty string when the attachments are not present or invalid for the schema.
Also fixes schema improperly creating properties as `string` when it should have been `array`

#### What problem is this solving?
Makes product-customizer properly identify that the product is not valid to show the customization UI, so it renders a default product-details UI.

#### How should this be manually tested?
[GraphiQL](https://dan--delivery.myvtex.com/_v/vtex.store-graphql@2.34.2/graphiql/v1?query=query%20product(%24slug%3A%20String)%20%7B%0A%20%20product(slug%3A%20%24slug)%20%7B%0A%20%20%20%20productName%0A%20%20%20%20items%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20calculatedAttachments%0A%20%20%20%20%20%20attachments%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20required%0A%20%20%20%20%20%20%20%20domainValues%20%7B%0A%20%20%20%20%20%20%20%20%20%20DomainValues%0A%20%20%20%20%20%20%20%20%20%20FieldName%0A%20%20%20%20%20%20%20%20%20%20MaxCaracters%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=product&variables=%7B%22slug%22%3A%20%22shake%22%7D)

The slug `shake` should return empty string. Other slugs, like `pizza-pepperoni` or `hawaiian` should have a schema on calculatedAttachments.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.