### PR TITLE
Remove slugify on facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.72.1] - 2019-05-09
 ### Fixed
 - Remove slugify on facets when computing selected property.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove slugify on facets when computing selected property.
 
 ## [2.72.0] - 2019-05-09
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.72.0",
+  "version": "2.72.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/facets.ts
+++ b/node/resolvers/catalog/facets.ts
@@ -2,7 +2,6 @@ import { map, prop, toPairs, zip } from 'ramda'
 
 import { toCategoryIOMessage, toFacetIOMessage } from '../../utils/ioMessage'
 import { pathToCategoryHref } from './category'
-import { Slugify } from './slug'
 
 const objToNameValue = (
   keyName: string,
@@ -45,7 +44,7 @@ const addSelected = (
         query
           .toLowerCase()
           .split('/')
-          .map(str => Slugify(decodeURIComponent(str))),
+          .map(decodeURIComponent),
         map.toLowerCase().split(',')
       ).find(
         ([slug, slugMap]) => slug === currentFacetSlug && facet.Map === slugMap


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the slugify call on the facets value when checking if the facet was selected or not.

#### What problem is this solving?
The values are already slugified from the API, and this second "slugification" was breaking some values, marking some as not selected when, in fact, they were.

#### How should this be manually tested?
[workspace](https://lucas--invictastores.myvtex.com/watches/Mens/Technomarine/S--Coifman?map=c%2CspecificationFilter_69%2Cb%2Cc), select the "watches" and the "S Coifman" filter should be gone.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
