### PR TITLE
Fix selected property not accounting for map field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.70.3] - 2019-05-06
+
 ### Fixed
 
 - Selected property in facets accounting for corresponding `map`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Selected property in facets accounting for corresponding `map`.
+
 ## [2.70.2] - 2019-05-03
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.70.2",
+  "version": "2.70.3",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/facets.ts
+++ b/node/resolvers/catalog/facets.ts
@@ -1,5 +1,5 @@
 import { GraphQLResolveInfo } from 'graphql'
-import { map, toPairs, prop } from 'ramda'
+import { map, toPairs, prop, zip } from 'ramda'
 
 import { toIOMessage } from '../../utils/ioMessage'
 
@@ -26,19 +26,29 @@ const formatCategoriesTree = (root: any) => {
   return format(root)
 }
 
-const addSelected = (facets: any[], { query }: { query: string }): any => {
+const addSelected = (
+  facets: any[],
+  { query, map }: { query: string; map: string }
+): any => {
   return facets.map((facet: any) => {
     let children = facet.Children
 
     if (children) {
-      children = addSelected(children, { query })
+      children = addSelected(children, { query, map })
     }
 
-    const isSelected = query
-        .toLowerCase()
-        .split('/')
-        .map(decodeURIComponent)
-        .includes(decodeURIComponent(facet.Value).toLowerCase())
+    const currentFacetSlug = decodeURIComponent(facet.Value).toLowerCase()
+
+    const isSelected =
+      zip(
+        query
+          .toLowerCase()
+          .split('/')
+          .map(decodeURIComponent),
+        map.toLowerCase().split(',')
+      ).find(
+        ([slug, slugMap]) => slug === currentFacetSlug && facet.Map === slugMap
+      ) !== undefined
 
     return {
       ...facet,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the `selected` property computation to account for the `map` in the facet value, when comparing against the query inputs.

#### What problem is this solving?
In Invicta, we have a category with the same name as the brand, which was causing the brand to appear as a selected facet, although only the category was selected.

#### How should this be manually tested?
[workspace](https://lucas--storecomponents.myvtex.com/clothing/Bord%C3%B4?map=c%2CspecificationFilter_38).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
