### PR TITLE
add assembly options related fields to orderform and product types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add assembly options fields to Order, OrderForm and Product types
+- Create ItemMetadata type
 
 ## [2.47.0] - 2019-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.47.1] - 2019-02-11
 ### Added
 - Add assembly options fields to Order, OrderForm and Product types
 - Create ItemMetadata type

--- a/graphql/types/ItemMetadata.graphql
+++ b/graphql/types/ItemMetadata.graphql
@@ -1,0 +1,56 @@
+type ItemMetadata {
+  items: [ItemMetadataUnit]
+  priceTable: [ItemPriceTable]
+}
+
+type ItemPriceTable {
+  type: String
+  values: [PriceTableItem]
+}
+
+type PriceTableItem {
+  id: String
+  price: Int
+}
+
+type ItemMetadataUnit {
+  id: ID
+  name: String
+  skuName: String
+  productId: String
+  refId: String
+  ean: String
+  imageUrl: String
+  detailUrl: String
+  seller: String
+  assemblyOptions: [AssemblyOption]
+}
+
+type AssemblyOption {
+  id: String
+  name: String
+  required: Boolean
+  composition: CompositionType
+}
+
+type CompositionType {
+  minQuantity: Int
+  maxQuantity: Int
+  items: [CompositionItem]
+}
+
+type CompositionItem {
+  id: String
+  minQuantity: Int
+  maxQuantity: Int
+  initialQuantity: Int
+  priceTable: String
+  seller: String
+}
+
+input AssemblyOptionInput {
+  id: String!
+  quantity: Int!
+  assemblyId: String!
+  seller: String!
+}

--- a/graphql/types/ItemMetadata.graphql
+++ b/graphql/types/ItemMetadata.graphql
@@ -27,7 +27,7 @@ type ItemMetadataUnit {
 }
 
 type AssemblyOption {
-  id: String
+  id: ID
   name: String
   required: Boolean
   composition: CompositionType
@@ -40,7 +40,7 @@ type CompositionType {
 }
 
 type CompositionItem {
-  id: String
+  id: ID
   minQuantity: Int
   maxQuantity: Int
   initialQuantity: Int
@@ -49,7 +49,7 @@ type CompositionItem {
 }
 
 input AssemblyOptionInput {
-  id: String!
+  id: ID!
   quantity: Int!
   assemblyId: String!
   seller: String!

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -41,6 +41,8 @@ type OrderItem {
   availability: String
   measurementUnit: String
   unitMultiplier: Int
+  parentItemIndex: Int
+  parentAssemblyBinding: String
 }
 
 type OrderItemAdditionalInfo {

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -17,6 +17,7 @@ type OrderForm {
   clientProfileData: ClientProfile
   shippingData: OrderFormShippingData
   storePreferencesData: StorePreferencesData
+  itemMetadata: ItemMetadata
 }
 
 type StorePreferencesData {
@@ -52,6 +53,8 @@ type OrderFormItem {
   sellingPrice: Float
   rewardValue: Int
   isGift: Boolean
+  parentItemIndex: Int
+  parentAssemblyBinding: String
 }
 
 type Totalizer {

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -39,6 +39,7 @@ type Product {
   jsonSpecifications: String
   """ List of benefits associated with this product """
   benefits: [Benefit]
+  itemMetadata: ItemMetadata
 }
 
 type OnlyProduct {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.47.0",
+  "version": "2.47.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -5,6 +5,7 @@ import ResolverError from '../../errors/resolverError'
 import { resolvers as brandResolvers } from './brand'
 import { resolvers as categoryResolvers } from './category'
 import { resolvers as facetsResolvers } from './facets'
+import { resolvers as itemMetadataUnitResolvers } from './itemMetadataUnit'
 import { resolvers as offerResolvers } from './offer'
 import { resolvers as productResolvers } from './product'
 import { resolvers as recommendationResolvers } from './recommendation'
@@ -49,6 +50,7 @@ export const fieldResolvers = {
   ...brandResolvers,
   ...categoryResolvers,
   ...facetsResolvers,
+  ...itemMetadataUnitResolvers,
   ...offerResolvers,
   ...productResolvers,
   ...recommendationResolvers,

--- a/node/resolvers/catalog/itemMetadataUnit.ts
+++ b/node/resolvers/catalog/itemMetadataUnit.ts
@@ -1,0 +1,13 @@
+
+/** 
+ * This is used because the itemMetadata that comes from the catalog has capitalized Name and MainImage.
+ * The itemMetadata that comes from the checkout API has name and imageUrl. This unify the patterns
+ */
+
+export const resolvers = {
+  ItemMetadataUnit: {
+    imageUrl: ({ imageUrl, MainImage }) => imageUrl || MainImage,
+    name: ({ name, Name }) => name || Name,
+    productId: ({ productId, ProductId }) => productId || ProductId
+  },
+} 


### PR DESCRIPTION
wks para teste: https://storeteste--delivery.myvtex.com

#### What is the purpose of this pull request?
Adicionar os campos de assembly options nos tipos de OrderForm, Order e Product

#### What problem is this solving?
Esses campos serão úteis quando algum dia podermos mergear as alterações de assembly options em master (quando saírem do beta).

Isso ajuda pois diminui a PR de assembly options. Não afeta em nada o que já existe.

#### How should this be manually tested?

Acessar https://storeteste--delivery.myvtex.com e adicionar algo simples ao carrinho.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
