### PR TITLE
Sales channel checkout calatalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Adds `?sc` parameter to checkout and catalog dataSources when sales channel is available. Note that sales channel availability depends if the root field resolver has a `@cacheControl(scope: SEGMENT)` AND `@withSegment` directives
+- get order by id query
 
 ## [2.52.1] - 2019-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Adds `?sc` parameter to checkout and catalog dataSources when sales channel is available. Note that sales channel availability depends if the root field resolver has a `@cacheControl(scope: SEGMENT)` AND `@withSegment` directives
 
 ## [2.52.1] - 2019-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.53.0] - 2019-03-07
 ### Added
 - Adds `?sc` parameter to checkout and catalog dataSources when sales channel is available. Note that sales channel availability depends if the root field resolver has a `@cacheControl(scope: SEGMENT)` AND `@withSegment` directives
 - get order by id query

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -5,7 +5,7 @@ type Query {
   product(
     """ Product slug """
     slug: String
-  ): Product @cacheControl(scope: SEGMENT, maxAge: SHORT)
+  ): Product @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   """ Product search filtered and ordered """
   products(
@@ -29,13 +29,13 @@ type Query {
     from: Int = 0,
     """ Pagination item end """
     to: Int = 9
-  ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT)
+  ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   """ Get facets category """
   facets(
     """ Categories separated by / followed by map. e.g.:  /eletronics/tvs?map=c,c """
     facets: String = ""
-  ): Facets @cacheControl(scope: SEGMENT)
+  ): Facets @cacheControl(scope: SEGMENT) @withSegment
 
   """ Search for products. e.g.: search(query: 'eletronics', rest: 'lg', map: 'c,b') """
   search(
@@ -61,7 +61,7 @@ type Query {
     from: Int = 0,
     """ Pagination item end """
     to: Int = 9
-  ): Search @cacheControl(scope: SEGMENT, maxAge: SHORT)
+  ): Search @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   """ Get category details """
   category(
@@ -92,7 +92,7 @@ type Query {
     postalCode: String,
     """ Country of postal code """
     country: String
-  ): ShippingData
+  ): ShippingData @cacheControl(scope: SEGMENT) @withSegment
 
   """ Get checkout cart details """
   orderForm: OrderForm @cacheControl(scope: PRIVATE)
