### PR TITLE
Replace OrderForm http URLs with https

### DIFF
--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -21,6 +21,9 @@ import paymentTokenResolver from './paymentTokenResolver'
  */
 const convertIntToFloat = int => int * 0.01
 
+const convertHttpToHttps =
+  (url: string) => url.startsWith('http:') ? url.replace('http', 'https') : url
+
 const shouldUpdateMarketingData = (orderFormMarketingTags, segmentData: SegmentData) => {
   const {utmSource=null, utmCampaign=null, utmiCampaign=null} = orderFormMarketingTags || {}
   const {utm_source, utm_campaign, utmi_campaign} = segmentData
@@ -42,6 +45,8 @@ export const fieldResolvers = {
     items: (orderForm) => {
       return map((item: OrderFormItem) => ({
         ...item,
+        detailUrl: convertHttpToHttps(item.detailUrl),
+        imageUrl: convertHttpToHttps(item.imageUrl),
         listPrice: convertIntToFloat(item.listPrice),
         price: convertIntToFloat(item.price),
         sellingPrice: convertIntToFloat(item.sellingPrice)


### PR DESCRIPTION
#### What is the purpose of this pull request?
To change URLs from `CheckoutItem` that use `http` to `https`.

#### What problem is this solving?
Assets being delivered with `http` to the minicart.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
