### PR TITLE
return new order form if adding options on addItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.59.2] - 2019-03-20
 ### Changed
 - Return new order form if added assembly options at end of addItem mutation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Return new order form if added assembly options at end of addItem mutation.
 
 ## [2.59.1] - 2019-03-19
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.59.1",
+  "version": "2.59.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -124,7 +124,7 @@ export const mutations: Record<string, Resolver> = {
 
     const cleanItems = items.map(({ options, ...rest }) => rest)
     const addItem = await checkout.addItem(orderFormId, cleanItems)
-    const withOptions = items.filter(({ options }) => !!options)
+    const withOptions = items.filter(({ options }) => !!options && options.length > 0)
     await addOptionsForItems(withOptions, checkout, addItem)
     
     return withOptions.length === 0 ? addItem : (await checkout.orderForm())

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -123,11 +123,11 @@ export const mutations: Record<string, Resolver> = {
     }
 
     const cleanItems = items.map(({ options, ...rest }) => rest)
-
     const addItem = await checkout.addItem(orderFormId, cleanItems)
-
-    await addOptionsForItems(items, checkout, addItem)
-    return addItem
+    const withOptions = items.filter(({ options }) => !!options)
+    await addOptionsForItems(withOptions, checkout, addItem)
+    
+    return withOptions.length === 0 ? addItem : (await checkout.orderForm())
   },
 
   addOrderFormPaymentToken: paymentTokenResolver,


### PR DESCRIPTION
On `addItem` mutation, return a new order form with cart updated after adding assembly options.
Necessary for link state feature.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
