### PR TITLE
Feature/future menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix category resolver.
 
 ## [2.66.3] - 2019-04-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix category resolver.
+- Return relative href within categories.
+- Fix how category children field was resolved.
 
 ## [2.66.3] - 2019-04-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.66.4] - 2019-04-15
 ### Fixed
 - Return relative href within categories.
 - Fix how category children field was resolved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.66.5] - 2019-04-15
+
 ## [2.66.4] - 2019-04-15
 ### Fixed
 - Return relative href within categories.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.66.4",
+  "version": "2.66.5",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.66.3",
+  "version": "2.66.4",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -3,6 +3,12 @@ import { toIOMessage } from '../../utils/ioMessage'
 
 const lastSegment = compose<string, string[], string>(last, split('/'))
 
+interface Category {
+  id: string,
+  url: string,
+  children: Category[],
+}
+
 export const resolvers = {
   Category: {
     cacheId: prop('id'),
@@ -55,7 +61,7 @@ export const resolvers = {
         (c : Category) => c.id === id,
         categories
       ) || {}
-      
+    
       return path(['children'], category)
     },
   },

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -56,10 +56,15 @@ export const resolvers = {
 
     children: async ({ id }: any, _: any, { dataSources: { catalog } }: any) => {
       const categories = await catalog.categories(3) as Category[]
+      
+      const flattenCategories = categories.reduce(
+        (acc : Category[], category) => acc.concat(category, category.children),
+        []
+      )
 
       const category = find(
         (c : Category) => c.id === id,
-        categories
+        flattenCategories
       ) || {}
     
       return path(['children'], category)

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -1,4 +1,4 @@
-import { compose, last, path, prop, split, find } from 'ramda'
+import { compose, find, last, path, prop, split } from 'ramda'
 import { toIOMessage } from '../../utils/ioMessage'
 
 const lastSegment = compose<string, string[], string>(last, split('/'))
@@ -17,7 +17,7 @@ export const resolvers = {
       const categories = await catalog.categories(3) as Category[]
 
       const flattenCategories = categories.reduce(
-        (acc : Category[], category) => acc.concat(category, category.children),
+        (acc : Category[], cat) => acc.concat(cat, cat.children),
         []
       )
 
@@ -40,7 +40,7 @@ export const resolvers = {
       const categories = await catalog.categories(3) as Category[]
 
       const flattenCategories = categories.reduce(
-        (acc : Category[], category) => acc.concat(category, category.children),
+        (acc : Category[], c) => acc.concat(c, c.children),
         []
       )
 
@@ -58,7 +58,7 @@ export const resolvers = {
       const categories = await catalog.categories(3) as Category[]
       
       const flattenCategories = categories.reduce(
-        (acc : Category[], category) => acc.concat(category, category.children),
+        (acc : Category[], c) => acc.concat(c, c.children),
         []
       )
 

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -1,5 +1,4 @@
-import { compose, last, prop, split } from 'ramda'
-
+import { compose, last, path, prop, split, find } from 'ramda'
 import { toIOMessage } from '../../utils/ioMessage'
 
 const lastSegment = compose<string, string[], string>(last, split('/'))
@@ -8,14 +7,56 @@ export const resolvers = {
   Category: {
     cacheId: prop('id'),
 
-    href: prop('url'),
+    href: async ({ id }: any, _: any, { dataSources: { catalog } }: any) => {
+      const categories = await catalog.categories(3) as Category[]
+
+      const flattenCategories = categories.reduce(
+        (acc : Category[], category) => acc.concat(category, category.children),
+        []
+      )
+
+      const category = find(
+        (c : Category) => c.id === id,
+        flattenCategories
+      ) || { url: '' }
+
+      return category.url.replace(
+        /https:\/\/[A-z0-9]+\.vtexcommercestable\.com\.br/,
+        ''
+      )
+    },
 
     metaTagDescription: prop('MetaTagDescription'),
 
     name: ({name}: any, _: any, ctx: Context) => toIOMessage(ctx, name, `category-${name}`),
 
-    slug: ({url}: any) => url ? lastSegment(url) : null,
+    slug: async ({ id }: any, _: any, { dataSources: { catalog } }: any) => {
+      const categories = await catalog.categories(3) as Category[]
+
+      const flattenCategories = categories.reduce(
+        (acc : Category[], category) => acc.concat(category, category.children),
+        []
+      )
+
+      const category = find(
+        (c : Category) => c.id === id,
+        flattenCategories
+      ) || { url: '' }
+
+      return category.url ? lastSegment(category.url) : null
+    },
 
     titleTag: prop('Title'),
-  }
+
+    children: async ({ id }: any, _: any, { dataSources: { catalog } }: any) => {
+      const categories = await catalog.categories(3) as Category[]
+
+      const category = find(
+        (c : Category) => c.id === id,
+        categories
+      ) || {}
+      
+      return path(['children'], category)
+    },
+  },
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Update the `Category` resolver to return the children of a category.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The children was only returned in the query for the categories tree. If you requested only one category its children weren't returned.

#### How should this be manually tested?
Checkout [this](https://subcategoriestree--storecomponents.myvtex.com/_v/vtex.store-graphql@2.64.2/graphiql/v1) workspace and run the following query:

```graphql
query {
  category(id: 1) {
    cacheId
    id
    href
    name
    titleTag
    children {
      id
      href
      name
      titleTag
    }
  }
}
```
See the children of the category being returned. 
#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
