### PR TITLE
Increase minReplicas to 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.41.2] - 2018-12-05
+
 ## [2.41.1] - 2018-12-03
 ### Changed
 - Removes custom axios config to avoid custom error handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [2.41.2] - 2018-12-05
+### Changed
+- Changed min replicas to 6
 
 ## [2.41.1] - 2018-12-03
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.41.1",
+  "version": "2.41.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/service.json
+++ b/node/service.json
@@ -3,7 +3,7 @@
   "memory": 512,
   "ttl": 60,
   "timeout": 9,
-  "minReplicas": 4,
+  "minReplicas": 6,
   "maxReplicas": 20,
   "routes": {
     "catalogProxy": {


### PR DESCRIPTION
I've seen the average CPU usage of this app is
around 2.5 only for Boticario. This means that
we'd need 5 replicas to keep a healthy 0.5 cpu usage
per instance.

Set minReplicas to 6 to leave a little gordurinha.