### PR TITLE
Using new segment scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Using new SEGMENT scoped directive
 
 ## [2.44.2] - 2019-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.45.0] - 2019-01-16
 ### Changed
 - Using new SEGMENT scoped directive
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -3,7 +3,7 @@ type Query {
   product(
     """ Product slug """
     slug: String
-  ): Product @response(vary: "x-vtex-segment") @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  ): Product @cacheControl(scope: SEGMENT, maxAge: SHORT)
 
   """ Product search filtered and ordered """
   products(
@@ -27,13 +27,13 @@ type Query {
     from: Int = 0,
     """ Pagination item end """
     to: Int = 9
-  ): [Product] @response(vary: "x-vtex-segment") @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT)
 
   """ Get facets category """
   facets(
     """ Categories separated by / followed by map. e.g.:  /eletronics/tvs?map=c,c """
     facets: String = ""
-  ): Facets @response(vary: "x-vtex-segment")
+  ): Facets @cacheControl(scope: SEGMENT)
 
   """ Search for products. e.g.: search(query: 'eletronics', rest: 'lg', map: 'c,b') """
   search(
@@ -59,7 +59,7 @@ type Query {
     from: Int = 0,
     """ Pagination item end """
     to: Int = 9
-  ): Search @response(vary: "x-vtex-segment") @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  ): Search @cacheControl(scope: SEGMENT, maxAge: SHORT)
 
   """ Get category details """
   category(
@@ -321,6 +321,6 @@ type Mutation {
    If the item given does not have the itemId, add it as a new item in the list.
    If the item given has got an itemId, but its quantity is 0, remove it from the list.
    Otherwise, update it. """
-  updateList(id: ID!, list: ListInput): List 
+  updateList(id: ID!, list: ListInput): List
   deleteList(id: ID!): List
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.44.2",
+  "version": "2.45.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR depends on these ones:
- [builder-hub](https://github.com/vtex/builder-hub/pull/306)
- [graphql-server](https://github.com/vtex/graphql-server/pull/136)
- [render-ssr](https://github.com/vtex/render-ssr/pull/17)
- [pages-graphql](https://github.com/vtex/pages-graphql/pull/99)
- [runtime-node](https://github.com/vtex/service-runtime-node/pull/92)

The main idea behind all of these PRs is that we need to have access to the segment cookie on SSR and on virtual public resolvers. To address this problem without jeopardizing our public cache, a new route was designed, the `/_v/segment`. To use this route, a new `SEGMENT` scope was added to our graphql spec. This scope has a side effect of varying the response with the segment header.

#### What problem is this solving?

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
