### PR TITLE
Add new mutation subscribeNewsletter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.62.0] - 2019-03-27
 ### Added 
 - Add `specificationGroups` in `product`'s resolvers. 
 - New mutation `subscribeNewsletter`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added 
 - Add `specificationGroups` in `product`'s resolvers. 
+- New mutation `subscribeNewsletter`.
 
 ## [2.61.1] - 2019-03-27
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -224,6 +224,9 @@ type Mutation {
     field: String
   ): Profile @withCurrentProfile @deprecated
 
+  """ Subscribe to newsletter """
+  subscribeNewsletter(email: String): Boolean
+
   """ Order Form """
   updateOrderFormProfile(orderFormId: String, fields: OrderFormProfileInput): OrderForm
   updateOrderFormShipping(orderFormId: String, address: OrderFormAddressInput): OrderForm

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.61.1",
+  "version": "2.62.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/dataSources/profile.ts
+++ b/node/dataSources/profile.ts
@@ -69,4 +69,13 @@ export class ProfileDataSource extends IODataSource {
       metric: 'profile-system-deleteAddress'
     })
   }
+
+  public updatePersonalPreferences = (
+    userEmail: string,
+    personalPreferences: PersonalPreferences,
+  ) => {
+    return this.http.post(`${userEmail}/personalPreferences/`, personalPreferences, {
+      metric: 'profile-system-subscribeNewsletter'
+    })
+  }
 }

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -1,4 +1,4 @@
-import { compose, map, omit, reject, toPairs, propOr } from 'ramda'
+import { compose, map, omit, propOr, reject, toPairs } from 'ramda'
 import { queries as benefitsQueries } from '../benefits'
 import { toIOMessage } from './../../utils/ioMessage'
 

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -23,6 +23,16 @@ export const mutations = {
 
   uploadProfilePicture: (_, { file }, context) =>
     updateProfilePicture(context, file),
+
+  subscribeNewsletter: async (_, { email }, context: Context) => {
+    const profile = context.dataSources.profile
+
+    await profile.updatePersonalPreferences(email, {
+      isNewsletterOptIn: 'True',
+    })
+
+    return true
+  }
 }
 
 export const queries = {

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -128,6 +128,10 @@ declare global {
     customFields: ProfileCustomField[]
   }
 
+  interface PersonalPreferences {
+    isNewsletterOptIn?: 'True' | 'False'
+  }
+
   interface ProfileCustomField {
     key: string
     value: string


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make it possible to add a new component to add an email to a newsletter.

#### What problem is this solving?
Add a new mutation so anyone can add an email to receive newsletter.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/_v/vtex.store-graphql@2.57.1/graphiql/v1?query=mutation%20sub%20%7B%0A%20%20subscribeNewsletter(email%3A%20%22uahseusahe%40masease.com%22)%0A%7D&operationName=sub

And check the value stored in MasterData:

https://storecomponents.vtexcrm.com.br/#RHluYW1pY0Zvcm0jRm9ybVZpZXcjcm93SWQ9Q0wtZjJmNjc3NTQtNDVkOS0xMWU5LTgyNjUtZGU0MDNhZjZhNTY3JmZvcm1JZD1lYTAyMjY1Zi03ZmE1LTQ4MWMtYmU3My1kOThjNmFlNGE5ZWQmd29ya2Zsb3dJZD0jRHluYW1pY0Zvcm1fQmVnaW4jRm9ybVZpZXdfQ29tcGxldGUoJ0NMLWYyZjY3NzU0LTQ1ZDktMTFlOS04MjY1LWRlNDAzYWY2YTU2NycpOyBEeW5hbWljRm9ybV9Gb3JtVmlld19BZnRlckxvYWQoKTsjbnVsbCNBamF4UmVxdWVzdEVycm9yI3RlbXBEaXY=

#### Screenshots or example usage

```graphql
mutation sub {
  subscribeNewsletter(email: "uahseusahe@masease.com")
}
```

#### Types of changes
- [X] New feature (a non-breaking change which adds functionality)