### PR TITLE
Message by id

### DIFF
--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -11,7 +11,7 @@ export const resolvers = {
 
     metaTagDescription: prop('MetaTagDescription'),
 
-    name: ({name}: any, _: any, ctx: Context) => toIOMessage(ctx, name),
+    name: ({name}: any, _: any, ctx: Context) => toIOMessage(ctx, name, name),
 
     slug: ({url}: any) => url ? lastSegment(url) : null,
 

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -1,4 +1,5 @@
 import { compose, last, prop, split } from 'ramda'
+
 import { toIOMessage } from '../../utils/ioMessage'
 
 const lastSegment = compose<string, string[], string>(last, split('/'))

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -11,7 +11,7 @@ export const resolvers = {
 
     metaTagDescription: prop('MetaTagDescription'),
 
-    name: ({name}: any, _: any, ctx: Context) => toIOMessage(ctx, name, name),
+    name: ({name}: any, _: any, ctx: Context) => toIOMessage(ctx, name, `category-${name}`),
 
     slug: ({url}: any) => url ? lastSegment(url) : null,
 

--- a/node/resolvers/catalog/facets.ts
+++ b/node/resolvers/catalog/facets.ts
@@ -8,7 +8,7 @@ const objToNameValue = (keyName: string, valueName: string, record: Record<strin
 
 export const resolvers = {
   Facet: {
-    Name: ({Name, Id}: any, _: any, ctx: Context) => toIOMessage(ctx, Name, Id),
+    Name: ({Name, Id}: any, _: any, ctx: Context) => toIOMessage(ctx, Name, `facet-name-${Id}`),
   },
   Facets: {
     SpecificationFilters: ({SpecificationFilters = {}}) => objToNameValue('name', 'facets', SpecificationFilters),

--- a/node/resolvers/catalog/facets.ts
+++ b/node/resolvers/catalog/facets.ts
@@ -1,4 +1,6 @@
+import { GraphQLResolveInfo } from 'graphql'
 import { map, toPairs } from 'ramda'
+
 import { toIOMessage } from '../../utils/ioMessage'
 
 const objToNameValue = (keyName: string, valueName: string, record: Record<string, any>) => map(
@@ -8,7 +10,7 @@ const objToNameValue = (keyName: string, valueName: string, record: Record<strin
 
 export const resolvers = {
   Facet: {
-    Name: ({Name, Id}: any, _: any, ctx: Context) => toIOMessage(ctx, Name, `facet-name-${Id}`),
+    Name: ({Name, Id}: any, _: any, ctx: Context, info: GraphQLResolveInfo) => toIOMessage(ctx, Name, `${info.parentType}-${info.fieldName}-${Id}`),
   },
   Facets: {
     SpecificationFilters: ({SpecificationFilters = {}}) => objToNameValue('name', 'facets', SpecificationFilters),

--- a/node/resolvers/catalog/facets.ts
+++ b/node/resolvers/catalog/facets.ts
@@ -8,7 +8,7 @@ const objToNameValue = (keyName: string, valueName: string, record: Record<strin
 
 export const resolvers = {
   Facet: {
-    Name: ({Name}: any, _: any, ctx: Context) => toIOMessage(ctx, Name),
+    Name: ({Name, Id}: any, _: any, ctx: Context) => toIOMessage(ctx, Name, Id),
   },
   Facets: {
     SpecificationFilters: ({SpecificationFilters = {}}) => objToNameValue('name', 'facets', SpecificationFilters),

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -1,7 +1,8 @@
 import { ApolloError } from 'apollo-server-errors'
+import { GraphQLResolveInfo } from 'graphql'
 import { compose, equals, find, head, last, map, path, prop, split, test } from 'ramda'
-import ResolverError from '../../errors/resolverError'
 
+import ResolverError from '../../errors/resolverError'
 import { toIOMessage } from '../../utils/ioMessage'
 import { resolvers as brandResolvers } from './brand'
 import { resolvers as categoryResolvers } from './category'
@@ -64,7 +65,7 @@ export const fieldResolvers = {
 }
 
 export const queries = {
-  autocomplete: async (_: any, args: any, ctx: Context) => {
+  autocomplete: async (_: any, args: any, ctx: Context, info: GraphQLResolveInfo) => {
     const { dataSources: { portal, messages, session } } = ctx
 
     const from = await session.getSegmentData().then(prop('cultureInfo'))
@@ -76,7 +77,7 @@ export const queries = {
       itemsReturned: map(
         item => ({
           ...item,
-          name: toIOMessage(ctx, item.name, `item-${extractSlug(item)}`),
+          name: toIOMessage(ctx, item.name, `${info.parentType}-${info.fieldName}-${extractSlug(item)}`),
           slug: extractSlug(item),
         }),
         itemsReturned

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -76,7 +76,7 @@ export const queries = {
       itemsReturned: map(
         item => ({
           ...item,
-          name: toIOMessage(ctx, item.name, `${extractSlug(item)}`),
+          name: toIOMessage(ctx, item.name, `item-${extractSlug(item)}`),
           slug: extractSlug(item),
         }),
         itemsReturned

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -76,7 +76,7 @@ export const queries = {
       itemsReturned: map(
         item => ({
           ...item,
-          name: toIOMessage(ctx, item.name),
+          name: toIOMessage(ctx, item.name, `${extractSlug(item)}`),
           slug: extractSlug(item),
         }),
         itemsReturned

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -42,9 +42,9 @@ export const resolvers = {
       category => toIOMessage(ctx, category, category)
     ),
 
-    description: ({ description, productId }: any, _: any, ctx: Context) => toIOMessage(ctx, description, `description-${productId}`),
+    description: ({ description, productId }: any, _: any, ctx: Context) => toIOMessage(ctx, description, `product-description-${productId}`),
 
-    productName: ({ productName, productId }: any, _: any, ctx: Context) => toIOMessage(ctx, productName, `name-${productId}`),
+    productName: ({ productName, productId }: any, _: any, ctx: Context) => toIOMessage(ctx, productName, `product-name-${productId}`),
 
     cacheId: ({ linkText }: any) => linkText,
 

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -1,4 +1,5 @@
 import { map as mapP } from 'bluebird'
+import { GraphQLResolveInfo } from 'graphql'
 import { compose, map, omit, propOr, reject, toPairs } from 'ramda'
 
 import { queries as benefitsQueries } from '../benefits'
@@ -39,12 +40,12 @@ export const resolvers = {
 
     categories: ({ categories }: {categories: string[]}, _: any, ctx: Context) => mapP(
       categories,
-      category => toIOMessage(ctx, category, category)
+      category => toIOMessage(ctx, category, `category-${category}`)
     ),
 
-    description: ({ description, productId }: any, _: any, ctx: Context) => toIOMessage(ctx, description, `product-description-${productId}`),
+    description: ({ description, productId }: any, _: any, ctx: Context, info: GraphQLResolveInfo) => toIOMessage(ctx, description, `${info.parentType}-${info.fieldName}-${productId}`),
 
-    productName: ({ productName, productId }: any, _: any, ctx: Context) => toIOMessage(ctx, productName, `product-name-${productId}`),
+    productName: ({ productName, productId }: any, _: any, ctx: Context, info: GraphQLResolveInfo) => toIOMessage(ctx, productName, `${info.parentType}-${info.fieldName}-${productId}`),
 
     cacheId: ({ linkText }: any) => linkText,
 

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -40,11 +40,11 @@ export const resolvers = {
     categories: ({ categories }: {categories: string[]}, _: any, ctx: Context) => mapP(
       categories,
       category => toIOMessage(ctx, category, category)
-      ),
+    ),
 
-    description: ({ description }: any, _: any, ctx: Context) => toIOMessage(ctx, description),
+    description: ({ description, productId }: any, _: any, ctx: Context) => toIOMessage(ctx, description, `description-${productId}`),
 
-    productName: ({ productName }: any, _: any, ctx: Context) => toIOMessage(ctx, productName),
+    productName: ({ productName, productId }: any, _: any, ctx: Context) => toIOMessage(ctx, productName, `name-${productId}`),
 
     cacheId: ({ linkText }: any) => linkText,
 

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -1,4 +1,6 @@
+import { map as mapP } from 'bluebird'
 import { compose, map, omit, propOr, reject, toPairs } from 'ramda'
+
 import { queries as benefitsQueries } from '../benefits'
 import { toIOMessage } from './../../utils/ioMessage'
 
@@ -35,9 +37,9 @@ export const resolvers = {
     benefits: ({ productId }: any, _: any, ctx: Context) =>
       benefitsQueries.benefits(_, { id: productId }, ctx),
 
-    categories: ({ categories }: any, _: any, ctx: Context) =>
-      Promise.all(
-        map((category: string) => toIOMessage(ctx, category), categories)
+    categories: ({ categories }: {categories: string[]}, _: any, ctx: Context) => mapP(
+      categories,
+      category => toIOMessage(ctx, category, category)
       ),
 
     description: ({ description }: any, _: any, ctx: Context) => toIOMessage(ctx, description),

--- a/node/utils/ioMessage.ts
+++ b/node/utils/ioMessage.ts
@@ -1,9 +1,10 @@
 import { prop } from 'ramda'
 
-export const toIOMessage = async (ctx: Context, str: string) => {
+export const toIOMessage = async (ctx: Context, str: string, id: string) => {
   const {dataSources: {session}} = ctx
   return {
     content: str,
     from: await session.getSegmentData(true).then(prop('cultureInfo')),
+    id,
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use the new messages api for translating by id instead of content

#### What problem is this solving?
To add a new translation to `vtex.messages` we need to add a key->value map with from->to language translations. After [this](https://github.com/vtex/messages/pull/30) PR, the key has become an id instead of the string content, allowing a better translation insertion of content. 

However, this generates the complexity of generating a key out of each IOMessage field. The following keys were arbitrarily chosen and can be changed:

1. Category name uses `category-${name}`
2. Facet name uses the `facet-name-${name}`
3. Search item name uses the slug of that `item-${name}`
4. Product description uses `product-description-${productId}`
5. Product name uses `product-name-${productId}`

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
