### PR TITLE
Update to new node-vtex-api with metrics and add 2000-keys memory cache for catalog proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.60.0] - 2019-03-20
+
 ## [2.59.2] - 2019-03-20
 ### Changed
 - Return new order form if added assembly options at end of addItem mutation.

--- a/lint.sh
+++ b/lint.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 cd node/
 [ -d node_modules ] && rm -rf node_modules
 yarn cache clean

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.59.2",
+  "version": "2.60.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -13,8 +13,7 @@
     "prereleasy": "bash lint.sh"
   },
   "dependencies": {
-    "vtex.messages": "1.x",
-    "infra:service-node": "4.3.0-beta"
+    "vtex.messages": "1.x"
   },
   "policies": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
     "prereleasy": "bash lint.sh"
   },
   "dependencies": {
-    "vtex.messages": "1.x"
+    "vtex.messages": "1.x",
+    "infra:service-node": "4.3.0-beta"
   },
   "policies": [
     {

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -96,11 +96,13 @@ export class CatalogDataSource extends IODataSource {
   private get = <T = any>(url: string, config: RequestConfig = {}) => {
     const segmentData: SegmentData | null = (this.context! as CustomIOContext).segment
     const { channel: salesChannel = '' } = segmentData || {}
+    const [appMajorNumber] = process.env.VTEX_APP_VERSION!.split('.')
+    const appMajor = `${appMajorNumber}.x`
 
     config.params = {
       ...config.params,
       ...!!salesChannel && {sc: salesChannel},
-      __p: process.env.VTEX_APP_ID,
+      __v: appMajor,
     }
     return this.http.get<T>(`/proxy/catalog${url}`, config)
   }
@@ -108,11 +110,13 @@ export class CatalogDataSource extends IODataSource {
   private getRaw = <T = any>(url: string, config: RequestConfig = {}) => {
     const segmentData: SegmentData | null = (this.context! as CustomIOContext).segment
     const { channel: salesChannel = '' } = segmentData || {}
+    const [appMajorNumber] = process.env.VTEX_APP_VERSION!.split('.')
+    const appMajor = `${appMajorNumber}.x`
 
     config.params = {
       ...config.params,
       ...!!salesChannel && {sc: salesChannel},
-      __p: process.env.VTEX_APP_ID,
+      __v: appMajor,
     }
     return this.http.getRaw<T>(`/proxy/catalog${url}`, config)
   }

--- a/node/dataSources/messages.ts
+++ b/node/dataSources/messages.ts
@@ -6,7 +6,7 @@ export class Messages extends IODataSource {
   protected service = 'messages.vtex'
 
   constructor(ctx?: IOContext, opts?: InstanceOptions) {
-    super(ctx, opts)
+    super(ctx, {...opts, metrics})
   }
 
   public translate = async (from: string, to: string, content: string): Promise<string> => {
@@ -15,7 +15,7 @@ export class Messages extends IODataSource {
     }
     try{
       return await this.http.get('/_v/translations', {
-        metric: 'messages-tranlations',
+        metric: 'messages-translations',
         params: {
           __p: process.env.VTEX_APP_ID,
           data: JSON.stringify([{from, content}]),

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,61 +1,46 @@
 import './globals'
 
-import { Logger } from '@vtex/api'
-import { map } from 'ramda'
+import { isNetworkErrorOrRouterTimeout, Service } from '@vtex/api'
 
 import { dataSources } from './dataSources'
 import { schemaDirectives } from './directives'
 import { resolvers } from './resolvers'
 import { catalogProxy } from './routes/catalogProxy'
 
-const prepare = (handler) => async (ctx: Context) => {
-  try {
-    await handler(ctx)
-  } catch (err) {
-    console.log('Error in proxy catalog', err)
-    const logger = new Logger(ctx.vtex)
-
-    ctx.set('Cache-Control', 'no-cache, no-store')
-
-    if (err.code && err.message && err.status) {
-      ctx.status = err.status
-      ctx.body = {
-        code: err.code,
-        message: err.message,
-      }
-      logger.error(err, {
-        path: ctx.originalPath,
-        status: err.status,
-      })
-      return
-    }
-
-    logger.error(err)
-
-    if (err.response) {
-      ctx.status = err.response.status || 500
-      ctx.body = ctx.status === 404 ? 'Not Found' : err.response.data
-      console.log(
-        `Error from HTTP request. ${err.response.config
-          ? `method=${err.response.config.method} url=${
-            err.response.config.url} `
-          : ''} status=${err.response.status} data=${err.response.data}`
-      )
-      return
-    }
-
-    throw err
+// Retry on timeout from our end
+const isAborted = (e: any) => {
+  if (e && e.code === 'ECONNABORTED') {
+    return true
   }
+  return isNetworkErrorOrRouterTimeout(e)
 }
 
-export default {
-  graphql: {
-    dataSources,
-    resolvers,
-    schemaDirectives,
-  },
-  routes: map(prepare, {
-    catalogProxy,
-  }),
-  statusTrack: metrics.statusTrack,
+const TWO_SECONDS_MS =  2 * 1000
+
+const retryConfig = {
+  retries: 1,
+  retryCondition: isAborted,
+  shouldResetTimeout: true,
 }
+
+const service = new Service({
+  clients: {
+    options: {
+      default: {
+        retryConfig,
+        timeout: TWO_SECONDS_MS,
+      },
+    }
+  },
+  routes: {
+    catalogProxy,
+  }
+})
+
+;(service as any).graphql = {
+  dataSources,
+  resolvers,
+  schemaDirectives,
+}
+
+export default service

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.store-graphql",
   "dependencies": {
     "@gocommerce/utils": "^0.5.26",
-    "@vtex/api": "^2.3.5",
+    "@vtex/api": "^3.0.0-beta.13",
     "apollo-datasource-rest": "^0.1.5",
     "apollo-server-errors": "^2.0.2",
     "axios": "0.16.2",

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.store-graphql",
   "dependencies": {
     "@gocommerce/utils": "^0.5.26",
-    "@vtex/api": "^3.0.0-beta.13",
+    "@vtex/api": "^3.0.0-beta.16",
     "apollo-datasource-rest": "^0.1.5",
     "apollo-server-errors": "^2.0.2",
     "axios": "0.16.2",

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -87,7 +87,7 @@ export const queries = {
     return catalog.facets(facets)
   },
 
-  product: async (_, { slug }, ctx) => {
+  product: async (_, { slug }, ctx: Context) => {
     const { dataSources: { catalog } } = ctx
     const products = await catalog.product(slug)
 

--- a/node/routes/catalogProxy.ts
+++ b/node/routes/catalogProxy.ts
@@ -16,7 +16,7 @@ export const catalogProxy = async (ctx: Context) => {
     ? ['api.gocommerce.com', `${account}/search`]
     : [`${account}.vtexcommercestable.com.br`, 'api/catalog_system']
 
-  const {data, headers} = await axios.request({
+  const {data, headers, status} = await axios.request({
     baseURL: `http://${host}/${basePath}`,
     headers: {
       'Authorization': authToken,
@@ -35,6 +35,7 @@ export const catalogProxy = async (ctx: Context) => {
     ctx.set(headerKey, headers[headerKey])
   })
 
+  ctx.status = status
   ctx.set('cache-control', production ? `public, max-age=${MAX_AGE_S}, stale-if-error=${STALE_IF_ERROR_S}` : 'no-store, no-cache')
   ctx.body = data
 }

--- a/node/routes/catalogProxy.ts
+++ b/node/routes/catalogProxy.ts
@@ -4,17 +4,19 @@ import qs from 'qs'
 import { keys } from 'ramda'
 
 const TIMEOUT_MS = 7 * 1000
-const MAX_AGE_S = 30
+const MAX_AGE_S = 2 * 60
 const STALE_IF_ERROR_S = 20 * 60
 
 export const catalogProxy = async (ctx: Context) => {
-  const {vtex: {account, authToken, production, route: {params: {path}}}, headers: {cookie}, query, method} = ctx
+  const {vtex: {account, authToken, production, route: {params: {path}}, segmentToken}, query, method} = ctx
 
   const isGoCommerce = Functions.isGoCommerceAcc(ctx)
 
   const [host, basePath] = isGoCommerce
     ? ['api.gocommerce.com', `${account}/search`]
     : [`${account}.vtexcommercestable.com.br`, 'api/catalog_system']
+
+  const cookie = segmentToken && {Cookie: `vtex_segment=${segmentToken}`}
 
   const {data, headers, status} = await axios.request({
     baseURL: `http://${host}/${basePath}`,

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -12,7 +12,7 @@ import { LogisticsDataSource } from './dataSources/logistics'
 import { OMSDataSource } from './dataSources/oms'
 import { PortalDataSource } from './dataSources/portal'
 import { ProfileDataSource } from './dataSources/profile'
-import { SessionDataSource } from './dataSources/session'
+import { SessionDataSource, SegmentData } from './dataSources/session'
 
 declare global {
   const metrics: MetricsAccumulator
@@ -29,6 +29,7 @@ declare global {
 
   interface CustomIOContext extends IOContext {
     currentProfile: CurrentProfile
+    segment: SegmentData
   }
 
   interface StoreGraphQLDataSources extends Record<string, DataSource> {

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -12,7 +12,7 @@ import { LogisticsDataSource } from './dataSources/logistics'
 import { OMSDataSource } from './dataSources/oms'
 import { PortalDataSource } from './dataSources/portal'
 import { ProfileDataSource } from './dataSources/profile'
-import { SessionDataSource, SegmentData } from './dataSources/session'
+import { SegmentData, SessionDataSource } from './dataSources/session'
 
 declare global {
   const metrics: MetricsAccumulator

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -1,4 +1,4 @@
-import { IOContext, MetricsAccumulator, ServiceContext } from '@vtex/api'
+import { IOClients, IOContext, MetricsAccumulator, ServiceContext } from '@vtex/api'
 import { DataSource } from 'apollo-datasource'
 
 import { dataSources } from './dataSources'
@@ -17,11 +17,14 @@ import { SessionDataSource } from './dataSources/session'
 declare global {
   const metrics: MetricsAccumulator
 
-  interface Context extends ServiceContext {
+  interface Context extends ServiceContext<IOClients, void, CustomContext> {
+    vtex: CustomIOContext
+  }
+
+  interface CustomContext {
+    cookie: string
     dataSources: StoreGraphQLDataSources
     originalPath: string
-    cookie: string
-    vtex: CustomIOContext
   }
 
   interface CustomIOContext extends IOContext {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -101,11 +101,6 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
-"@types/graphql@^14.0.4":
-  version "14.0.7"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.7.tgz#daa09397220a68ce1cbb3f76a315ff3cd92312f6"
-  integrity sha512-BoLDjdvLQsXPZLJux3lEZANwGr3Xag56Ngy0U3y8uoRSDdeLcn43H3oBcgZlnd++iOQElBpaRVDHPzEDekyvXQ==
-
 "@types/graphql@^14.0.5":
   version "14.0.5"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.5.tgz#e696292fd2d77dc168b5b791710f83463aa39abd"
@@ -123,6 +118,25 @@
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@types/koa-compose/-/koa-compose-3.2.2.tgz#dc106e000bbf92a3ac900f756df47344887ee847"
 
+"@types/koa-compose@^3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@types/koa-compose/-/koa-compose-3.2.3.tgz#4e2981f7bc4ce0f4797219516a91bf6ff3a70fa1"
+  integrity sha512-kXvR0DPyZ3gaFxZs4WycA8lpzlPGtFmwdbgce+NWd+TG3PycPO3o5FkePH60HoBPd8BBaSiw3vhtgM42O2kQcg==
+  dependencies:
+    "@types/koa" "*"
+
+"@types/koa@*", "@types/koa@^2.0.48":
+  version "2.0.48"
+  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.0.48.tgz#29162783029d3e5df8b58c55f6bf0d35f78fc39f"
+  integrity sha512-CiIUYhHlOFJhSCTmsFoFkV2t9ij1JwW26nt0W9XZoWTvmAw6zTE0+k3IAoGICtjzIfhZpZcO323NHmI1LGmdDw==
+  dependencies:
+    "@types/accepts" "*"
+    "@types/cookies" "*"
+    "@types/http-assert" "*"
+    "@types/keygrip" "*"
+    "@types/koa-compose" "*"
+    "@types/node" "*"
+
 "@types/koa@^2.0.46":
   version "2.0.46"
   resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.0.46.tgz#24bc3cd405d10fcde81f876cd8285b44d4ddc3e9"
@@ -134,10 +148,6 @@
     "@types/keygrip" "*"
     "@types/koa-compose" "*"
     "@types/node" "*"
-
-"@types/lru-cache@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-4.1.1.tgz#b2d87a5e3df8d4b18ca426c5105cd701c2306d40"
 
 "@types/mime@*":
   version "2.0.0"
@@ -152,18 +162,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.30.tgz#4c2b4f0015f214f8158a347350481322b3b29b2f"
   integrity sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q==
 
-"@types/p-queue@^2.3.1":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/p-queue/-/p-queue-2.3.2.tgz#16bc5fece69ef85efaf2bce8b13f3ebe39c5a1c8"
-
 "@types/qs@^6.5.1":
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.5.1.tgz#a38f69c62528d56ba7bd1f91335a8004988d72f7"
   integrity sha512-mNhVdZHdtKHMMxbqzNK3RzkBcN1cux3AvuCYGTvjEIQT2uheH3eCAyYsbMbh2Bq8nXkeOWs1kyDiF7geWRFQ4Q==
-
-"@types/ramda@^0.25.38":
-  version "0.25.46"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.46.tgz#8399a35eb117f4a821deb9c4cfecc9b276fb7daf"
 
 "@types/ramda@types/npm-ramda#dist":
   version "0.25.0"
@@ -180,36 +182,32 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@^2.3.5":
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-2.3.5.tgz#21a0f5448058c502dc01a1fb51589967abf0c019"
-  integrity sha512-hkbh5metl29dLM6k4KSNP6UsfZyUvMfczBNRzpl6nxgq5Pya7UFr1nnPZ0ixqj+6aVwqdIjdSJP9YNVPLhbuvg==
+"@vtex/api@^3.0.0-beta.13":
+  version "3.0.0-beta.13"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.0.0-beta.13.tgz#832a37b9f145603f4cf5b349515315efbaab71e7"
+  integrity sha512-uzajBay/Yryn9bdVRotK4NrBgs0Oa2gyjVibpMAWL8Zr5d6c7mQVfxp017IfcXRw+e0fdI++ZZdg69qqyCwATg==
   dependencies:
-    "@types/graphql" "^14.0.4"
-    "@types/lru-cache" "^4.1.1"
-    "@types/p-queue" "^2.3.1"
-    "@types/ramda" "^0.25.38"
-    apollo-datasource "^0.1.3"
+    "@types/koa" "^2.0.48"
+    "@types/koa-compose" "^3.2.3"
+    apollo-datasource "^0.3.1"
     archiver "^3.0.0"
     axios "^0.18.0"
     axios-retry "^3.1.2"
     fs-extra "^7.0.0"
     graphql "^14.0.2"
     graphql-tools "^4.0.3"
-    json-stringify-safe "^5.0.1"
     koa-compose "^4.1.0"
-    lru-cache "^4.1.3"
+    lru-cache "^5.1.1"
     mime-types "^2.1.12"
     multipart-stream "^2.0.1"
     p-limit "^2.2.0"
-    p-queue "^3.0.0"
     qs "^6.5.1"
     querystring "^0.2.0"
-    ramda "^0.25.0"
+    ramda "^0.26.0"
     rwlock "^5.0.0"
     semver "^5.5.1"
     stats-lite vtex/node-stats-lite#dist
-    tar-fs "^1.15.3"
+    tar-fs "^2.0.0"
 
 abbrev@1:
   version "1.1.1"
@@ -250,12 +248,20 @@ apollo-datasource-rest@^0.1.5:
     apollo-server-errors "2.0.2"
     http-cache-semantics "^4.0.0"
 
-apollo-datasource@0.1.3, apollo-datasource@^0.1.3:
+apollo-datasource@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.1.3.tgz#e7ae9d20f29a8a35f239b02f0c47169cfd78d70b"
   dependencies:
     apollo-server-caching "0.1.2"
     apollo-server-env "2.0.3"
+
+apollo-datasource@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.3.1.tgz#4b7ec4c2dd7d08eb7edc865b95fd46b83a4679fd"
+  integrity sha512-qdEUeonc9pPZvYwXK36h2NZoT7Pddmy0HYOzdV0ON5pcG1YtNmUyyYi83Q60V5wTWjuaCjyJ9hOY6wr0BMvQuA==
+  dependencies:
+    apollo-server-caching "0.3.1"
+    apollo-server-env "2.2.0"
 
 apollo-link@^1.2.3:
   version "1.2.3"
@@ -270,9 +276,24 @@ apollo-server-caching@0.1.2:
   dependencies:
     lru-cache "^4.1.3"
 
+apollo-server-caching@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.3.1.tgz#63fcb2aaa176e1e101b36a8450e6b4c593d2767a"
+  integrity sha512-mfxzikYXbB/OoEms77AGYwRh7FF3Oim5v5XWAL+VL49FrkbZt5lopVa4bABi7Mz8Nt3Htl9EBJN8765s/yh8IA==
+  dependencies:
+    lru-cache "^5.0.0"
+
 apollo-server-env@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-2.0.3.tgz#3c13552cd33f400160076cf8e1c9b24be4d27e13"
+  dependencies:
+    node-fetch "^2.1.2"
+    util.promisify "^1.0.0"
+
+apollo-server-env@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-2.2.0.tgz#5eec5dbf46581f663fd6692b2e05c7e8ae6d6034"
+  integrity sha512-wjJiI5nQWPBpNmpiLP389Ezpstp71szS6DHAeTgYLb/ulCw3CTuuA+0/E1bsThVWiQaDeHZE0sE3yI8q2zrYiA==
   dependencies:
     node-fetch "^2.1.2"
     util.promisify "^1.0.0"
@@ -1086,6 +1107,13 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+bl@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-3.0.0.tgz#3611ec00579fd18561754360b21e9f784500ff88"
+  integrity sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==
+  dependencies:
+    readable-stream "^3.0.1"
+
 bluebird@^3.5.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
@@ -1216,7 +1244,7 @@ chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chownr@^1.0.1, chownr@^1.1.1:
+chownr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
 
@@ -1406,7 +1434,7 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   dependencies:
@@ -1776,7 +1804,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1997,10 +2025,6 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-stringify-safe@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
@@ -2099,6 +2123,13 @@ lru-cache@^4.1.3:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^5.0.0, lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 make-error@^1.1.1:
   version "1.3.5"
@@ -2382,10 +2413,6 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-queue@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-3.0.0.tgz#0ef247082f0dd5a21b66e2cfe8fb7b06db13fb52"
-
 p-try@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
@@ -2454,9 +2481,10 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-pump@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
@@ -2478,9 +2506,10 @@ ramda@^0.24.1:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
 
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+ramda@^0.26.0:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randomatic@^3.0.0:
   version "3.1.1"
@@ -2510,6 +2539,15 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@^3.0.1, readable-stream@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.2.0.tgz#de17f229864c120a9f56945756e4f32c4045245d"
+  integrity sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@^2.0.0:
   version "2.2.1"
@@ -2759,7 +2797,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -2779,6 +2817,13 @@ string-width@^1.0.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string_decoder@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -2812,16 +2857,17 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-tar-fs@^1.15.3:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.3.tgz#966a628841da2c4010406a82167cbd5e0c72d509"
+tar-fs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
+  integrity sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==
   dependencies:
-    chownr "^1.0.1"
+    chownr "^1.1.1"
     mkdirp "^0.5.1"
-    pump "^1.0.0"
-    tar-stream "^1.1.2"
+    pump "^3.0.0"
+    tar-stream "^2.0.0"
 
-tar-stream@^1.1.2, tar-stream@^1.5.0:
+tar-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
   dependencies:
@@ -2832,6 +2878,17 @@ tar-stream@^1.1.2, tar-stream@^1.5.0:
     readable-stream "^2.3.0"
     to-buffer "^1.1.1"
     xtend "^4.0.0"
+
+tar-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.0.1.tgz#42fbe41cd1cc5e6657c813e7d98e7afca2858a8c"
+  integrity sha512-I6OJF7wE62BC6zNPdHDtseK0D0187PBjbKSLYY4ffvVkBM6tyBn2O9plDvVM2229/mozfEL/X3++qSvYYQE2xw==
+  dependencies:
+    bl "^3.0.0"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 tar@^4:
   version "4.4.8"
@@ -2993,7 +3050,7 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -182,10 +182,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@^3.0.0-beta.13":
-  version "3.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.0.0-beta.13.tgz#832a37b9f145603f4cf5b349515315efbaab71e7"
-  integrity sha512-uzajBay/Yryn9bdVRotK4NrBgs0Oa2gyjVibpMAWL8Zr5d6c7mQVfxp017IfcXRw+e0fdI++ZZdg69qqyCwATg==
+"@vtex/api@^3.0.0-beta.16":
+  version "3.0.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.0.0-beta.16.tgz#a4dad71001d6a3937c140cf1d279d3990a1efc7f"
+  integrity sha512-I9tYe74hunmKSzJ8l44zWLbDICY9NWRnLdksnTc1sWsoFM/iTz4ssrYmBavyrTukpO07S+ag1z86CNlq42zmIA==
   dependencies:
     "@types/koa" "^2.0.48"
     "@types/koa-compose" "^3.2.3"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2797,7 +2797,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
Caching and adding decent metrics (separated by env) to all catalog access.

> É verdade esse bilete

![image](https://user-images.githubusercontent.com/1633518/54717978-3884f480-4b38-11e9-8366-5785e900ce71.png)
