### PR TITLE
Fix comma in product query breaking search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove comma from invalid characters of product search.
 
 ## [2.72.1] - 2019-05-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.72.2] - 2019-05-10
 ### Fixed
 - Remove comma from invalid characters of product search.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.72.1",
+  "version": "2.72.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -223,7 +223,7 @@ export const queries = {
       dataSources: { catalog },
     } = ctx
     const queryTerm = args.query
-    if (queryTerm == null || test(/[?&[\]=,]/, queryTerm)) {
+    if (queryTerm == null || test(/[?&[\]=]/, queryTerm)) {
       throw new UserInputError(
         `The query term contains invalid characters. query=${queryTerm}`
       )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove comma from invalid query term regex.

#### What problem is this solving?
If you have a filter that has a comma in the product specification, it breaks the search when you apply that filter.

#### How should this be manually tested?
[workspace](https://lucas--invictastores.myvtex.com/watches/Technomarine/Technomarine?map=c%2Cb%2Cc), select a case tone with a comma in it.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
