### PR TITLE
Add brand, category, collection and department search by string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `Collection` type.
+- Brand, category, collection and department searches by string.
+
 ## [2.66.6] - 2019-04-16
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -138,7 +138,7 @@ type Query {
   ): [Category] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
   """
-  Get a list of categories (of level 1) whose name contains a given 'query' string
+  Get a list of categories (of level 1) whose name contains a given 'query' string (here, children only means next level children)
   """
   categorySearch(
     """
@@ -148,7 +148,7 @@ type Query {
   ): [Category] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
   """
-  Get a list of departments (level 0 categories) whose name contains a given 'query' string
+  Get a list of departments (level 0 categories) whose name contains a given 'query' string (here, children only means next level children)
   """
   departmentSearch(
     """

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,349 +1,628 @@
 scalar IOMessage
 
 type Query {
-    """ Get a specified product """
+  """
+  Get a specified product
+  """
   product(
-     """ Product slug """
-    slug: String,
-    """ Product identifier """
-    identifier: ProductUniqueIdentifier
+    """
+    Product slug
+    """
+    slug: String
   ): Product @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
-  """ Product search filtered and ordered """
+  """
+  Product search filtered and ordered
+  """
   products(
-    """ Terms that is used in search e.g.: eletronics/samsung """
-    query: String = "",
-    """ Defines terms types: Brand, Category, Department e.g.: c,b """
-    map: String = "",
-    """ Filter by category. {a}/{b} - {a} and {b} are categoryIds """
-    category: String = "",
-    """ Array of product specification. specificationFilter_{a}:{b} - {a} is the specificationId, {b} = specification value """
-    specificationFilters: [String],
-    """ Filter by price range. e.g.: {a} TO {b} - {a} is the minimum price "from" and {b} is the highest price "to" """
-    priceRange: String = "",
-    """ Filter by collection. where collection also know as productClusterId"""
-    collection: String = "",
-    """ Filter by availability at a specific sales channel. e.g.: salesChannel:4 if want filter by available products for the sales channel 4"""
-    salesChannel: String = "",
-    """ Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC """
-    orderBy: String = "OrderByPriceDESC",
-    """ Pagination item start """
-    from: Int = 0,
-    """ Pagination item end """
+    """
+    Terms that is used in search e.g.: eletronics/samsung
+    """
+    query: String = ""
+    """
+    Defines terms types: Brand, Category, Department e.g.: c,b
+    """
+    map: String = ""
+    """
+    Filter by category. {a}/{b} - {a} and {b} are categoryIds
+    """
+    category: String = ""
+    """
+    Array of product specification. specificationFilter_{a}:{b} - {a} is the specificationId, {b} = specification value
+    """
+    specificationFilters: [String]
+    """
+    Filter by price range. e.g.: {a} TO {b} - {a} is the minimum price "from" and {b} is the highest price "to"
+    """
+    priceRange: String = ""
+    """
+    Filter by collection. where collection also know as productClusterId
+    """
+    collection: String = ""
+    """
+    Filter by availability at a specific sales channel. e.g.: salesChannel:4 if want filter by available products for the sales channel 4
+    """
+    salesChannel: String = ""
+    """
+    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC
+    """
+    orderBy: String = "OrderByPriceDESC"
+    """
+    Pagination item start
+    """
+    from: Int = 0
+    """
+    Pagination item end
+    """
     to: Int = 9
   ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
-  """ Get facets category """
+  """
+  Get facets category
+  """
   facets(
-    """ Categories separated by / followed by map. e.g.:  /eletronics/tvs?map=c,c """
+    """
+    Categories separated by / followed by map. e.g.:  /eletronics/tvs?map=c,c
+    """
     facets: String = ""
   ): Facets @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
-  """ Search for products. e.g.: search(query: 'eletronics', rest: 'lg', map: 'c,b') """
+  """
+  Search for products. e.g.: search(query: 'eletronics', rest: 'lg', map: 'c,b')
+  """
   search(
-    """ Terms that is used in search e.g.: eletronics/samsung """
-    query: String = "",
-    """ Defines terms types: Brand, Category, Department e.g.: c,b """
-    map: String = "",
-    """ Rest terms that is used in search e.g.: samsung,Android7 """
-    rest: String = "",
-    """ Filter by category. {a}/{b} - {a} and {b} are categoryIds """
-    category: String = "",
-    """ Array of product specification. specificationFilter_{a}:{b} - {a} is the specificationId, {b} = specification value """
-    specificationFilters: [String],
-    """ Filter by price range. e.g.: {a} TO {b} - {a} is the minimum price "from" and {b} is the highest price "to" """
-    priceRange: String = "",
-    """ Filter by collection. where collection also know as productClusterId"""
-    collection: String = "",
-    """ Filter by availability at a specific sales channel. e.g.: salesChannel:4 if want filter by available products for the sales channel 4"""
-    salesChannel: String = "",
-    """ Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC """
-    orderBy: String = "OrderByPriceDESC",
-    """ Pagination item start """
-    from: Int = 0,
-    """ Pagination item end """
+    """
+    Terms that is used in search e.g.: eletronics/samsung
+    """
+    query: String = ""
+    """
+    Defines terms types: Brand, Category, Department e.g.: c,b
+    """
+    map: String = ""
+    """
+    Rest terms that is used in search e.g.: samsung,Android7
+    """
+    rest: String = ""
+    """
+    Filter by category. {a}/{b} - {a} and {b} are categoryIds
+    """
+    category: String = ""
+    """
+    Array of product specification. specificationFilter_{a}:{b} - {a} is the specificationId, {b} = specification value
+    """
+    specificationFilters: [String]
+    """
+    Filter by price range. e.g.: {a} TO {b} - {a} is the minimum price "from" and {b} is the highest price "to"
+    """
+    priceRange: String = ""
+    """
+    Filter by collection. where collection also know as productClusterId
+    """
+    collection: String = ""
+    """
+    Filter by availability at a specific sales channel. e.g.: salesChannel:4 if want filter by available products for the sales channel 4
+    """
+    salesChannel: String = ""
+    """
+    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC
+    """
+    orderBy: String = "OrderByPriceDESC"
+    """
+    Pagination item start
+    """
+    from: Int = 0
+    """
+    Pagination item end
+    """
     to: Int = 9
   ): Search @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
-  """ Get category details """
+  """
+  Get category details
+  """
   category(
-    """ Category id """
+    """
+    Category id
+    """
     id: Int
   ): Category @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Get categories tree """
+  """
+  Get categories tree
+  """
   categories(
-    """ Category tree level. Default: 3"""
+    """
+    Category tree level. Default: 3
+    """
     treeLevel: Int = 3
   ): [Category] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Get a list of categories (of level 1) whose name contains a given 'query' string"""
+  """
+  Get a list of categories (of level 1) whose name contains a given 'query' string
+  """
   categorySearch(
-    """ String to be searched """
+    """
+    String to be searched
+    """
     query: String
   ): [Category] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Get a list of departments (level 0 categories) whose name contains a given 'query' string """
+  """
+  Get a list of departments (level 0 categories) whose name contains a given 'query' string
+  """
   departmentSearch(
-    """ String to be searched """
+    """
+    String to be searched
+    """
     query: String
   ): [Category] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Get brand details """
+  """
+  Get brand details
+  """
   brand(
-    """ Brand id """
+    """
+    Brand id
+    """
     id: Int
   ): Brand @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Get a list of brands """
+  """
+  Get a list of brands
+  """
   brands: [Brand] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Get a list of brands whose name contains a given 'query' string """
+  """
+  Get a list of brands whose name contains a given 'query' string
+  """
   brandSearch(
-    """ String to be searched """
+    """
+    String to be searched
+    """
     query: String
   ): [Brand] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Get a list of collections whose name contains a given 'query' string """
+  """
+  Get a list of collections whose name contains a given 'query' string
+  """
   collectionSearch(
-    """ String to be searched """
+    """
+    String to be searched
+    """
     query: String
   ): [Collection] @cacheControl(scope: PRIVATE)
 
-  """ OrderForm simulation """
+  """
+  OrderForm simulation
+  """
   shipping(
-    """ List of SKU products """
-    items: [ShippingItem],
-    """ Postal code to freight calculator """
-    postalCode: String,
-    """ Country of postal code """
+    """
+    List of SKU products
+    """
+    items: [ShippingItem]
+    """
+    Postal code to freight calculator
+    """
+    postalCode: String
+    """
+    Country of postal code
+    """
     country: String
   ): ShippingData @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
-  """ Get checkout cart details """
+  """
+  Get checkout cart details
+  """
   orderForm: OrderForm @cacheControl(scope: PRIVATE)
 
-  """ Get user orders details """
+  """
+  Get user orders details
+  """
   orders: [Order] @cacheControl(scope: PRIVATE)
 
-    """ Get user order by id """
+  """
+   Get user order by id
+  """
   order(id: String!): Order @cacheControl(scope: PRIVATE)
 
-  """ Get user profile details """
+  """
+   Get user profile details
+  """
   profile(
-    """ Comma separated fields """
+    """
+    Comma separated fields
+    """
     customFields: String
   ): Profile @cacheControl(scope: PRIVATE) @withCurrentProfile
 
-  """ Get auto complete suggestions in search """
+  """
+  Get auto complete suggestions in search
+  """
   autocomplete(
-    """ Number of items that is returned """
-    maxRows: Int = 12,
-    """ Terms that is used in search e.g.: iphone """
+    """
+    Number of items that is returned
+    """
+    maxRows: Int = 12
+    """
+    Terms that is used in search e.g.: iphone
+    """
     searchTerm: String
   ): Suggestions @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
-  """ Search documents """
+  """
+  Search documents
+  """
   documents(
-    """ Schema name. e.g.: CL, AD"""
-    acronym: String,
-    """ Fields that will be returned by document. e.g.: _fields=email,firstName,document """
-    fields: [String],
-    """ Pagination. Default: 1 """
-    page: Int = 1,
-    """ Items returned in the page. Default: 15"""
-    pageSize: Int = 15,
-    """ Filters the results. eg.: _where=email=my@email.com """
+    """
+    Schema name. e.g.: CL, AD
+    """
+    acronym: String
+    """
+    Fields that will be returned by document. e.g.: _fields=email,firstName,document
+    """
+    fields: [String]
+    """
+    Pagination. Default: 1
+    """
+    page: Int = 1
+    """
+    Items returned in the page. Default: 15
+    """
+    pageSize: Int = 15
+    """
+    Filters the results. eg.: _where=email=my@email.com
+    """
     where: String
   ): [Document]
 
-  """ Get document """
+  """
+  Get document
+  """
   document(
-    """ Schema name. e.g.: CL, AD"""
-    acronym: String,
-    """ Fields that will be returned in document. e.g.: _fields=email,firstName,document """
-    fields: [String],
-    """ Document id """
+    """
+    Schema name. e.g.: CL, AD
+    """
+    acronym: String
+    """
+    Fields that will be returned in document. e.g.: _fields=email,firstName,document
+    """
+    fields: [String]
+    """
+    Document id
+    """
     id: String
   ): Document
 
-  """ Get the benefits associated with a list of products """
+  """
+  Get the benefits associated with a list of products
+  """
   benefits(
-    """ List of Products """
+    """
+    List of Products
+    """
     items: [ShippingItem]
   ): [Benefit] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
-  """ Get the options available to authenticate users """
+  """
+   Get the options available to authenticate users
+  """
   loginOptions: LoginOptions @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Get the IDs for the provided search context slugs """
+  """
+  Get the IDs for the provided search context slugs
+  """
   searchContextFromParams(
-    brand: String,
-    department: String,
-    category: String,
+    brand: String
+    department: String
+    category: String
     subcategory: String
   ): SearchContext
 
-  """ Get logistics information about the store """
+  """
+   Get logistics information about the store
+  """
   logistics: LogisticsData @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
-  """ Get a list of pickup points near specified lat and long """
+  """
+   Get a list of pickup points near specified lat and long
+  """
   nearPickupPoints(
-    """ Desired latitude coordinate, for example: -22.4321 """
-    lat: String!,
-    """ Desired longitude coordinate, for example: 44.10101 """
-    long: String!,
-    """ max distance of pickup points from given coordinates, in kilometers, default value 50  """
-    maxDistance: Int = 50,
+    """
+     Desired latitude coordinate, for example: -22.4321
+    """
+    lat: String!
+    """
+     Desired longitude coordinate, for example: 44.10101
+    """
+    long: String!
+    """
+     max distance of pickup points from given coordinates, in kilometers, default value 50
+    """
+    maxDistance: Int = 50
   ): NearPickupPointQueryResponse
 
-  """ Get pickup point by its id  """
+  """
+   Get pickup point by its id
+  """
   pickupPoint(id: String!): PickupPoint
 
-  """ Get profile information to session users """
+  """
+  Get profile information to session users
+  """
   getSession: Session @cacheControl(scope: PRIVATE)
 
-  """ Get the Wish List informations by the received id """
+  """
+   Get the Wish List informations by the received id
+  """
   list(
-    """ The list document id """
+    """
+    The list document id
+    """
     id: ID
   ): List
 
-  """ Get all lists from the received owner """
+  """
+  Get all lists from the received owner
+  """
   listsByOwner(
-    """ The list's owner id """
+    """
+    The list's owner id
+    """
     owner: ID!
-    """ The page that will be fetched """
+    """
+    The page that will be fetched
+    """
     page: Int = 1
-    """ The page size """
+    """
+    The page size
+    """
     pageSize: Int = 15
-  ) : [List]
+  ): [List]
 
-  """ Get logged in user's last order """
+  """
+  Get logged in user's last order
+  """
   userLastOrder: Order @cacheControl(scope: PRIVATE)
 }
 
 type Mutation {
-  """ Cart """
-  addItem(orderFormId: String, items: [OrderFormItemInput]): OrderForm @withSegment
+  """
+   Cart
+  """
+  addItem(orderFormId: String, items: [OrderFormItemInput]): OrderForm
+    @withSegment
   cancelOrder(orderFormId: String, reason: String): Boolean
-  updateItems(orderFormId: String, items: [OrderFormItemInput]): OrderForm @withSegment
+  updateItems(orderFormId: String, items: [OrderFormItemInput]): OrderForm
+    @withSegment
 
-  """ Profile """
-  updateProfile(fields: ProfileInput, customFields: [ProfileCustomFieldInput]): Profile @withCurrentProfile
+  """
+   Profile
+  """
+  updateProfile(
+    fields: ProfileInput
+    customFields: [ProfileCustomFieldInput]
+  ): Profile @withCurrentProfile
   updateAddress(id: String, fields: AddressInput): Profile @withCurrentProfile
   createAddress(fields: AddressInput): Profile @withCurrentProfile
   deleteAddress(id: String): Profile @withCurrentProfile
 
-  """ Updates the Profile Picture by erasing the old ones """
+  """
+  Updates the Profile Picture by erasing the old ones
+  """
   updateProfilePicture(
-    """ File being uploaded """
-    file: Upload!,
-    """ Attachment's field name (default: profilePicture) """
+    """
+     File being uploaded
+    """
+    file: Upload!
+    """
+     Attachment's field name (default: profilePicture)
+    """
     field: String @deprecated
   ): Profile @withCurrentProfile
-  """ Uploads the Profile Picture by appending to the existing ones DEPRECATED"""
+  """
+   Uploads the Profile Picture by appending to the existing ones DEPRECATED
+  """
   uploadProfilePicture(
-    """ File being uploaded """
-    file: Upload!,
-    """ Attachment's field name (default: profilePicture) """
+    """
+    File being uploaded
+    """
+    file: Upload!
+    """
+    Attachment's field name (default: profilePicture)
+    """
     field: String
   ): Profile @withCurrentProfile @deprecated
 
-  """ Subscribe to newsletter """
+  """
+   Subscribe to newsletter
+  """
   subscribeNewsletter(email: String): Boolean
 
-  """ Order Form """
-  updateOrderFormProfile(orderFormId: String, fields: OrderFormProfileInput): OrderForm
-  updateOrderFormShipping(orderFormId: String, address: OrderFormAddressInput): OrderForm
-  updateOrderFormPayment(orderFormId: String,  payments: [OrderFormPaymentInput]): OrderForm
-  updateOrderFormIgnoreProfile(orderFormId: String, ignoreProfileData: Boolean): OrderForm
-  addOrderFormPaymentToken(orderFormId: String, paymentToken: OrderFormPaymentTokenInput): OrderForm
-  setOrderFormCustomData(orderFormId: String, appId: String, field: String, value: String): OrderForm
-  addAssemblyOptions(orderFormId: String, itemId: String, assemblyOptionsId: String, options: [AssemblyOptionInput]): OrderForm
-  updateOrderFormCheckin(orderFormId: String, checkin: OrderFormCheckinInput): OrderForm
+  """
+   Order Form
+  """
+  updateOrderFormProfile(
+    orderFormId: String
+    fields: OrderFormProfileInput
+  ): OrderForm
+  updateOrderFormShipping(
+    orderFormId: String
+    address: OrderFormAddressInput
+  ): OrderForm
+  updateOrderFormPayment(
+    orderFormId: String
+    payments: [OrderFormPaymentInput]
+  ): OrderForm
+  updateOrderFormIgnoreProfile(
+    orderFormId: String
+    ignoreProfileData: Boolean
+  ): OrderForm
+  addOrderFormPaymentToken(
+    orderFormId: String
+    paymentToken: OrderFormPaymentTokenInput
+  ): OrderForm
+  setOrderFormCustomData(
+    orderFormId: String
+    appId: String
+    field: String
+    value: String
+  ): OrderForm
+  addAssemblyOptions(
+    orderFormId: String
+    itemId: String
+    assemblyOptionsId: String
+    options: [AssemblyOptionInput]
+  ): OrderForm
+  updateOrderFormCheckin(
+    orderFormId: String
+    checkin: OrderFormCheckinInput
+  ): OrderForm
 
-  """ Payment """
+  """
+  Payment
+  """
   createPaymentSession: PaymentSession
-  createPaymentTokens(sessionId: String, payments: [PaymentInput]): [PaymentToken]
+  createPaymentTokens(
+    sessionId: String
+    payments: [PaymentInput]
+  ): [PaymentToken]
   setPlaceholder(fields: PlaceholderInput): Boolean
 
-  """ Send access key to user email """
+  """
+  Send access key to user email
+  """
   sendEmailVerification(
-    """ User email"""
+    """
+    User email
+    """
     email: String!
   ): Boolean
 
-  """ Access key sign in mode """
+  """
+  Access key sign in mode
+  """
   accessKeySignIn(
-    """ User email """
-    email: String!,
-    """ Access key that was received """
+    """
+    User email
+    """
+    email: String!
+    """
+    Access key that was received
+    """
     code: String!
   ): String
 
-  """ Classic sign in mode """
+  """
+  Classic sign in mode
+  """
   classicSignIn(
-    """ User email """
-    email: String!,
-    """ User password """
+    """
+    User email
+    """
+    email: String!
+    """
+    User password
+    """
     password: String!
   ): String
 
-  """ OAuth to login with Social Account """
+  """
+  OAuth to login with Social Account
+  """
   oAuth(
-    """ The OAuth Provider, e.g: Google, Facebook """
-    provider: String,
-    """ The URL to be redirected after authentication """
+    """
+    The OAuth Provider, e.g: Google, Facebook
+    """
+    provider: String
+    """
+    The URL to be redirected after authentication
+    """
     redirectUrl: String
   ): String
 
-  """ To recovery password you need to get your email, password and access code """
+  """
+  To recovery password you need to get your email, password and access code
+  """
   recoveryPassword(
-    """ User email """
-    email: String!,
-    """ User password """
-    newPassword: String!,
-    """ Access Code """
+    """
+    User email
+    """
+    email: String!
+    """
+    User password
+    """
+    newPassword: String!
+    """
+    Access Code
+    """
     code: String!
-    ): String
+  ): String
 
-  """ Change password using email and old password """
+  """
+  Change password using email and old password
+  """
   redefinePassword(
-    """ User's email """
-    email: String!,
-    """ User's current password """
-    currentPassword: String!,
-    """ User's new password """
-    newPassword: String!,
-    """ Your app's identification to help VTEX ID track requests """
+    """
+    User's email
+    """
+    email: String!
+    """
+    User's current password
+    """
+    currentPassword: String!
+    """
+    User's new password
+    """
+    newPassword: String!
+    """
+    Your app's identification to help VTEX ID track requests
+    """
     vtexIdVersion: String
   ): String
 
-  """ Invalidate VtexIdclientAutCookie """
+  """
+  Invalidate VtexIdclientAutCookie
+  """
   logout: Boolean
 
-  """ Impersonate a customer """
+  """
+  Impersonate a customer
+  """
   impersonate(
-    """ The email which will be used to impersonate a user """
-    email: String!,
+    """
+    The email which will be used to impersonate a user
+    """
+    email: String!
   ): Session
 
-  """ Depersonify a customer """
+  """
+  Depersonify a customer
+  """
   depersonify: Boolean
 
-  """ Document """
+  """
+  Document
+  """
   createDocument(acronym: String!, document: DocumentInput): DocumentResponse
   updateDocument(acronym: String!, document: DocumentInput): DocumentResponse
   deleteDocument(acronym: String!, documentId: String!): DocumentResponse
-  uploadAttachment(acronym: String!, documentId: String!, field: String!, file: Upload!): AttachmentResponse
+  uploadAttachment(
+    acronym: String!
+    documentId: String!
+    field: String!
+    file: Upload!
+  ): AttachmentResponse
 
-  """ List """
+  """
+   List
+  """
   createList(list: ListInput): List
-   """ Update the list informations and its items.
-   If the item given does not have the itemId, add it as a new item in the list.
-   If the item given has got an itemId, but its quantity is 0, remove it from the list.
-   Otherwise, update it. """
+  """
+   Update the list informations and its items.
+  If the item given does not have the itemId, add it as a new item in the list.
+  If the item given has got an itemId, but its quantity is 0, remove it from the list.
+  Otherwise, update it.
+  """
   updateList(id: ID!, list: ListInput): List
   deleteList(id: ID!): List
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -77,6 +77,18 @@ type Query {
     treeLevel: Int = 3
   ): [Category] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
+  """ Get a list of categories (of level 1) whose name contains a given 'query' string"""
+  categorySearch(
+    """ String to be searched """
+    query: String
+  ): [Category] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
+
+  """ Get a list of departments (level 0 categories) whose name contains a given 'query' string """
+  departmentSearch(
+    """ String to be searched """
+    query: String
+  ): [Category] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
+
   """ Get brand details """
   brand(
     """ Brand id """
@@ -85,6 +97,18 @@ type Query {
 
   """ Get a list of brands """
   brands: [Brand] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
+
+  """ Get a list of brands whose name contains a given 'query' string """
+  brandSearch(
+    """ String to be searched """
+    query: String
+  ): [Brand] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
+
+  """ Get a list of collections whose name contains a given 'query' string """
+  collectionSearch(
+    """ String to be searched """
+    query: String
+  ): [Collection] @cacheControl(scope: PRIVATE)
 
   """ OrderForm simulation """
   shipping(

--- a/graphql/types/Collection.graphql
+++ b/graphql/types/Collection.graphql
@@ -1,0 +1,26 @@
+type Collection {
+  """
+  Collection name
+  """
+  name: String
+  """
+  Collection ID
+  """
+  id: Int
+  """
+  Is it possible to search the products of this collection using collection ID?
+  """
+  searchable: Boolean
+  """
+  Flag to indicate the products of this collection are special
+  """
+  highlight: Boolean
+  """
+  Date from which one can search products by collection id
+  """
+  dateFrom: String
+  """
+  Date until which one can search products by collection id
+  """
+  dateTo: String
+}

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -99,9 +99,7 @@ export class CatalogDataSource extends IODataSource {
     const clientAuth = cookies.get('VtexIdclientAutCookie')
     /* TODO: use this.context.vtex.region in getting these data */
     const { data } = await http.get(
-      `http://${account}.vtexcommercestable.com.br/api/catalog_system${this.collectionsUrl(
-        query
-      )}`,
+      `http://${account}.vtexcommercestable.com.br/api/catalog_system/pvt/collection/search/${query}?pageSize=50`,
       {
         headers: {
           'Proxy-Authorization': authToken,
@@ -163,9 +161,6 @@ export class CatalogDataSource extends IODataSource {
 
     return this.http.getRaw<T>(`/proxy/catalog${url}`, config)
   }
-
-  private collectionsUrl = (query: string) =>
-    `/pvt/collection/search/${query}?pageSize=50`
 
   private productSearchUrl = ({
     query = '',

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -80,10 +80,35 @@ export class CatalogDataSource extends IODataSource {
     {metric: 'catalog-brands'}
   )
 
+  public brandSearch = (query: string = '') => this.get(
+    `/pub/brand/list/${query}`
+  )
+
   public categories = (treeLevel: number) => this.get(
     `/pub/category/tree/${treeLevel}/`,
     {metric: 'catalog-categories'}
   )
+
+  public categorySearch = (query: string = '', parentId: string = '') => this.get(
+    `/pub/category/list?filter=${query}&parent=${parentId}`
+  )
+
+  public collectionSearch = async (query: string = '') => {
+    const { vtex: { authToken, account, workspace }, cookies } = this.context
+    const clientAuth = cookies.get('VtexIdclientAutCookie')
+    /* TODO: use this.context.vtex.region in getting these data */
+    const { data } = await http.get(
+      `http://${workspace}--${account}.vtexcommercestable.com.br/api/catalog_system${this.collectionsUrl(query)}`,
+      {
+        headers: {
+          'Proxy-Authorization': authToken,
+          'VtexIdclientAutCookie': clientAuth,
+        }
+      }
+    )
+
+    return data
+  }
 
   public facets = (facets: string = '') => {
     const [path, options] = decodeURI(facets).split('?')
@@ -135,6 +160,8 @@ export class CatalogDataSource extends IODataSource {
 
     return this.http.getRaw<T>(`/proxy/catalog${url}`, config)
   }
+
+  private collectionsUrl = (query: string) => `/pvt/collection/search/${query}?pageSize=50`
 
   private productSearchUrl = ({
     query = '',

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -99,7 +99,7 @@ export class CatalogDataSource extends IODataSource {
     const clientAuth = cookies.get('VtexIdclientAutCookie')
     /* TODO: use this.context.vtex.region in getting these data */
     const { data } = await http.get(
-      `http://${workspace}--${account}.vtexcommercestable.com.br/api/catalog_system${this.collectionsUrl(
+      `http://${account}.vtexcommercestable.com.br/api/catalog_system${this.collectionsUrl(
         query
       )}`,
       {
@@ -110,7 +110,7 @@ export class CatalogDataSource extends IODataSource {
       }
     )
 
-    return data
+    return data.items
   }
 
   public facets = (facets: string = '') => {

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -170,25 +170,60 @@ export class CatalogDataSource extends IODataSource {
   private productSearchUrl = ({
     query = '',
     category = '',
-    specificationFilters,
+    specificationFilters = [],
     priceRange = '',
     collection = '',
     salesChannel = '',
     orderBy = '',
     from = 0,
     to = 9,
-    map = ''
+    map = '',
   }: ProductsArgs) => {
+    const BASE_URL = '/pub/products/search/'
+
     const sanitizedQuery = encodeURIComponent(decodeURIComponent(query).trim())
-    return `/pub/products/search/${sanitizedQuery}?${category &&
-      !query &&
-      `&fq=C:/${category}/`}${(specificationFilters &&
-      specificationFilters.length > 0 &&
-      specificationFilters.map(filter => `&fq=${filter}`)) ||
-      ''}${priceRange && `&fq=P:[${priceRange}]`}${collection &&
-      `&fq=productClusterIds:${collection}`}${salesChannel &&
-      `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy &&
-      `&O=${orderBy}`}${map && `&map=${map}`}${from > -1 &&
-      `&_from=${from}`}${to > -1 && `&_to=${to}`}`
+
+    let queryString = '?'
+
+    if (category && !query) {
+      queryString += `fq=C:/${category}/&`
+    }
+
+    queryString += specificationFilters.reduce(
+      (acc, currFilter) => acc + `fq=${currFilter}&`,
+      ''
+    )
+
+    if (priceRange) {
+      queryString += `fq=P:[${priceRange}]&`
+    }
+
+    if (collection) {
+      queryString += `fq=productClusterIds:${collection}&`
+    }
+
+    if (salesChannel) {
+      queryString += `fq=isAvailablePerSalesChannel_${salesChannel}:1&`
+    }
+
+    if (orderBy) {
+      queryString += `O=${orderBy}&`
+    }
+
+    if (map) {
+      queryString += `map=${map}&`
+    }
+
+    if (from > -1) {
+      queryString += `_from=${from}&`
+    }
+
+    if (to > -1) {
+      queryString += `_to=${to}&`
+    }
+
+    queryString = queryString.slice(0, queryString.length - 1)
+
+    return `${BASE_URL}${sanitizedQuery}${queryString}`
   }
 }

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -80,29 +80,32 @@ export class CatalogDataSource extends IODataSource {
     {metric: 'catalog-brands'}
   )
 
-  public brandSearch = (query: string = '') => this.get(
-    `/pub/brand/list/${query}`
-  )
+  public brandSearch = (query: string = '') =>
+    this.get(`/pub/brand/list/${query}`)
 
   public categories = (treeLevel: number) => this.get(
     `/pub/category/tree/${treeLevel}/`,
     {metric: 'catalog-categories'}
   )
 
-  public categorySearch = (query: string = '', parentId: string = '') => this.get(
-    `/pub/category/list?filter=${query}&parent=${parentId}`
-  )
+  public categorySearch = (query: string = '', parentId: string = '') =>
+    this.get(`/pub/category/list?filter=${query}&parent=${parentId}`)
 
   public collectionSearch = async (query: string = '') => {
-    const { vtex: { authToken, account, workspace }, cookies } = this.context
+    const {
+      vtex: { authToken, account, workspace },
+      cookies
+    } = this.context
     const clientAuth = cookies.get('VtexIdclientAutCookie')
     /* TODO: use this.context.vtex.region in getting these data */
     const { data } = await http.get(
-      `http://${workspace}--${account}.vtexcommercestable.com.br/api/catalog_system${this.collectionsUrl(query)}`,
+      `http://${workspace}--${account}.vtexcommercestable.com.br/api/catalog_system${this.collectionsUrl(
+        query
+      )}`,
       {
         headers: {
           'Proxy-Authorization': authToken,
-          'VtexIdclientAutCookie': clientAuth,
+          VtexIdclientAutCookie: clientAuth
         }
       }
     )
@@ -161,7 +164,8 @@ export class CatalogDataSource extends IODataSource {
     return this.http.getRaw<T>(`/proxy/catalog${url}`, config)
   }
 
-  private collectionsUrl = (query: string) => `/pvt/collection/search/${query}?pageSize=50`
+  private collectionsUrl = (query: string) =>
+    `/pvt/collection/search/${query}?pageSize=50`
 
   private productSearchUrl = ({
     query = '',
@@ -176,8 +180,15 @@ export class CatalogDataSource extends IODataSource {
     map = ''
   }: ProductsArgs) => {
     const sanitizedQuery = encodeURIComponent(decodeURIComponent(query).trim())
-    return (
-      `/pub/products/search/${sanitizedQuery}?${category && !query && `&fq=C:/${category}/`}${(specificationFilters && specificationFilters.length > 0 && specificationFilters.map(filter => `&fq=${filter}`)) || ''}${priceRange && `&fq=P:[${priceRange}]`}${collection && `&fq=productClusterIds:${collection}`}${salesChannel && `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy && `&O=${orderBy}`}${map && `&map=${map}`}${from > -1 && `&_from=${from}`}${to > -1 && `&_to=${to}`}`
-    )
+    return `/pub/products/search/${sanitizedQuery}?${category &&
+      !query &&
+      `&fq=C:/${category}/`}${(specificationFilters &&
+      specificationFilters.length > 0 &&
+      specificationFilters.map(filter => `&fq=${filter}`)) ||
+      ''}${priceRange && `&fq=P:[${priceRange}]`}${collection &&
+      `&fq=productClusterIds:${collection}`}${salesChannel &&
+      `&fq=isAvailablePerSalesChannel_${salesChannel}:1`}${orderBy &&
+      `&O=${orderBy}`}${map && `&map=${map}`}${from > -1 &&
+      `&_from=${from}`}${to > -1 && `&_to=${to}`}`
   }
 }

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -376,14 +376,6 @@ interface Brand {
   metaTagDescription: string
 }
 
-interface Brand {
-  id: string
-  name: string
-  isActive: boolean
-  title: string
-  metaTagDescription: string
-}
-
 interface Category {
   id: string
   name: string

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -216,11 +216,11 @@ export const queries = {
   brands: async (_: any, __: any, { dataSources: { catalog } }: Context) =>
     catalog.brands(),
 
-  brandSearch: async (
+  brandSearch: (
     _: any,
     { query }: any,
     { dataSources: { catalog } }: Context
-  ) => catalog.brandSearch(query) as Promise<Brand[]>,
+  ): Promise<Brand[]> => catalog.brandSearch(query),
 
   category: async (
     _: any,
@@ -252,23 +252,17 @@ export const queries = {
     return categories
   },
 
-  collectionSearch: async (
+  collectionSearch: (
     _: any,
     { query }: any,
     { dataSources: { catalog } }: Context
-  ) => {
-    const data = await catalog.collectionSearch(query)
+  ): Promise<Collection[]> => catalog.collectionSearch(query),
 
-    const collections = data.items
-
-    return collections
-  },
-
-  departmentSearch: async (
+  departmentSearch: (
     _: any,
     { query }: any,
     { dataSources: { catalog } }: Context
-  ) => catalog.categorySearch(query),
+  ): Promise<Category[]> => catalog.categorySearch(query),
 
   search: async (_: any, args: any, ctx: Context) => {
     const { map: mapParams, query } = args
@@ -382,9 +376,29 @@ interface Brand {
   metaTagDescription: string
 }
 
+interface Brand {
+  id: string
+  name: string
+  isActive: boolean
+  title: string
+  metaTagDescription: string
+}
+
 interface Category {
   id: string
   name: string
   url: string
   children: Category[]
+  hasChildren: boolean
+  Title: string
+  MetaTagDescription: string
+}
+
+interface Collection {
+  id: number
+  name: string
+  searchable: boolean
+  highlight: boolean
+  dateFrom: string
+  dateTo: string
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Now one can search brands, collections, departments (level 0 categories) and categories (level 1 categories)

#### What problem is this solving?

Now one can search brands, collections, departments (level 0 categories) and categories (level 1 categories)

#### How should this be manually tested?

You can download this branch, link it, open GraphiQL and play with it

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
