### PR TITLE
fix parsing empty cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error `argument str must be a string`	in orderForm resolver
 
 ## [2.57.2] - 2019-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.57.3] - 2019-03-13
+
 ## [2.57.2] - 2019-03-13
 ### Fixed
 - Error `argument str must be a string`	in orderForm resolver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.57.2] - 2019-03-13
 ### Fixed
 - Error `argument str must be a string`	in orderForm resolver
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.57.2",
+  "version": "2.57.3",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/checkout/sessionManager.ts
+++ b/node/resolvers/checkout/sessionManager.ts
@@ -1,7 +1,6 @@
-import { parse } from 'cookie'
 import { equals, path } from 'ramda'
-import { appendToCookie } from '../../utils'
 
+import { appendToCookie } from '../../utils'
 import { SessionFields } from '../session/sessionResolver'
 
 export const CHECKOUT_COOKIE = 'checkout.vtex.com'
@@ -10,9 +9,9 @@ interface GenericObject { [key: string]: any }
 
 const checkoutCookieFormat = (orderFormId: string) => `${CHECKOUT_COOKIE}=__ofid=${orderFormId}`
 
-const getOrderFormIdFromCookie = (cookie): string | null => {
-  const cookieParsed = parse(cookie)
-  return cookieParsed[CHECKOUT_COOKIE] && cookieParsed[CHECKOUT_COOKIE].split('=')[1]
+const getOrderFormIdFromCookie = (cookies: any): string | void => {
+  const cookie: string | void = cookies.get(CHECKOUT_COOKIE)
+  return cookie && cookie.split('=')[1]
 }
 
 /**
@@ -57,8 +56,8 @@ const syncOrderFormAndSessionOrderFormId = async (orderFormId: string, sessionOr
  */
 
 export const syncCheckoutAndSessionPreCheckout = (sessionData: SessionFields, ctx: Context) => {
-  const {request: { headers: { cookie } }} = ctx
-  const checkoutOrderFormId = getOrderFormIdFromCookie(cookie)
+  const { cookies } = ctx
+  const checkoutOrderFormId = getOrderFormIdFromCookie(cookies)
   if (sessionData.orderFormId && !checkoutOrderFormId) {
     appendToCookie(ctx, checkoutCookieFormat(sessionData.orderFormId))
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes the issue given by this query 

[index=colossus sender=vtex.store-graphql@*  "body.details.0.message"="argument str must be a string"| spath region | search region="aws-us-east-1"](https://splunk7.vtex.com/en-US/app/vtex_colossus/search?q=search%20index%3Dcolossus%20sender%3Dvtex.store-graphql%40*%20%20%22body.details.0.message%22%3D%22argument%20str%20must%20be%20a%20string%22%7C%20spath%20region%20%7C%20search%20region%3D%22aws-us-east-1%22&earliest=-60m%40m&latest=now&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&sid=1552509292.25706_B07AC1AB-7164-44F1-8003-70F0A649A707)

#### What problem is this solving?
When there is no cookies being used, the method `parse` of `cookie` library fails with code 
```
argument str must be a string
```

The fix drops the usage of this library and uses Koa's `ctx.cookie` parameter that works in this scenario.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
