### PR TITLE
Fixing Invalid token specified in profile query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.48.2] - 2019-02-14
+
 ## [2.48.1] - 2019-02-12
 ### Fixed
 - Fix cookie name in `isUserLoggedIn` function

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.48.1",
+  "version": "2.48.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/profile/fieldResolvers.ts
+++ b/node/resolvers/profile/fieldResolvers.ts
@@ -12,15 +12,15 @@ export default {
   Profile: {
     address: (obj, args, context) => obj.id && getAddresses(context, obj.id),
     cacheId: prop('email'),
-    customFields: (obj) =>  { 
-      if (typeof obj.customFields === 'string') { 
+    customFields: (obj) =>  {
+      if (obj && typeof obj.customFields === 'string') {
         return pickCustomFieldsFromData(obj.customFields, obj)
       }
-        
-      return obj.customFields
+
+      return obj && obj.customFields
     },
-    payments: (obj, args, context) => obj.id && getPayments(context, obj.id),
-    profilePicture: (obj, args, context) => obj.profilePicture && obj.id
+    payments: (obj, args, context) => obj && obj.id && getPayments(context, obj.id),
+    profilePicture: (obj, args, context) => obj && obj.profilePicture && obj.id
        && `//api.vtex.com/${context.vtex.account}/dataentities/CL/documents/${obj.id}/profilePicture/attachments/${obj.profilePicture}`
   },
   ProfileCustomField: {

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -25,7 +25,7 @@ export const updateProfile = async (context: Context, profile) => {
     ...reduce(addFieldsToObj, profile || {}, profile.customFields || []),
     id: oldData.id,
   }
-  
+
   return dataSources.profile.updateProfileInfo(newData).then(
     () => getProfile(context, { customFields: customFieldsStr }))
   .catch(returnOldOnNotChanged(oldData))
@@ -53,14 +53,14 @@ export const getPayments = async (context: Context, profileId: string) => {
   const { dataSources: { payments }, vtex: { currentProfile } } = context
 
   const paymentsRawData = await payments.getUserPayments(currentProfile.userId)
- 
+
   if (!paymentsRawData) {
     return null
   }
 
   const addresses = await getAddresses(context, profileId)
   const availableAccounts = JSON.parse(paymentsRawData.paymentData).availableAccounts
-  
+
   return availableAccounts.map((account) => {
     const {bin, availableAddresses, accountId, ...cleanAccount} = account
     const accountAddress = addresses.find(


### PR DESCRIPTION
#### What is the purpose of this pull request?
#198 introduced a bug with the following error:

`Invalid token specified`

This pr fixes this error by correctly parsing the admin jwt token and returning null when necessary in `withCurrentProfile` directive resolver

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
