### PR TITLE
Fix Document.updateDocument call in updateDocument resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.56.1] - 2019-03-13
 - Fix the Document.updateDocument call the in updateDocument resolver.
 
 ## [2.56.0] - 2019-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Fix the Document.updateDocument call the in updateDocument resolver.
+- Fix the Document.updateDocument call the in updateDocument resolver.
 
 ## [2.56.0] - 2019-03-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+Fix the Document.updateDocument call the in updateDocument resolver.
 
 ## [2.56.0] - 2019-03-12
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.56.1-beta.0",
+  "version": "2.56.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.56.0",
+  "version": "2.56.1-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -1,4 +1,4 @@
-import { union } from 'ramda'
+import { compose, fromPairs, map, union } from 'ramda'
 import { mapKeyValues } from '../../utils/object'
 
 export const queries = {
@@ -29,7 +29,11 @@ export const mutations = {
 
   updateDocument: async (_, args, { dataSources: { document } }) => {
     const { acronym, document: { fields } } = args
-    const { Id, Href, DocumentId } = await document.updateDocument(acronym, fields)
+    const id = compose<any[], any[], any>(
+      fromPairs,
+      map(({key, value}) => [key, value]),
+    )(fields).id
+    const { Id, Href, DocumentId } = await document.updateDocument(acronym, id, fields)
     return { cacheId: DocumentId, id: Id, href: Href, documentId: DocumentId }
   },
 


### PR DESCRIPTION
This PR proposes a fix to the `updateDocument` resolver which seems to be passing wrong arguments to `Document.updateDocument`.


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
