### PR TITLE
Remove required in slug field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `Slug` field not required in `Facet` type.
 
 ## [2.68.0] - 2019-04-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.68.1] - 2019-04-25
 ### Changed
 - `Slug` field not required in `Facet` type.
 

--- a/graphql/types/Facets.graphql
+++ b/graphql/types/Facets.graphql
@@ -17,7 +17,7 @@ type Facet {
   Name: IOMessage! @deprecated(reason: "Use 'name' field instead")
   Quantity: Int! @deprecated(reason: "Use 'quantity' field instead")
   Link: String! @deprecated(reason: "Use 'link' field instead")
-  Slug: String! @deprecated(reason: "Use 'slug' field instead")
+  Slug: String @deprecated(reason: "Use 'slug' field instead")
   Children: [Facet] @deprecated(reason: "Use 'children' field instead")
   id: Int
   name: IOMessage!

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.68.0",
+  "version": "2.68.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove required on `Slug` field in the `Facet` type.

#### What problem is this solving?
The `slug` field isn't required, so as the `Slug` should be, and this was causing errors in some accounts.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
