### PR TITLE
Add FacetImage Datasource and Resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `FacetImage` dataSource and resolvers.
 
 ## [2.64.3] - 2019-04-04
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -197,6 +197,34 @@ type Query {
 
   """ Get logged in user's last order """
   userLastOrder: Order @cacheControl(scope: PRIVATE)
+
+  """
+  Get facet images
+  """
+  facetImages(
+    """
+    Facet type
+    """
+    facetType: String!
+    """ The page that will be fetched """
+    page: Int = 1
+    """ The page size """
+    pageSize: Int = 15
+  ): [FacetImage] @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
+  
+  """
+  Get a facet image
+  """
+  facetImage(
+    """
+    Facet type
+    """
+    facetType: String!
+    """
+    Facet ID
+    """
+    facetId: String!
+  ): FacetImage @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 }
 
 type Mutation {

--- a/graphql/types/FacetImage.graphql
+++ b/graphql/types/FacetImage.graphql
@@ -1,0 +1,18 @@
+type FacetImage {
+  """
+  ID
+  """
+  id: String
+  """
+  Facet ID
+  """
+  facetId: String
+  """
+  Facet type
+  """
+  facetType: String
+  """
+  Facet image URL
+  """
+  imageUrl: String
+}

--- a/node/dataSources/document.ts
+++ b/node/dataSources/document.ts
@@ -27,6 +27,12 @@ export class DocumentDataSource extends RESTDataSource {
     { headers: { ...pagination } , metric: 'masterdata-searchDocuments'}
   )
 
+  public searchDocumentsWithSchema = (acronym: string, fields: string[], where: string, schema: string, pagination: PaginationArgs) => this.get(
+    `${acronym}/search`,
+    { _fields: fields, _where: where, _schema: schema },
+    { headers: { ...pagination } , metric: 'masterdata-searchDocumentsWithSchema'}
+  )
+
   public createDocument = (acronym: string, fields: string[]) => this.post(
     `${acronym}/documents`,
     parseFieldsToJson(fields),

--- a/node/resolvers/facetImage/index.ts
+++ b/node/resolvers/facetImage/index.ts
@@ -1,0 +1,43 @@
+import { head } from 'ramda'
+import ResolverError from '../../errors/resolverError'
+import { acronymFacetImage, fields } from './util'
+
+export const queries = {
+  facetImages: async (
+    _: any,
+    { facetType, page = 1, pageSize = 15 }: any,
+    context: any
+  ) => {
+    const {
+      dataSources: { document },
+    } = context
+    const list = await document.searchDocumentsWithSchema(
+      acronymFacetImage,
+      fields,
+      `facetType=${facetType}`,
+      'facet-image-schema-v1',
+      { page, pageSize }
+    )
+    return list
+  },
+
+  facetImage: async (_: any, { facetId, facetType }: any, context: any) => {
+    const {
+      dataSources: { document },
+    } = context
+    const list = await document.searchDocumentsWithSchema(
+      acronymFacetImage,
+      fields,
+      `facetId=${facetId} AND facetType=${facetType}`,
+      'facet-image-schema-v1',
+      { page: 1, pageSize: 1 }
+    )
+    if (list.length < 1) {
+      throw new ResolverError(
+        `Image not found for document ${facetId} of type ${facetType}.`,
+        404
+      )
+    }
+    return head(list)
+  },
+}

--- a/node/resolvers/facetImage/util.ts
+++ b/node/resolvers/facetImage/util.ts
@@ -1,0 +1,2 @@
+export const fields = ['id', 'facetType', 'facetId', 'imageUrl']
+export const acronymFacetImage = 'FacetImage'

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -7,6 +7,7 @@ import {
   queries as checkoutQueries,
 } from './checkout'
 import { mutations as documentMutations, queries as documentQueries } from './document'
+import { queries as facetImageQueries } from './facetImage'
 import { mutation as listMutations, queries as listQueries } from './list'
 import { fieldResolvers as logisticsResolvers, queries as logisticsQueries } from './logistics'
 import { queries as omsQueries } from './oms'
@@ -45,5 +46,6 @@ export const resolvers = {
     ...sessionQueries,
     ...listQueries,
     ...omsQueries,
+    ...facetImageQueries,
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
We add a datasource and a resolver to retrieve image URLs stored in Master Data V2. We store this information in a dataentity called `FacetImage` using the schema `facet-image-schema-v1`. We use the following fields in this dataentity.
1. `facetType` - Type of facet i.e. category, brand (**required**)
2. `facetId` - ID of the facet (ID of the category or the brand, **required**)
3. `imageUrl` - URL of the facet image (**required**)

#### What problem is this solving?
We need to store images for categories and brands. We do not get image data in the catalog REST API. As a workaround we store mage URLs in Master Data.

#### How should this be manually tested?
1. Persist a document in `FacetImage` dataentity using the fields mentioned above. Use the schema `facet-image-schema-v1`.
2. Fire up the GraphQL IDE to test the two queries (list and single).

#### Screenshots or example usage
![facet-images](https://user-images.githubusercontent.com/42151054/55612909-006fe980-57a7-11e9-8d9b-4127488ee95d.png)
![facet-image](https://user-images.githubusercontent.com/42151054/55612922-0665ca80-57a7-11e9-8679-a2fbd9505bce.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
