### PR TITLE
Fix plain text credentials in login and use HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Using `application/x-www-form-urlencoded` for logging-in instead of raw querystring with plain text credentials
 
 ## [2.59.0] - 2019-03-19 [YANKED]
 ### Removed	

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.59.0] - 2019-03-19
 ### Fixed
 - Using `application/x-www-form-urlencoded` for logging-in instead of raw querystring with plain text credentials
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.59.1] - 2019-03-19
+
 ## [2.59.0] - 2019-03-19
 ### Fixed
 - Using `application/x-www-form-urlencoded` for logging-in instead of raw querystring with plain text credentials

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.59.0",
+  "version": "2.59.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.58.0",
+  "version": "2.59.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/package.json
+++ b/node/package.json
@@ -15,6 +15,7 @@
     "jwt-decode": "^2.2.0",
     "node-fetch": "^2.1.2",
     "qs": "^6.6.0",
+    "querystring": "^0.2.0",
     "ramda": "^0.24.1",
     "slugify": "^1.2.6",
     "typescript": "^2.5.2",

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -1,5 +1,6 @@
 import http from 'axios'
 import { parse, serialize } from 'cookie'
+import { stringify } from 'querystring'
 
 import ResolverError from '../../errors/resolverError'
 import { headers as authHeaders, withAuthToken } from '../headers'
@@ -9,6 +10,18 @@ import paths from '../paths'
 const makeRequest = async (ctx, url, method='POST', vtexIdVersion='store-graphql') => http.request({
   headers: withAuthToken({
     ...authHeaders.profile,
+    'vtex-ui-id-version': vtexIdVersion,
+  })(ctx),
+  method,
+  url,
+})
+
+const makeSecureRequest = async (ctx, url, body, method='POST', vtexIdVersion='store-graphql') => http.request({
+  data: stringify(body),
+  headers: withAuthToken({
+    'X-Vtex-Use-Https': 'true',
+    accept: 'application/vnd.vtex.ds.v10+json',
+    'content-type': 'application/x-www-form-urlencoded',
     'vtex-ui-id-version': vtexIdVersion,
   })(ctx),
   method,
@@ -78,7 +91,11 @@ export const mutations = {
     if (!VtexSessionToken) {
       throw new ResolverError('ERROR VtexSessionToken is null', 400)
     }
-    const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.accessKeySignIn(VtexSessionToken, args.email, args.code))
+    const { headers, data: { authStatus } } = await makeSecureRequest(ioContext, paths.accessKeySignIn(), {
+      accesskey: args.code,
+      authenticationToken: VtexSessionToken,
+      email: args.email,
+    })
     return setVtexIdAuthCookie(ioContext, response, headers, authStatus)
   },
 
@@ -91,7 +108,11 @@ export const mutations = {
       throw new ResolverError('Password does not follow specific format', 400)
     }
     const VtexSessionToken = await getSessionToken(ioContext)
-    const { headers, data: { authStatus } } = await makeRequest(ioContext, paths.classicSignIn(VtexSessionToken, args.email, args.password))
+    const { headers, data: { authStatus } } = await makeSecureRequest(ioContext, paths.classicSignIn(), {
+      authenticationToken: VtexSessionToken,
+      login: args.email,
+      password: args.password,
+    })
     return setVtexIdAuthCookie(ioContext, response, headers, authStatus)
   },
 

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -29,8 +29,8 @@ const paths = {
   gatewayTokenizePayment: (account, { sessionId }) => `${paths.gateway(account)}/pub/sessions/${sessionId}/tokens`,
 
   /** VTEX ID API */
-  accessKeySignIn: (token, email, code) => `${paths.vtexId}/authentication/accesskey/validate?authenticationToken=${token}&login=${email}&accesskey=${code}`,
-  classicSignIn: (token, email, password) => `${paths.vtexId}/authentication/classic/validate?authenticationToken=${token}&login=${email}&password=${password}`,
+  accessKeySignIn: () => `${paths.vtexId}/authentication/accesskey/validate`,
+  classicSignIn: () => `${paths.vtexId}/authentication/classic/validate`,
   oAuth: (authenticationToken, providerName) => `${paths.vtexId}/authentication/oauth/redirect?authenticationToken=${authenticationToken}&providerName=${providerName}`,
   recoveryPassword: (token, email, password, code) => `${paths.vtexId}/authentication/classic/setpassword?authenticationToken=${token}&login=${email}&newPassword=${password}&accessKey=${code}`,
   redefinePassword: (token, email, currentPassword, newPassword) => `${paths.vtexId}/authentication/classic/setpassword?authenticationToken=${token}&login=${email}&newPassword=${newPassword}&currentPassword=${currentPassword}`,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Requests to vtexid should be made by using a `'content-type': 'application/x-www-form-urlencoded'` POST request and using HTTPS.

I could not test the password change, so I did not applied the fix, however it should be simple. 

The only resolvers fixed are ` accessKeySignIn` and `classicSignIn `

#### What problem is this solving?
Login is made by passing the password and email directly in the querystring

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
