### PR TITLE
Check if extrafields is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.57.4] - 2019-03-13
+
 ## [2.57.3] - 2019-03-13
 
 ## [2.57.2] - 2019-03-13

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.57.3",
+  "version": "2.57.4",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -66,27 +66,27 @@ export async function getPayments(context: Context) {
 export async function updateProfile(
   context: Context,
   profile: Profile,
-  customFields
+  customFields: CustomField[] | undefined
 ) {
   const {
     dataSources,
     vtex: { currentProfile },
   } = context
 
-  const extraFields = mapCustomFieldsToObjNStr(customFields)
+  const extraFields = customFields && mapCustomFieldsToObjNStr(customFields)
 
   const newData = {
     ...profile,
-    ...extraFields.customFieldsObj,
+    ...extraFields && extraFields.customFieldsObj,
   }
 
   return dataSources.profile
     .updateProfileInfo(
       currentProfile.email,
       newData,
-      extraFields.customFieldsStr
+      extraFields && extraFields.customFieldsStr
     )
-    .then(() => getProfile(context, extraFields.customFieldsStr))
+    .then(() => getProfile(context, extraFields && extraFields.customFieldsStr))
 }
 
 export async function updateProfilePicture(context: Context, file: string) {


### PR DESCRIPTION
### What is the purpose of this pull request?
Fixes the issue given by this query

[index=colossus sender=vtex.store-graphql@2.57.3  "body.details.0.message"="Cannot read property 'reduce' of null"](https://splunk7.vtex.com/en-US/app/vtex_colossus/search?q=search%20index%3Dcolossus%20sender%3Dvtex.store-graphql%402.57.3%20%20%22body.details.0.message%22%3D%22Cannot%20read%20property%20%27reduce%27%20of%20null%22&earliest=-60m%40m&latest=now&display.page.search.mode=fast&dispatch.sample_ratio=1&sid=1552515642.31150_758F1174-7E15-4996-8733-56204ADE7565)

### What problem is this solving?
When there are no extra fields the reduce fails with `Cannot read property 'reduce' of null`. This issue was fixed by checking the nullity of extraFields variable

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
