### PR TITLE
Fix seller field type on OrderFormInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `seller` field type on OrderFormInput to accept strings as valid values
 
 ## [2.41.3] - 2018-12-10
 ### Fixed

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -76,7 +76,7 @@ input OrderFormItemInput {
   id: Int
   index: Int
   quantity: Int
-  seller: Int
+  seller: ID
 }
 
 input OrderFormAddressInput {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make possible add items on cart from other sellers rather than principal

#### What problem is this solving?
Cast problem trying to convert a string to a Int on OrderFormInput

#### How should this be manually tested?
Try add an item on cart that belongs to other seller

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
