### PR TITLE
Fix/datasources cache max age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.39.1] - 2018-11-16
+
 ## [2.39.0] - 2018-11-14
 ### Added
 - `SubscriptionOrders` resolvers

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.39.0",
+  "version": "2.39.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/dataSources/index.ts
+++ b/node/dataSources/index.ts
@@ -6,6 +6,8 @@ import { SessionDataSource } from './session'
 import { SubscriptionsDataSource } from './subscriptions'
 import { SubscriptionsGroupDataSource } from './subscriptionsGroup'
 
+const TEN_SECONDS_MS = 10 * 1000
+
 export const dataSources = () => ({
   catalog: new CatalogDataSource(),
   checkout: new CheckoutDataSource(),
@@ -16,7 +18,8 @@ export const dataSources = () => ({
 })
 
 const cacheStorage = new LRUCache<string, any>({
-  max: 200
+  max: 200,
+  maxAge: TEN_SECONDS_MS,
 })
 
 export const cache = () => cacheStorage


### PR DESCRIPTION
**Nevermind - let's remove the logs and just reduce the cache `maxAge` for now**

#### What is the purpose of this pull request?
~~There is a random bug re the search results page: sometimes, the products displayed do not seem to be the 'correct' ones (i.e. the ones that were supposed to be there) and, in some cases, the products being displayed are out-of-stock (which is problematic if the purpose of the given page is to display 'easy-to-sell' products).~~

~~From our investigation, one of the possibilities is that there may be an issue with the catalog API: it seemed that, sometimes, it was responding incorrect product arrays. We are not sure if those were indeed incorrect results but, in our small sample of requests, they were changing a lot quite often .~~ Thus, this PR:
- adds `maxAge` to in-memory LRU cache (so we make sure that we do not cache wrong results for a long time)
- ~~adds an ugly temporary log (**we should remove this ASAP!**) so we can check the details of each request / response from the catalog API when this issue surfaces again.~~

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
