### PR TITLE
Using IODataSource instead of buggy Apollo DatasSourceREST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.49.1] - 2019-02-22
 ### Fixed
 - Fixes `Unexpected end of JSON input` errors in payments data source
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixes `Unexpected end of JSON input` errors in payments data source
 
 ## [2.49.0] - 2019-02-19
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.49.0",
+  "version": "2.49.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.store-graphql",
   "dependencies": {
     "@gocommerce/utils": "^0.5.26",
-    "@vtex/api": "^1.5.2",
+    "@vtex/api": "1.8.2-beta",
     "apollo-datasource-rest": "^0.1.5",
     "apollo-server-errors": "^2.0.2",
     "axios": "0.16.2",

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.store-graphql",
   "dependencies": {
     "@gocommerce/utils": "^0.5.26",
-    "@vtex/api": "1.8.2-beta",
+    "@vtex/api": "^1.8.2",
     "apollo-datasource-rest": "^0.1.5",
     "apollo-server-errors": "^2.0.2",
     "axios": "0.16.2",

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -15,7 +15,8 @@
     "module": "commonjs",
     "sourceMap": false,
     "outDir": "service",
-    "allowJs": true
+    "allowJs": true,
+    "skipLibCheck": true
   },
   "typeAcquisition": {
     "enable": false

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -1,4 +1,5 @@
 import { IOContext, ServiceContext } from '@vtex/api'
+import { DataSource } from 'apollo-datasource'
 
 import { dataSources } from './dataSources'
 import { CallcenterOperatorDataSource } from './dataSources/callcenterOperator'
@@ -25,7 +26,7 @@ declare global {
     currentProfile: CurrentProfile
   }
 
-  interface StoreGraphQLDataSources {
+  interface StoreGraphQLDataSources extends Record<string, DataSource> {
     catalog: CatalogDataSource
     checkout: CheckoutDataSource
     document: DocumentDataSource

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -107,6 +107,11 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/graphql@^14.0.4":
+  version "14.0.7"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.7.tgz#daa09397220a68ce1cbb3f76a315ff3cd92312f6"
+  integrity sha512-BoLDjdvLQsXPZLJux3lEZANwGr3Xag56Ngy0U3y8uoRSDdeLcn43H3oBcgZlnd++iOQElBpaRVDHPzEDekyvXQ==
+
 "@types/graphql@^14.0.5":
   version "14.0.5"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.5.tgz#e696292fd2d77dc168b5b791710f83463aa39abd"
@@ -179,10 +184,12 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@^1.5.2":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.5.2.tgz#c33196c59ed3b7e5cd5694ec9e67754b325cb425"
+"@vtex/api@1.8.2-beta":
+  version "1.8.2-beta"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.8.2-beta.tgz#e6c384f997b35355cc869b9e467092df95ff53dd"
+  integrity sha512-4YzBrfRRwVZZPu3ssUvcicrIx0Nc7ZmC5JywAO2o/GBzvX/gzNTjEQIIRTDfPPMI/eaKDSMfgXPs/ncJL3zEAg==
   dependencies:
+    "@types/graphql" "^14.0.4"
     "@types/lru-cache" "^4.1.1"
     "@types/p-queue" "^2.3.1"
     "@types/ramda" "^0.25.38"
@@ -191,6 +198,8 @@
     axios "^0.18.0"
     axios-retry "^3.0.3"
     fs-extra "^7.0.0"
+    graphql "^14.0.2"
+    graphql-tools "^4.0.3"
     json-stringify-safe "^5.0.1"
     koa-compose "^4.1.0"
     lru-cache "^4.1.3"
@@ -198,6 +207,7 @@
     multipart-stream "^2.0.1"
     p-queue "^3.0.0"
     qs "^6.5.1"
+    querystring "^0.2.0"
     ramda "^0.25.0"
     rwlock "^5.0.0"
     semver "^5.5.1"
@@ -1656,6 +1666,17 @@ graphql-tools@^4.0.2:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
+graphql-tools@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.4.tgz#ca08a63454221fdde825fe45fbd315eb2a6d566b"
+  integrity sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==
+  dependencies:
+    apollo-link "^1.2.3"
+    apollo-utilities "^1.0.1"
+    deprecated-decorator "^0.1.6"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
+
 graphql@^14.0.2:
   version "14.0.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
@@ -2432,6 +2453,11 @@ qs@^6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
+querystring@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
 querystringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
@@ -2721,7 +2747,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2747,7 +2747,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -184,10 +184,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@1.8.2-beta":
-  version "1.8.2-beta"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.8.2-beta.tgz#e6c384f997b35355cc869b9e467092df95ff53dd"
-  integrity sha512-4YzBrfRRwVZZPu3ssUvcicrIx0Nc7ZmC5JywAO2o/GBzvX/gzNTjEQIIRTDfPPMI/eaKDSMfgXPs/ncJL3zEAg==
+"@vtex/api@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.8.2.tgz#cff82603c7aaf0dbbdfc421d9f458da60aff44f2"
+  integrity sha512-K6abemfSU2QJ1ZTN0atjYSkciaDsa3R8AV0RhoTh3CoYy6sY/euXmI2OtEx9WWubZHSENTSPEennoaxn4r+GVA==
   dependencies:
     "@types/graphql" "^14.0.4"
     "@types/lru-cache" "^4.1.1"


### PR DESCRIPTION
#### What is the purpose of this pull request?
We were having lots of errors like this one in `PaymentsDataSource`: 
```
invalid json response body
reason: Unexpected end of JSON input
```

This error happens because `profile-system` responds a 200 status code for an empty body with the header `Content-Type: application/json` set. ApolloDataSourceREST uses `node-fetch` behind the scenes. When `node-fetch` receives a `Content-Type: application/json` with a 200 status code, it blindly tries to `JSON.parse` the body, causing the error.

To fix this issue and also align to our vision of using only one DataSources library, I created this PR that uses IODataSoure instead of the Apollo DatasSourceREST. Since IODataSoure uses `axios` for the http client, the main issue is gone for now.

However, when I was developing this PR, I found this [bug](https://github.com/vtex/node-vtex-api/pull/87) in node-vtex-api that need to be solved before releasing this patch

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
