### PR TITLE
Fixes priceTable fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `ItemMetadata` will not return null when there is no priceTable for some item.
 
 ## [2.64.3] - 2019-04-04
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.64.4] - 2019-04-05
 ### Fixed
 - `ItemMetadata` will not return null when there is no priceTable for some item.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.64.3",
+  "version": "2.64.4",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/itemMetadata.ts
+++ b/node/resolvers/catalog/itemMetadata.ts
@@ -1,6 +1,6 @@
 import http from 'axios'
 import camelCase from 'camelcase'
-import { both, find, isEmpty, pickBy, prop, propEq } from 'ramda'
+import { both, find, isEmpty, path, pickBy, prop, propEq } from 'ramda'
 import { renameKeysWith } from '../../utils'
 import paths from '../paths'
 
@@ -55,9 +55,10 @@ const fetchPrice = async ({
     ...(isEmpty(marketingData) ? {} : { marketingData }),
   }
   const orderForm = await http.post(url, payload, { headers }).catch(() => null)
+  const shouldCheckTotals = orderForm && path(['data', 'totals', 'length'], orderForm)
   return {
     id,
-    price: orderForm ? prop('value', find<any>(propEq('id', 'Items'))(orderForm.data.totals)) : 0,
+    price: shouldCheckTotals? prop('value', find<any>(propEq('id', 'Items'))((orderForm as any).data.totals)) : 0,
     priceTable,
   }
 }


### PR DESCRIPTION
You can test it [here](https://maceio--phmex.myvtex.com/_v/vtex.store-graphql@2.64.2/graphiql/v1?query=query%20promo%20%7B%0A%20%20product(slug%3A%22promo-952%22)%7B%0A%20%20%20%20itemMetadata%7B%0A%20%20%20%20%20%20priceTable%7B%0A%20%20%20%20%20%20%20%09type%20%0A%20%20%20%20%20%20%20%20values%7B%0A%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20price%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=promo)

Before this, the node `itemMetadata` would return null if any subitem price consulting came up wrong. I've added another check that solves the main problem.

_(For some reason, after I've extracted the check,  `eslint` would not recognise my `orderForm` guard, so I've had to add an `as any` there)_

I've skipped `prettier` because this file is not _prettified_. I'm discussing with Fidelis how we can address this.