### PR TITLE
Add Category/Brand name in titleTag when meta tag title are null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,36 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Add Category/Brand name in `titleTag` when meta tag title are null.
+
 ## [2.71.2] - 2019-05-07
+
 ### Fixed
+
 - Slugify facets when checking if is selected.
 
 ## [2.71.1] - 2019-05-07
 
 ## [2.71.0] - 2019-05-07
+
 ### Added
+
 - Added `href` field to facets category. This field should be used to populate links in the store
 
 ### Changed
+
 - SEGMENT scope to root field resolvers containing translatable fields
 
 ### Fixed
+
 - Uses default sales channel as API language
 
 ## [2.70.4] - 2019-05-06
+
 ### Added
+
 - Parameter `hideUnavailableItems` to catalog search queries.
 
 ## [2.70.3] - 2019-05-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.71.3] - 2019-05-09
+
 ### Changed
 
 - Add Category/Brand name in `titleTag` when meta tag title are null.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.71.2",
+  "version": "2.71.3",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -1,5 +1,16 @@
 import { NotFoundError, UserInputError } from '@vtex/api'
-import { compose, equals, find, head, last, map, path, prop, split, test } from 'ramda'
+import {
+  compose,
+  equals,
+  find,
+  head,
+  last,
+  map,
+  path,
+  prop,
+  split,
+  test,
+} from 'ramda'
 
 import { toProductIOMessage } from '../../utils/ioMessage'
 import { resolvers as brandResolvers } from './brand'
@@ -61,7 +72,7 @@ const categoryMetaData = async (_: any, args: any, ctx: any) => {
   )
   return {
     metaTagDescription: path(['MetaTagDescription'], category),
-    titleTag: path(['Title'], category),
+    titleTag: path(['Title'], category) || path(['Name'], category),
   }
 }
 /** Get brand metadata for the search/productSearch query
@@ -79,7 +90,7 @@ const brandMetaData = async (_: any, args: any, ctx: any) => {
   )
   return {
     metaTagDescription: path(['metaTagDescription'], brand as any),
-    titleTag: path(['title'], brand as any),
+    titleTag: path(['title'], brand as any) || path(['name'], brand as any),
   }
 }
 
@@ -126,11 +137,7 @@ export const fieldResolvers = {
 }
 
 export const queries = {
-  autocomplete: async (
-    _: any,
-    args: any,
-    ctx: Context
-  ) => {
+  autocomplete: async (_: any, args: any, ctx: Context) => {
     const {
       dataSources: { catalog },
       clients: { segment, messages },


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
As the title says

#### How should this be manually tested?
[Test here](https://meta--storecomponents.myvtex.com/_v/vtex.store-graphql@2.71.2/graphiql/v1?operationName=search)
```
query search {
  productSearch(query: "Clothing", map: "c") {
    titleTag
    metaTagDescription
  }
}
```
#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
