### PR TITLE
translates query terms for productSearch and autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Translate terms (with `Messages`) before sending them to search api for `productSearch` and `facets` resolvers
 
 ## [2.72.2] - 2019-05-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.73.0] - 2019-05-13
 ### Changed
 - Translate terms (with `Messages`) before sending them to search api for `productSearch` and `facets` resolvers
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.72.2",
+  "version": "2.73.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -111,7 +111,7 @@ export class CatalogDataSource extends IODataSource {
     {metric: 'catalog-crossSelling'}
   )
 
-  public autocomplete = ({maxRows, searchTerm}: AutocompleteArgs) => this.get(
+  public autocomplete = ({maxRows, searchTerm}: AutocompleteArgs) => this.get<{itemsReturned: Item[]}>(
     `/buscaautocomplete?maxRows=${maxRows}&productNameContains=${encodeURIComponent(searchTerm)}`,
     {metric: 'catalog-autocomplete'}
   )

--- a/node/resolvers/catalog/autocomplete.ts
+++ b/node/resolvers/catalog/autocomplete.ts
@@ -1,11 +1,11 @@
 import { extractSlug } from '.'
-import { toProductIOMessage } from '../../utils/ioMessage'
+import { toProductIOMessage, toIOMessage } from '../../utils/ioMessage'
 
 export const resolvers = {
   Items: {
     name: ({name, id}: {name: string, id?: string}, _: any, { clients: {segment} }: Context) => id != null
       ? toProductIOMessage('name')(segment, name, id)
-      : name,
+      : toIOMessage(segment, name, name),
 
     slug: (root: any) => extractSlug(root),
   }

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -173,19 +173,24 @@ export const queries = {
   facets: async (_: any, { facets, query, map }: any, ctx: Context) => {
     const {
       dataSources: { catalog },
+      clients,
     } = ctx
-    const queryArgs = { query, map }
-
     let result
 
     if (facets) {
       result = await catalog.facets(facets)
+      result.queryArgs = {
+        query,
+        map
+      }
     } else {
-      result = await catalog.facets(`${query}?map=${map}`)
+      const translatedQuery = await translateToStoreDefaultLanguage(clients)(query)
+      result = await catalog.facets(`${translatedQuery}?map=${map}`)
+      result.queryArgs = {
+        query: translatedQuery,
+        map,
+      }
     }
-
-    result.queryArgs = queryArgs
-
     return result
   },
 

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -1,6 +1,9 @@
 import { NotFoundError, UserInputError } from '@vtex/api'
+import { all } from 'bluebird'
 import { compose, equals, find, head, last, path, prop, split, test } from 'ramda'
 
+import { toSearchTerm } from '../../utils/ioMessage'
+import { resolvers as autocompleteResolvers } from './autocomplete'
 import { resolvers as brandResolvers } from './brand'
 import { resolvers as categoryResolvers } from './category'
 import { resolvers as discountResolvers } from './discount'
@@ -12,8 +15,21 @@ import { resolvers as productResolvers } from './product'
 import { resolvers as recommendationResolvers } from './recommendation'
 import { resolvers as searchResolvers } from './search'
 import { resolvers as skuResolvers } from './sku'
-import { resolvers as autocompleteResolvers } from './autocomplete'
 import { Slugify } from './slug'
+
+interface SearchArgs {
+  query: string
+  map: string
+  category: string
+  specificationFilters: [string]
+  priceRange: string
+  collection: string
+  salesChannel: string
+  orderBy: string
+  from: number
+  to: number
+  hideUnavailableItems: boolean
+}
 
 /**
  * It will extract the slug from the HREF in the item
@@ -111,6 +127,17 @@ async function getProductBySlug(slug: string, catalog: any) {
   throw new NotFoundError('No product was found with requested sku')
 }
 
+const translateToStoreDefaultLanguage = (clients: Context['clients']) => async (term: string): Promise<string> => {
+  const { segment, messages } = clients
+  const [{cultureInfo: to}, {cultureInfo: from}] = await all([
+    segment.getSegmentByToken(null),
+    segment.getSegment()
+  ])
+  return from && from !== to
+    ? messages.translate(to, [toSearchTerm(term, from)]).then(head)
+    : term
+}
+
 export const fieldResolvers = {
   ...autocompleteResolvers,
   ...brandResolvers,
@@ -130,29 +157,10 @@ export const queries = {
   autocomplete: async (_: any, args: any, ctx: Context) => {
     const {
       dataSources: { catalog },
-      clients: { segment, messages },
+      clients,
     } = ctx
-
-    const segmentData = await segment.getSegment()
-    // Grabbing a segment without token should give us the default store locale
-    const defaultSegmentData = await segment.getSegmentByToken(null)
-    const from = segmentData.cultureInfo
-    const to = defaultSegmentData.cultureInfo
-    // Only translate if necessary
-    const translatedTerm =
-      from && from !== to
-        ? await messages.translate(to, [
-            {
-              id: `autocomplete-${args.searchTerm}`,
-              description: '',
-              content: args.searchTerm,
-              from,
-            },
-          ])
-        : args.searchTerm
-    const {
-      itemsReturned,
-    }: { itemsReturned: Item[] } = await catalog.autocomplete({
+    const translatedTerm = await translateToStoreDefaultLanguage(clients)(args.searchTerm)
+    const { itemsReturned } = await catalog.autocomplete({
       maxRows: args.maxRows,
       searchTerm: translatedTerm,
     })
@@ -231,15 +239,21 @@ export const queries = {
     return catalog.products(args)
   },
 
-  productSearch: async (_: any, args: any, ctx: Context) => {
+  productSearch: async (_: any, args: SearchArgs, ctx: Context) => {
     const {
       dataSources: { catalog },
+      clients,
     } = ctx
-    const products = await queries.products(_, args, ctx)
-    const recordsFiltered = await catalog.productsQuantity(args)
+    const translate = translateToStoreDefaultLanguage(clients)
+    const translatedArgs = {
+      ...args,
+      query: await translate(args.query),
+    }
+    const products = await queries.products(_, translatedArgs, ctx)
+    const recordsFiltered = await catalog.productsQuantity(translatedArgs)
     const { titleTag, metaTagDescription }: any = await searchMetaData(
       _,
-      args,
+      translatedArgs,
       ctx
     )
     return {

--- a/node/utils/ioMessage.ts
+++ b/node/utils/ioMessage.ts
@@ -1,6 +1,8 @@
 import { Segment } from '@vtex/api'
 import { prop } from 'ramda'
 
+import { Slugify } from '../resolvers/catalog/slug'
+
 const localeFromDefaultSalesChannel = (segment: Segment) =>
   segment.getSegmentByToken(null).then(prop('cultureInfo'))
 
@@ -27,3 +29,10 @@ export const toFacetIOMessage = (segment: Segment, content: string, id: string) 
   content,
   `SpecificationFilter-id.${id}::${content}`
 )
+
+export const toSearchTerm = (term: string, from: string, description: string = '') => ({
+  id: `Search::${Slugify(term)}`,
+  description,
+  content: term,
+  from,
+})


### PR DESCRIPTION
#### What is the purpose of this pull request?
Uses messages in autocomplete and productSearch resolvers for translating terms before sending then to catalog API

To test, just visit this [link](https://gimenes--storecomponents.myvtex.com/)

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
