### PR TITLE
 Add '/d' on department 'href'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.70.2] - 2019-05-03
+
 ### Changed
 
 - Add `/d` to `href` when it's a department.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Add `/d` to `href` when it's a department.
+
+### Fixed
+
+- Fields `href` and `slug` from a subcategory.
+
 ## [2.70.1] - 2019-05-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
+
 - Add `/d` to `href` when it's a department.
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.70.1",
+  "version": "2.70.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -12,32 +12,20 @@ interface Category {
 
 type CategoryMap = Record<string, Category>
 
+const appendToMap = (mapCategories: CategoryMap, category: Category) => {
+  mapCategories[category.id] = {
+    ...category,
+  }
+
+  mapCategories = category.children.reduce(appendToMap, mapCategories)
+
+  return mapCategories
+}
+
 const getCategoryInfo = async (catalog: any, id: string) => {
   const categories = await catalog.categories(3) as Category[]
 
-  const mapCategories = categories.reduce((mapCategories: CategoryMap, department) => {
-    mapCategories[department.id] = {
-      ...department,
-    }
-
-    mapCategories = department.children.reduce((mapCategories: CategoryMap, category) => {
-      mapCategories[category.id] = {
-        ...category,
-      }
-
-      mapCategories = category.children.reduce((mapCategories, subCategory) => {
-        mapCategories[subCategory.id] = {
-          ...subCategory,
-        }
-
-        return mapCategories
-      }, mapCategories)
-
-      return mapCategories
-    }, mapCategories)
-
-    return mapCategories
-  }, {}) as CategoryMap
+  const mapCategories = categories.reduce(appendToMap, {}) as CategoryMap
 
   const category = mapCategories[id] || { url: '' }
 

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -22,7 +22,8 @@ type CategoryMap = Record<string, Category>
  * there instead until the Catalog team fixes this issue with the category API.
  */
 async function getCategoryInfo(catalog: CatalogDataSource, id: string) {
-  const categories = (await catalog.categories(3)) as Category[]
+  const LEVELS = ['department', 'category', 'subcategory']
+  const categories = (await catalog.categories(LEVELS.length)) as Category[]
 
   const mapCategories = categories.reduce(appendToMap, {}) as CategoryMap
 

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -1,4 +1,4 @@
-import { compose, find, last, path, prop, split } from 'ramda'
+import { compose, last, path, prop, split } from 'ramda'
 import { toIOMessage } from '../../utils/ioMessage'
 
 const lastSegment = compose<string, string[], string>(last, split('/'))
@@ -6,48 +6,74 @@ const lastSegment = compose<string, string[], string>(last, split('/'))
 interface Category {
   id: string,
   url: string,
+  name: string,
   children: Category[],
+}
+
+type CategoryMap = Record<string, Category>
+
+const getCategoryInfo = async (catalog: any, id: string) => {
+  const categories = await catalog.categories(3) as Category[]
+
+  const mapCategories = categories.reduce((mapCategories: CategoryMap, department) => {
+    mapCategories[department.id] = {
+      ...department,
+    }
+
+    mapCategories = department.children.reduce((mapCategories: CategoryMap, category) => {
+      mapCategories[category.id] = {
+        ...category,
+      }
+
+      mapCategories = category.children.reduce((mapCategories, subCategory) => {
+        mapCategories[subCategory.id] = {
+          ...subCategory,
+        }
+
+        return mapCategories
+      }, mapCategories)
+
+      return mapCategories
+    }, mapCategories)
+
+    return mapCategories
+  }, {}) as CategoryMap
+
+  const category = mapCategories[id] || { url: '' }
+
+  return category
+}
+
+function cleanUrl(url: string) {
+  return url.replace(
+    /https:\/\/[A-z0-9]+\.vtexcommercestable\.com\.br/,
+    ''
+  )
 }
 
 export const resolvers = {
   Category: {
     cacheId: prop('id'),
 
-    href: async ({ id }: any, _: any, { dataSources: { catalog } }: any) => {
-      const categories = await catalog.categories(3) as Category[]
+    href: async ({ id }: Category, _: any, { dataSources: { catalog } }: any) => {
+      const category = await getCategoryInfo(catalog, id)
 
-      const flattenCategories = categories.reduce(
-        (acc : Category[], cat) => acc.concat(cat, cat.children),
-        []
-      )
+      const path = cleanUrl(category.url)
 
-      const category = find(
-        (c : Category) => c.id === id,
-        flattenCategories
-      ) || { url: '' }
+      const isDepartment = path.slice(1).indexOf('/') === -1
+      if (isDepartment) {
+        return path + '/d'
+      }
 
-      return category.url.replace(
-        /https:\/\/[A-z0-9]+\.vtexcommercestable\.com\.br/,
-        ''
-      )
+      return path
     },
 
     metaTagDescription: prop('MetaTagDescription'),
 
-    name: ({name}: any, _: any, ctx: Context) => toIOMessage(ctx, name, `category-${name}`),
+    name: ({ name }: Category, _: any, ctx: Context) => toIOMessage(ctx, name, `category-${name}`),
 
-    slug: async ({ id }: any, _: any, { dataSources: { catalog } }: any) => {
-      const categories = await catalog.categories(3) as Category[]
-
-      const flattenCategories = categories.reduce(
-        (acc : Category[], c) => acc.concat(c, c.children),
-        []
-      )
-
-      const category = find(
-        (c : Category) => c.id === id,
-        flattenCategories
-      ) || { url: '' }
+    slug: async ({ id }: Category, _: any, { dataSources: { catalog } }: any) => {
+      const category = await getCategoryInfo(catalog, id)
 
       return category.url ? lastSegment(category.url) : null
     },
@@ -55,18 +81,8 @@ export const resolvers = {
     titleTag: prop('Title'),
 
     children: async ({ id }: any, _: any, { dataSources: { catalog } }: any) => {
-      const categories = await catalog.categories(3) as Category[]
-      
-      const flattenCategories = categories.reduce(
-        (acc : Category[], c) => acc.concat(c, c.children),
-        []
-      )
+      const category = await getCategoryInfo(catalog, id)
 
-      const category = find(
-        (c : Category) => c.id === id,
-        flattenCategories
-      ) || {}
-    
       return path(['children'], category)
     },
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix flattening of categories and  add `/d` to `href` when it's department.

#### What problem is this solving?
Linking to a category or department.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/_v/vtex.store-graphql@2.70.1/graphiql/v1?query=query%20%7B%0A%20%20department%3A%20category(id%3A%2016)%20%7B%0A%20%20%20%20href%0A%20%20%20%20slug%0A%20%20%20%20name%0A%20%20%7D%0A%20%20category%3A%20category(id%3A%203)%20%7B%0A%20%20%20%20href%0A%20%20%20%20slug%0A%20%20%20%20name%0A%20%20%7D%0A%20%20subcategory%3A%20category(id%3A%2013)%20%7B%0A%20%20%20%20href%0A%20%20%20%20slug%0A%20%20%20%20name%0A%20%20%7D%0A%7D%0A

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/284515/57157885-4aed8180-6db8-11e9-8352-04b6f248a337.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
