### PR TITLE
Create a profile for the user if he is logged but hasn't one yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.64.1] - 2019-04-02
 ### Fixed
 - `withCurrentProfile` directive, create a profile for the user if he is logged but hasn't one yet.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `withCurrentProfile` directive, create a profile for the user if he is logged but hasn't one yet.
 
 ## [2.64.0] - 2019-03-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New mutation `subscribeNewsletter`.
 
 ## [2.61.1] - 2019-03-27
-
-## [2.61.1-beta] - 2019-03-27
 ### Fixed
 - `Invalid CEP` messages in checkout API. This was due to updating the order form shipping address with a masked session address. The fix was to check if the address was not masked before sending it to checkout api
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.64.0",
+  "version": "2.64.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -11,8 +11,8 @@ export class WithCurrentProfile extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
     const { resolve = defaultFieldResolver } = field
     field.resolve = async (root, args, context, info) => {
-      const currentProfile: CurrentProfile | null = await getCurrentProfileFromSession(context)
-        .catch(async _ => getCurrentProfileFromCookies(context))
+      const currentProfile: CurrentProfile | null = await (getCurrentProfileFromSession(context)
+        .catch(() => getCurrentProfileFromCookies(context))).catch(() => null)
 
       if (!isLogged(currentProfile)) {
         return null

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -11,32 +11,23 @@ export class WithCurrentProfile extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
     const { resolve = defaultFieldResolver } = field
     field.resolve = async (root, args, context, info) => {
-      let currentProfile: any = null
-      await getCurrentProfileFromSession(context)
-        .then(profile => {
-          currentProfile = profile
-        })
-        .catch(async _ => {
-          currentProfile = await getCurrentProfileFromCookies(context)
-        })
-        .catch(_ => {
-          currentProfile = null
-        })
+      const currentProfile: CurrentProfile | null = await getCurrentProfileFromSession(context)
+        .catch(async _ => getCurrentProfileFromCookies(context))
 
-      if (!currentProfile || !currentProfile.email) {
+      if (!isLogged(currentProfile)) {
         return null
       }
 
-      context.vtex.currentProfile = currentProfile
+      context.vtex.currentProfile = await validatedProfile(context, currentProfile as CurrentProfile)
 
       return resolve(root, args, context, info)
     }
   }
 }
 
-const getCurrentProfileFromSession = (
+function getCurrentProfileFromSession(
   context: Context
-): Promise<CurrentProfile | null> => {
+): Promise<CurrentProfile | null> {
   return sessionQueries.getSession(null, null, context).then(currentSession => {
     const session = currentSession as SessionFields
 
@@ -51,16 +42,16 @@ const getCurrentProfileFromSession = (
 
     return profile
       ? ({
-          email: profile && profile.email,
-          userId: profile && profile.id,
-        } as CurrentProfile)
+        email: profile && profile.email,
+        userId: profile && profile.id,
+      } as CurrentProfile)
       : null
   })
 }
 
-const getCurrentProfileFromCookies = async (
+async function getCurrentProfileFromCookies(
   context: Context
-): Promise<CurrentProfile> => {
+): Promise<CurrentProfile | null> {
   const {
     dataSources: { profile, identity },
     vtex: { account },
@@ -97,10 +88,25 @@ const getCurrentProfileFromCookies = async (
       .then(({ email, userId }) => ({ email, userId }))
   }
 
-  return null as any
+  return null
 }
 
-const isValidCallcenterOperator = (context: Context, email: string) => {
+async function validatedProfile(context: Context, currentProfile: CurrentProfile): Promise<CurrentProfile> {
+  const {
+    dataSources: { profile },
+  } = context
+
+  const { id, userId } = await profile.getProfileInfo(currentProfile.email, 'id')
+
+  if (!id) {
+    // doesn't have a profile, create one
+    await profile.updateProfileInfo(currentProfile.email, { email: currentProfile.email, userId })
+  }
+
+  return { userId, email: currentProfile.email }
+}
+
+function isValidCallcenterOperator(context: Context, email: string) {
   const {
     dataSources: { callcenterOperator, licenseManager },
   } = context
@@ -110,4 +116,8 @@ const isValidCallcenterOperator = (context: Context, email: string) => {
     .then(id =>
       callcenterOperator.isValidCallcenterOperator({ email, accountId: id })
     )
+}
+
+function isLogged(currentProfile: CurrentProfile | null) {
+  return currentProfile && currentProfile.email
 }

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -112,23 +112,23 @@ declare global {
   }
 
   interface Profile {
-    firstName: string
-    lastName: string
-    profilePicture: string
+    firstName?: string
+    lastName?: string
+    profilePicture?: string
     email: string
-    document: string
+    document?: string
     userId: string
-    birthDate: string
-    gender: string
-    homePhone: string
-    businessPhone: string
-    isCorporate: boolean
-    corporateName: string
-    corporateDocument: string
-    stateRegistration: string
-    addresses: Address[]
-    payments: PaymentProfile[]
-    customFields: ProfileCustomField[]
+    birthDate?: string
+    gender?: string
+    homePhone?: string
+    businessPhone?: string
+    isCorporate?: boolean
+    corporateName?: string
+    corporateDocument?: string
+    stateRegistration?: string
+    addresses?: Address[]
+    payments?: PaymentProfile[]
+    customFields?: ProfileCustomField[]
   }
 
   interface PersonalPreferences {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- as the title says...

#### What problem is this solving?
##### Scenario: 
- The user logs in for the first time, with no purchase history, the vtex-id creates a user so he can sign in but it doesn't create a profile for that user, so he has the userId but not the profile.

#### How should this be manually tested?
- Log in with a user, go to the my-account and try to upload a new profile-picture.

[linked workspace](https://fixprofile--recorrenciaqa.myvtexdev.com/account)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
