### PR TITLE
Isolate products and facets queries on search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Isolate the query to `facets` and `products` from the search resolver.
 
 ## [2.39.1] - 2018-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.40.0] - 2018-11-16
 ### Changed
 - Isolate the query to `facets` and `products` from the search resolver.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.39.1",
+  "version": "2.40.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -1,5 +1,8 @@
 import { RequestOptions, RESTDataSource } from 'apollo-datasource-rest'
+import http from 'axios'
 import { forEachObjIndexed } from 'ramda'
+
+import { withAuthToken } from '../resolvers/headers'
 
 const DEFAULT_TIMEOUT_MS = 8 * 1000
 
@@ -44,22 +47,26 @@ export class CatalogDataSource extends RESTDataSource<ServiceContext> {
     `/pub/products/search?${skuIds.map(skuId => `fq=skuId:${skuId}`).join('&')}`
   )
 
-  public products = ({
-    query = '',
-    category = '',
-    specificationFilters,
-    priceRange = '',
-    collection = '',
-    salesChannel = '',
-    orderBy = '',
-    from = 0,
-    to = 9,
-    map = ''
-  }: ProductsArgs) => {
-    const sanitizedQuery = encodeURIComponent(decodeURIComponent(query).trim())
-    return this.get(
-      `/pub/products/search/${sanitizedQuery}?${category && !query && `&fq=C:/${category}/`}${(specificationFilters && specificationFilters.length > 0 && specificationFilters.map(filter => `&fq=${filter}`)) || ''}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${map && `&map=${map}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`
+  public products = (args: ProductsArgs) => {
+    return this.get(this.productSearchUrl(args))
+  }
+
+  public productsQuantity = async (args: ProductsArgs) => {
+    const { vtex: ioContext, vtex: { account } } = this.context
+
+    const { headers } = await http.head(
+      `https://${account}.vtexcommercestable.com.br/api/catalog_system${this.productSearchUrl(args)}`,
+      {
+        headers: withAuthToken()(ioContext),
+      }
     )
+
+    console.log(headers)
+    const { resources } = headers
+
+    const [_, quantity] = resources.split('/')
+
+    return parseInt(quantity, 10)
   }
 
   public brands = () => this.get(
@@ -116,6 +123,24 @@ export class CatalogDataSource extends RESTDataSource<ServiceContext> {
         Authorization: authToken,
         ...segment && {Cookie: `vtex_segment=${segment}`},
       }
+    )
+  }
+
+  private productSearchUrl = ({
+    query = '',
+    category = '',
+    specificationFilters,
+    priceRange = '',
+    collection = '',
+    salesChannel = '',
+    orderBy = '',
+    from = 0,
+    to = 9,
+    map = ''
+  }: ProductsArgs) => {
+    const sanitizedQuery = encodeURIComponent(decodeURIComponent(query).trim())
+    return (
+      `/pub/products/search/${sanitizedQuery}?${category && !query && `&fq=C:/${category}/`}${(specificationFilters && specificationFilters.length > 0 && specificationFilters.map(filter => `&fq=${filter}`)) || ''}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${map && `&map=${map}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`
     )
   }
 }

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -54,15 +54,12 @@ export class CatalogDataSource extends RESTDataSource<ServiceContext> {
   public productsQuantity = async (args: ProductsArgs) => {
     const { vtex: ioContext, vtex: { account } } = this.context
 
-    const { headers } = await http.head(
+    const { headers: { resources } } = await http.head(
       `https://${account}.vtexcommercestable.com.br/api/catalog_system${this.productSearchUrl(args)}`,
       {
         headers: withAuthToken()(ioContext),
       }
     )
-
-    console.log(headers)
-    const { resources } = headers
 
     const [_, quantity] = resources.split('/')
 

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -8,6 +8,7 @@ import { resolvers as facetsResolvers } from './facets'
 import { resolvers as offerResolvers } from './offer'
 import { resolvers as productResolvers } from './product'
 import { resolvers as recommendationResolvers } from './recommendation'
+import { resolvers as searchResolvers } from './search'
 import { resolvers as skuResolvers } from './sku'
 import { Slugify } from './slug'
 
@@ -51,6 +52,7 @@ export const fieldResolvers = {
   ...offerResolvers,
   ...productResolvers,
   ...recommendationResolvers,
+  ...searchResolvers,
   ...skuResolvers,
 }
 
@@ -122,18 +124,6 @@ export const queries = {
       throw new ApolloError('Search query/map cannot be null', 'ERR_EMPTY_QUERY')
     }
 
-    const queryWithRest = query + (rest && '/' + rest.replace(/,/g, '/'))
-
-    const facetValues = queryWithRest + '?map=' + mapParams
-
-    const productsPromise = queries.products(_, { ...args, query: queryWithRest }, ctx)
-    const facetsPromise = queries.facets(_, { facets: facetValues }, ctx)
-
-    const [products, facets] = await Promise.all([
-      productsPromise,
-      facetsPromise,
-    ])
-
     const categoryMetaData = async () => {
       const category = findInTree(
         await queries.categories(_, { treeLevel: query.split('/').length }, ctx),
@@ -165,16 +155,9 @@ export const queries = {
 
     const { titleTag, metaTagDescription } = await searchMetaData()
 
-    const recordsFiltered = facets.Departments.reduce(
-      (total, dept) => total + dept.Quantity,
-      0
-    )
-
     return {
-      facets,
       metaTagDescription,
-      products,
-      recordsFiltered,
+      queryArgs: args,
       titleTag,
     }
   },

--- a/node/resolvers/catalog/search.ts
+++ b/node/resolvers/catalog/search.ts
@@ -51,28 +51,26 @@ const getQueryAndFacets = ({ map: unsortedMap = '', query: queryParam = '', rest
 export const resolvers = {
   Search: {
     facets: (root, _, ctx) => {
-      const { dataSources: { catalog } } = ctx
       const args = root.queryArgs || {}
 
       const { facets } = getQueryAndFacets(args)
 
-      return queries.facets(_, { ...args, facets }, ctx)
+      return queries.facets(root, { ...args, facets }, ctx)
     },
     products: (root, _, ctx) => {
-      const { dataSources: { catalog } } = ctx
       const args = root.queryArgs || {}
 
       const { map, query } = getQueryAndFacets(args)
 
-      return queries.products(_, { ...args, query, map }, ctx)
+      return queries.products(root, { ...args, query, map }, ctx)
     },
-    recordsFiltered: async (root, _, ctx) => {
+    recordsFiltered: async (root, args, ctx) => {
       if (!path(['queryArgs', 'map', 'length'], root)) {
         return 0
       }
 
       try {
-        const facets = await resolvers.Search.facets(root, _, ctx)
+        const facets = await resolvers.Search.facets(root, args, ctx)
 
         const recordsFiltered = facets.Departments.reduce(
           (total, dept) => total + dept.Quantity,

--- a/node/resolvers/catalog/search.ts
+++ b/node/resolvers/catalog/search.ts
@@ -11,7 +11,9 @@ const sortMapAndQuery = (map: string[], query: string[]) => {
   const zipped = zip(map, query)
 
   const sorted = sort(([a], [b]) => {
-    if (a !== b && a === 'c') {
+    if (a !== b && a === 'productClusterIds') {
+      return -1
+    } else if (a !== b && a === 'c') {
       return -1
     } else if (a === b && a === 'c') {
       return 0
@@ -68,7 +70,7 @@ export const resolvers = {
       const { dataSources: { catalog } } = ctx
 
       try {
-        return catalog.productsQuantity(root.queryArgs)
+        return catalog.productsQuantity(Object.assign({}, root.queryArgs, getQueryAndFacets(root.queryArgs)))
       } catch (e) {
         return 0
       }

--- a/node/resolvers/catalog/search.ts
+++ b/node/resolvers/catalog/search.ts
@@ -1,0 +1,55 @@
+import { length } from 'ramda'
+
+import { queries } from './index'
+
+const getQueryAndFacets = ({ map = '', query: queryParam = '', rest = '' }) => {
+  let query = queryParam
+
+  if (rest) {
+    query += `/${rest.replace(/,/g, '/')}`
+  }
+
+  return {
+    facets: `${query}?map=${map}`,
+    query,
+  }
+}
+
+export const resolvers = {
+  Search: {
+    facets: (root, _, ctx) => {
+      const { dataSources: { catalog } } = ctx
+      const args = root.queryArgs || {}
+
+      const { facets } = getQueryAndFacets(args)
+
+      return queries.facets(_, { ...args, facets }, ctx)
+    },
+    products: (root, _, ctx) => {
+      const { dataSources: { catalog } } = ctx
+      const args = root.queryArgs || {}
+
+      const { query } = getQueryAndFacets(args)
+
+      return queries.products(_, { ...args, query }, ctx)
+    },
+    recordsFiltered: async (root, _, ctx) => {
+      if (!length(root.queryArgs.map)) {
+        return 0
+      }
+
+      try {
+        const facets = await resolvers.Search.facets(root, _, ctx)
+
+        const recordsFiltered = facets.Departments.reduce(
+          (total, dept) => total + dept.Quantity,
+          0
+        )
+
+        return recordsFiltered
+      } catch (e) {
+        return 0
+      }
+    },
+  },
+}

--- a/node/resolvers/catalog/search.ts
+++ b/node/resolvers/catalog/search.ts
@@ -65,19 +65,10 @@ export const resolvers = {
       return queries.products(root, { ...args, query, map }, ctx)
     },
     recordsFiltered: async (root, args, ctx) => {
-      if (!path(['queryArgs', 'map', 'length'], root)) {
-        return 0
-      }
+      const { dataSources: { catalog } } = ctx
 
       try {
-        const facets = await resolvers.Search.facets(root, args, ctx)
-
-        const recordsFiltered = facets.Departments.reduce(
-          (total, dept) => total + dept.Quantity,
-          0
-        )
-
-        return recordsFiltered
+        return catalog.productsQuantity(root.queryArgs)
       } catch (e) {
         return 0
       }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Isolate the query to the `facets` and `products` api from the `search` query, so it will only make the request to the catalog if the user query has the respective `facets` and `products`.

#### What problem is this solving?
This will make possible to query the `search` with an empty query and map parameter, without breaking the query, due to a limitation in the facets api that can't be queried without those arguments.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/d)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