@@ -112,7 +112,7 @@ type Query {
     maxRows: Int = 12,
     """ Terms that is used in search e.g.: iphone """
     searchTerm: String
-  ): Suggestions @cacheControl(scope: SEGMENT, maxAge: LONG)
+  ): Suggestions @cacheControl(scope: SEGMENT, maxAge: LONG) @withSegment
 
   """ Search documents """
   documents(
@@ -142,7 +142,7 @@ type Query {
   benefits(
     """ List of Products """
     items: [ShippingItem]
-  ): [Benefit]
+  ): [Benefit] @cacheControl(scope: SEGMENT) @withSegment
 
   """ Get the options available to authenticate users """
   loginOptions: LoginOptions
@@ -222,9 +222,9 @@ type Query {
 
 type Mutation {
   """ Cart """
-  addItem(orderFormId: String, items: [OrderFormItemInput]): OrderForm
+  addItem(orderFormId: String, items: [OrderFormItemInput]): OrderForm @withSegment
   cancelOrder(orderFormId: String, reason: String): Boolean
-  updateItems(orderFormId: String, items: [OrderFormItemInput]): OrderForm
+  updateItems(orderFormId: String, items: [OrderFormItemInput]): OrderForm @withSegment
 
   """ Profile """
   updateProfile(fields: ProfileInput, customFields: [ProfileCustomFieldInput!]): Profile @withCurrentProfile

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -100,6 +100,9 @@ type Query {
   """ Get user orders details """
   orders: [Order] @cacheControl(scope: PRIVATE)
 
+    """ Get user order by id """
+  order(id: String!): Order @cacheControl(scope: PRIVATE)
+
   """ Get user profile details """
   profile(
     """ Comma separated fields """

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -43,6 +43,7 @@ type OrderItem {
   unitMultiplier: Int
   parentItemIndex: Int
   parentAssemblyBinding: String
+  bundleItems: [OrderItem]
 }
 
 type OrderItemAdditionalInfo {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.52.1",
+  "version": "2.53.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -3,6 +3,7 @@ import http from 'axios'
 import { forEachObjIndexed } from 'ramda'
 
 import { withAuthToken } from '../resolvers/headers'
+import { SegmentData } from './session'
 
 const DEFAULT_TIMEOUT_MS = 8 * 1000
 
@@ -96,6 +97,8 @@ export class CatalogDataSource extends RESTDataSource<Context> {
 
   protected willSendRequest (request: RequestOptions) {
     const {vtex: {authToken, production}, cookies} = this.context
+    const segmentData: SegmentData | null = (this.context.vtex as any).segment
+    const { channel: salesChannel = '' } = segmentData || {}
     const segment = cookies.get('vtex_segment')
     const [appMajorNumber] = process.env.VTEX_APP_VERSION.split('.')
     const appMajor = `${appMajorNumber}.x`
@@ -110,6 +113,7 @@ export class CatalogDataSource extends RESTDataSource<Context> {
         '__v': appMajor,
         'production': production ? 'true' : 'false',
         ...segment && {'vtex_segment': segment},
+        ...!!salesChannel && {sc: salesChannel}
       }
     )
 

--- a/node/dataSources/checkout.ts
+++ b/node/dataSources/checkout.ts
@@ -1,6 +1,8 @@
 import { Request, RequestOptions, Response, RESTDataSource } from 'apollo-datasource-rest'
 import { forEachObjIndexed } from 'ramda'
 
+import { SegmentData } from './session'
+
 const DEFAULT_TIMEOUT_MS = 4 * 1000
 
 export interface SimulationData {
@@ -88,13 +90,13 @@ export class CheckoutDataSource extends RESTDataSource<Context> {
     `/pub/orderForm/${orderFormId}/attachments/marketingData`,
     marketingData,
   )
-  
-  public addAssemblyOptions = async (orderFormId: string, itemId: string, assemblyOptionsId: string, body) => 
+
+  public addAssemblyOptions = async (orderFormId: string, itemId: string, assemblyOptionsId: string, body) =>
     this.post(
-      `pub/orderForm/${orderFormId}/items/${itemId}/assemblyOptions/${assemblyOptionsId}`, 
+      `pub/orderForm/${orderFormId}/items/${itemId}/assemblyOptions/${assemblyOptionsId}`,
       body
     )
-  
+
   public removeAssemblyOptions = async (orderFormId: string, itemId: string, assemblyOptionsId: string, body) =>
     this.delete(
       `pub/orderForm/${orderFormId}/items/${itemId}/assemblyOptions/${assemblyOptionsId}`,
@@ -144,9 +146,15 @@ export class CheckoutDataSource extends RESTDataSource<Context> {
 
   protected willSendRequest (request: RequestOptions) {
     const {vtex: {account, authToken}, headers} = this.context
+    const segmentData: SegmentData | null = (this.context.vtex as any).segment
+    const { channel: salesChannel = '' } = segmentData || {}
 
     if (!request.timeout) {
       request.timeout = DEFAULT_TIMEOUT_MS
+    }
+
+    if (!!salesChannel) {
+      request.params.set('sc', salesChannel)
     }
 
     forEachObjIndexed(

--- a/node/dataSources/oms.ts
+++ b/node/dataSources/oms.ts
@@ -6,6 +6,8 @@ const DEFAULT_TIMEOUT_MS = 4 * 1000
 export class OMSDataSource extends RESTDataSource<Context> {
   public userLastOrder = () => this.get('user/orders/last')
 
+  public order = (id: string) => this.get(`/pvt/orders/${id}`)
+
   get baseURL() {
     const { vtex: { account } } = this.context
     return `http://${account}.vtexcommercestable.com.br/api/oms`

--- a/node/directives/index.ts
+++ b/node/directives/index.ts
@@ -1,7 +1,7 @@
-import { Response } from './response'
 import { WithCurrentProfile } from './withCurrentProfile'
+import { WithSegment } from './withSegment'
 
 export const schemaDirectives = {
-  response: Response,
-  withCurrentProfile: WithCurrentProfile
+  withCurrentProfile: WithCurrentProfile,
+  withSegment: WithSegment,
 }

--- a/node/directives/withSegment.ts
+++ b/node/directives/withSegment.ts
@@ -1,14 +1,12 @@
 import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 
-export class Response extends SchemaDirectiveVisitor {
+export class WithSegment extends SchemaDirectiveVisitor {
   public visitFieldDefinition (field: GraphQLField<any, any>) {
     const {resolve = defaultFieldResolver} = field
     field.resolve = async (root, args, ctx, info) => {
-      const {vary = null} = this.args || {}
-      if (typeof vary === 'string') {
-        ctx.vary(vary)
-      }
+      const {dataSources: {session}, vtex: {segmentToken}} = ctx
+      ctx.vtex.segment = !!segmentToken ? await session.getSegmentData() : undefined
       return resolve(root, args, ctx, info)
     }
   }

--- a/node/resolvers/oms/index.ts
+++ b/node/resolvers/oms/index.ts
@@ -4,5 +4,7 @@ export const queries = {
   userLastOrder: (_, __, ctx) => {
     const { dataSources: { oms } } = ctx
     return isUserLoggedIn(ctx) ? oms.userLastOrder() : null
-  }
+  },
+
+  order: (_, {id}: {id: string}, {dataSources: {oms}}: Context) => oms.order(id)
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds the withSegment directive resolver that opens the incoming segment request. With the segment oppened, we can use the sales channel while querying checkout and catalog APIs

> Note: This was an "extreme go horse" feature and requires further testing

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
