### PR TITLE
Adding slugify to category name

### DIFF
--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -1,6 +1,7 @@
 import { compose, map, omit, reject, toPairs } from 'ramda'
 
 import { queries as benefitsQueries } from '../benefits'
+import { Slugify as slugify } from './slug'
 
 const objToNameValue = (keyName: string, valueName: string, record: Record<string, any>) => compose(
   reject(value => typeof value === 'boolean' && value === false),
@@ -30,6 +31,8 @@ export const resolvers = {
     benefits: ({productId}, _, ctx) => benefitsQueries.benefits(_, {id: productId}, ctx),
 
     cacheId: ({linkText}) => linkText,
+
+    categories: ({categories}) => Array.isArray(categories) && map(slugify, categories),
 
     clusterHighlights: ({clusterHighlights = {}}) => objToNameValue('id', 'name', clusterHighlights),
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Products categories are used in breadcrumb and in link. When these category names are not slugified correctly, the links do not form correctly. This PR slugifies all category names so the links work

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
