### PR TITLE
Fix NULL Subcategory Slug Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Take subcategories into account when generating slug for a category.
+
 ## [2.70.1] - 2019-05-01
 
 ### Fixed

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -9,6 +9,14 @@ interface Category {
   children: Category[],
 }
 
+const flatten: (categories: Category[]) => Category[] = (
+  categories: Category[]
+) => {
+  return categories.reduce((acc: Category[], cat) => {
+    return [...acc, cat, ...cat.children, ...flatten(cat.children)]
+  }, [])
+}
+
 export const resolvers = {
   Category: {
     cacheId: prop('id'),
@@ -39,10 +47,7 @@ export const resolvers = {
     slug: async ({ id }: any, _: any, { dataSources: { catalog } }: any) => {
       const categories = await catalog.categories(3) as Category[]
 
-      const flattenCategories = categories.reduce(
-        (acc : Category[], c) => acc.concat(c, c.children),
-        []
-      )
+      const flattenCategories: Category[] = flatten(categories)
 
       const category = find(
         (c : Category) => c.id === id,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Take subcategories into account when generating the slug for a category.

#### What problem is this solving?
The category menu is not showing links to subcategories. This happens because only departments and categories are included in the flattened category tree when generating the slug.

#### How should this be manually tested?
Check the subcategory links in the category menu.

#### Screenshots or example usage
https://demo--biscoind.myvtex.com/

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
