### PR TITLE
Add product search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `productSearch` query.
 
 ## [2.69.1] - 2019-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.70.0] - 2019-04-29
 ### Added
 - `productSearch` query.
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -10,6 +10,30 @@ type Query {
   ): Product @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   """ Returns products list filtered and ordered """
+  productSearch(
+    """ Terms that is used in search e.g.: eletronics/samsung """
+    query: String = "",
+    """ Defines terms types: Brand, Category, Department e.g.: c,b """
+    map: String = "",
+    """ Filter by category. {a}/{b} - {a} and {b} are categoryIds """
+    category: String = "",
+    """ Array of product specification. specificationFilter_{a}:{b} - {a} is the specificationId, {b} = specification value """
+    specificationFilters: [String],
+    """ Filter by price range. e.g.: {a} TO {b} - {a} is the minimum price "from" and {b} is the highest price "to" """
+    priceRange: String = "",
+    """ Filter by collection. where collection also know as productClusterId"""
+    collection: String = "",
+    """ Filter by availability at a specific sales channel. e.g.: salesChannel:4 if want filter by available products for the sales channel 4"""
+    salesChannel: String = "",
+    """ Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC """
+    orderBy: String = "OrderByPriceDESC",
+    """ Pagination item start """
+    from: Int = 0,
+    """ Pagination item end """
+    to: Int = 9
+  ): ProductSearch @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
+
+  """ Returns products list filtered and ordered """
   products(
     """ Terms that is used in search e.g.: eletronics/samsung """
     query: String = "",

--- a/graphql/types/ProductSearch.graphql
+++ b/graphql/types/ProductSearch.graphql
@@ -1,0 +1,4 @@
+type ProductSearch {
+  products: [Product]
+  recordsFiltered: Int
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.69.1",
+  "version": "2.70.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -158,6 +158,17 @@ export const queries = {
     return catalog.products(args)
   },
 
+  productSearch: async (_: any, args: any, ctx: Context) => {
+    const { dataSources: { catalog } } = ctx
+    const products = await queries.products(_, args, ctx)
+    const recordsFiltered = await catalog.productsQuantity(args)
+
+    return {
+      products,
+      recordsFiltered,
+    }
+  },
+
   brand: async (_: any, args: any, { dataSources: { catalog } }: Context) => {
     const brands = await catalog.brands()
     const brand = find(compose(equals(args.id), prop('id') as any), brands)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the product search query.

#### What problem is this solving?
With this query, you can get the `recordsFiltered` property that's returned from the API as the `resources` header.

#### How should this be manually tested?
[GraphiQL](https://lucas--storecomponents.myvtex.com/_v/vtex.store-graphql@2.69.1/graphiql/v1).

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
