### PR TITLE
Disable long stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.38.0] - 2018-11-09
+
 ## [2.37.0] - 2018-11-08
 ### Added
 - Subscription resolvers

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -12,7 +12,6 @@ import { queries as subscriptionsQueries } from './subscriptions'
 
 // tslint:disable-next-line:no-var-requires
 Promise = require('bluebird')
-Promise.config({ longStackTraces: true })
 
 export const resolvers = {
   ...catalogFieldResolvers,


### PR DESCRIPTION
> Long stack traces imply a substantial performance penalty, around 4-5x for throughput and 0.5x for latency.

http://bluebirdjs.com/docs/api/promise.longstacktraces.html