### PR TITLE
should not overwrite headers object from apollo datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Do not modify apollo request headers by overwritting the object
 
 ## [2.45.0] - 2019-01-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.44.3] - 2019-01-30
 ### Fixed
 - Do not modify apollo request headers by overwritting the object
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.45.1] - 2019-01-30
+
 ## [2.44.3] - 2019-01-30
 ### Fixed
 - Do not modify apollo request headers by overwritting the object

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,11 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
+<<<<<<< HEAD
   "version": "2.45.0",
+=======
+  "version": "2.44.3",
+>>>>>>> Release v2.44.3
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.45.0",
+  "version": "2.45.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-<<<<<<< HEAD
   "version": "2.45.0",
-=======
-  "version": "2.44.3",
->>>>>>> Release v2.44.3
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/dataSources/document.ts
+++ b/node/dataSources/document.ts
@@ -1,5 +1,7 @@
 import { RESTDataSource } from 'apollo-datasource-rest'
 import FormData from 'form-data'
+import { forEachObjIndexed } from 'ramda'
+
 import { withMDPagination } from '../resolvers/headers'
 import { parseFieldsToJson } from '../utils'
 
@@ -49,20 +51,24 @@ export class DocumentDataSource extends RESTDataSource<Context> {
     const page = request.headers.get('page')
     const pageSize = request.headers.get('pageSize')
     const formDataHeaders = request.headers.get('formDataHeaders')
+
+    let headers = {}
     if (page && pageSize) {
-      request.headers = withMDPagination()(vtex, cookie)(+page, +pageSize)
+      headers = withMDPagination()(vtex, cookie)(+page, +pageSize)
     } else if (formDataHeaders) {
-      request.headers = {
+      headers = {
         'Proxy-Authorization': this.context.vtex.authToken,
         'VtexIdclientAutCookie': this.context.vtex.authToken,
         ...formDataHeaders
       }
     } else {
-      request.headers = {
+      headers = {
         Accept: 'application/vnd.vtex.ds.v10+json',
         Authorization: this.context.vtex.authToken
       }
     }
+
+    forEachObjIndexed((value, key) => request.headers.set(key, value), headers)
   }
 
   get baseURL() {


### PR DESCRIPTION
#### What is the purpose of this pull request?
They way apollo datasource is implemented makes that we cannot override it's headers. This PR fixes a bug caused by overriding it's header object by using the `set` method

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
