### PR TITLE
Add simulation query and deprecation warning on shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `simulation` checkout query.
+
+### Deprecated
+- `shipping` query.
 
 ## [2.70.4] - 2019-05-06
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -118,15 +118,25 @@ type Query {
   """ Returns brands list """
   brands: [Brand] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Returns orderForm shipping simulation """
-  shipping(
+  """ OrderForm simulation """
+  simulation(
     """ List of SKU products """
-    items: [ShippingItem],
+    items: [SimulationItem],
     """ Postal code to freight calculator """
     postalCode: String,
     """ Country of postal code """
     country: String
-  ): ShippingData @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
+  ): SimulationData @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
+
+  """ Returns orderForm shipping simulation """
+  shipping(
+    """ List of SKU products """
+    items: [SimulationItem],
+    """ Postal code to freight calculator """
+    postalCode: String,
+    """ Country of postal code """
+    country: String
+  ): ShippingData @deprecated(reason: "Use the simulation query instead") @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
   """ Returns checkout cart details """
   orderForm: OrderForm @cacheControl(scope: PRIVATE)
@@ -178,7 +188,7 @@ type Query {
   """ Get the benefits associated with a list of products """
   benefits(
     """ List of Products """
-    items: [ShippingItem]
+    items: [SimulationItem]
   ): [Benefit] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   """ Get the options available to authenticate users """

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -188,7 +188,7 @@ type Query {
   """ Get the benefits associated with a list of products """
   benefits(
     """ List of Products """
-    items: [SimulationItem]
+    items: [ShippingItem]
   ): [Benefit] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   """ Get the options available to authenticate users """

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -131,7 +131,7 @@ type Query {
   """ Returns orderForm shipping simulation """
   shipping(
     """ List of SKU products """
-    items: [SimulationItem],
+    items: [ShippingItem],
     """ Postal code to freight calculator """
     postalCode: String,
     """ Country of postal code """

--- a/graphql/types/Payment.graphql
+++ b/graphql/types/Payment.graphql
@@ -9,30 +9,30 @@ type PaymentOptions {
   bin: String
   paymentName: String
   paymentGroupName: String
-  value: Number
+  value: Int
   installments: [PaymentInstallments]
 }
 
 type PaymentInstallments {
-  count: Number
+  count: Int
   hasInterestRate: Boolean
-  interestRate: Number
-  value: Number
-  total: Number
+  interestRate: Int
+  value: Int
+  total: Int
   sellerMerchantInstallments: [SellerInstallment]
 }
 
 type SellerInstallment {
   id: String
-  count: Number
+  count: Int
   hasInterestRate: Boolean
-  interestRate: Number
-  value: Number
-  total: Number
+  interestRate: Int
+  value: Int
+  total: Int
 }
 
 type PaymentSystem {
-  id: Number
+  id: Int
   name: String
   groupName: String
   stringId: String

--- a/graphql/types/Payment.graphql
+++ b/graphql/types/Payment.graphql
@@ -4,6 +4,45 @@ type PaymentSession {
     expiresAt: String
 }
 
+type PaymentOptions {
+  paymentSystem: String
+  bin: String
+  paymentName: String
+  paymentGroupName: String
+  value: Number
+  installments: [PaymentInstallments]
+}
+
+type PaymentInstallments {
+  count: Number
+  hasInterestRate: Boolean
+  interestRate: Number
+  value: Number
+  total: Number
+  sellerMerchantInstallments: [SellerInstallment]
+}
+
+type SellerInstallment {
+  id: String
+  count: Number
+  hasInterestRate: Boolean
+  interestRate: Number
+  value: Number
+  total: Number
+}
+
+type PaymentSystem {
+  id: Number
+  name: String
+  groupName: String
+  stringId: String
+  template: String
+  requiresDocument: Boolean
+  isCustom: Boolean
+  requiresAuthentication: Boolean
+  dueDate: String
+}
+
 type PaymentToken {
     token: String
     bin: String

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -1,19 +1,9 @@
 type ShippingData {
+  ...Shipping
+}
+
+fragment Shipping {
   logisticsInfo: [LogisticsInfo],
-  messages: [MessageInfo]
-}
-
-type MessageInfo {
-  code: String,
-  text: String,
-  status: String,
-  fields: MessageFields
-}
-
-type MessageFields {
-  itemIndex: String
-  ean: String
-  skuName: String
 }
 
 type LogisticsInfo {
@@ -27,10 +17,4 @@ type ShippingSLA {
   price: Float
   shippingEstimate: String
   shippingEstimateDate: String
-}
-
-input ShippingItem {
-  id: String,
-  quantity: String,
-  seller: String
 }

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -15,3 +15,9 @@ type ShippingSLA {
   shippingEstimate: String
   shippingEstimateDate: String
 }
+
+input ShippingItem {
+  id: String,
+  quantity: String,
+  seller: String
+}

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -1,9 +1,6 @@
 type ShippingData {
-  ...Shipping
-}
-
-fragment Shipping {
   logisticsInfo: [LogisticsInfo],
+  messages: [MessageInfo]
 }
 
 type LogisticsInfo {

--- a/graphql/types/Simulation.graphql
+++ b/graphql/types/Simulation.graphql
@@ -1,0 +1,44 @@
+type SimulationData {
+  ratesAndBenefitsData: BenefitsData
+  postalCode: String
+  country: String
+  messages: [MessageInfo]
+  paymentData: PaymentData
+  ...Shipping
+}
+
+type PaymentData {
+  installmentOptions: [PaymentOptions]
+  paymentSystems: [PaymentSystem]
+}
+
+type BenefitsData {
+  rateAndBenefitsIdentifiers: [BenefitsIdentifier]
+  teaser: [Benefit]
+}
+
+type BenefitsIdentifier {
+  id: String
+  name: String
+  featured: Boolean
+  description: String
+}
+
+type MessageInfo {
+  code: String,
+  text: String,
+  status: String,
+  fields: MessageFields
+}
+
+type MessageFields {
+  itemIndex: String
+  ean: String
+  skuName: String
+}
+
+input SimulationItem {
+  id: String
+  quantity: Number
+  seller: String
+}

--- a/graphql/types/Simulation.graphql
+++ b/graphql/types/Simulation.graphql
@@ -39,6 +39,6 @@ type MessageFields {
 
 input SimulationItem {
   id: String
-  quantity: Number
+  quantity: Int
   seller: String
 }

--- a/graphql/types/Simulation.graphql
+++ b/graphql/types/Simulation.graphql
@@ -2,9 +2,9 @@ type SimulationData {
   ratesAndBenefitsData: BenefitsData
   postalCode: String
   country: String
+  logisticsInfo: [LogisticsInfo],
   messages: [MessageInfo]
   paymentData: PaymentData
-  ...Shipping
 }
 
 type PaymentData {

--- a/node/dataSources/checkout.ts
+++ b/node/dataSources/checkout.ts
@@ -144,7 +144,7 @@ export class CheckoutDataSource extends RESTDataSource {
     {metric: 'checkout-orders'}
   )
 
-  public shipping = (simulation: SimulationData) => this.post(
+  public simulation = (simulation: SimulationData) => this.post(
     '/pub/orderForms/simulation',
     simulation,
     {metric: 'checkout-shipping'}

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -96,8 +96,15 @@ export const queries: Record<string, Resolver> = {
     return checkout.orders()
   },
 
+  /**
+   * @deprecated Should be removed in the next major
+   */
   shipping: (_, args: SimulationData, {dataSources: {checkout}}) => {
-    return checkout.shipping(args)
+    return checkout.simulation(args)
+  },
+
+  simulation: (_, args: SimulationData, {dataSources: {checkout}}) => {
+    return checkout.simulation(args)
   },
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `simulation` query, which is essentially the same one as the `shipping`, but has more fields on the return type, including the ones from the `shipping`.

This PR also adds a `@deprecated` annotation to the `shipping` query, since now it's just a less powerful `simulation` query.

#### What problem is this solving?
There wasn't a query with the `rateAndBenefitsIdentifiers` field, which is needed to see if the product has discounts.

#### How do I manually test this?
Access the [graphiql](https://lucas--storecomponents.myvtex.com/_v/vtex.store-graphql@2.46.1/graphiql/v1), and type in the following query

```graphql
query {
  simulation(
    items: [
      { id: "33", quantity: 1, seller: "1" },
      { id: "2000533", quantity: 1, seller: "1" }
    ],
    postalCode: "22250040",
    country: "BRA"
  ) {
    ratesAndBenefitsData {
      rateAndBenefitsIdentifiers {
        id
        name
        featured
        description
      }
    }
    logisticsInfo {
      itemIndex
      slas {
        id
        name
        price
        shippingEstimate
        shippingEstimateDate
      }
    }
  }
}
```

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
