### PR TITLE
Add check for when user is impersonated in passwordLastUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+- Check for when user is impersonated in `getPasswordLastUpdate`
+
 ## [2.74.0] - 2019-05-16
 ### Fixed
 - `document` resolvers working according to the graphql schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## Added
-- Check for when user is impersonated in `getPasswordLastUpdate`
+- Check when user is impersonated in `getPasswordLastUpdate`
 
 ## [2.74.0] - 2019-05-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.74.1] - 2019-05-16
+
 ## Added
 - Check when user is impersonated in `getPasswordLastUpdate`
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.74.0",
+  "version": "2.74.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/profile/fieldResolvers.ts
+++ b/node/resolvers/profile/fieldResolvers.ts
@@ -19,9 +19,7 @@ export default {
       typeof obj.customFields === 'string'
         ? pickCustomFieldsFromData(obj.customFields, obj)
         : obj.customFields,
-    passwordLastUpdate: (_: any, __: any, context: any) => {
-      return getPasswordLastUpdate(context)
-    },
+    passwordLastUpdate: (_: any, __: any, context: any) => getPasswordLastUpdate(context),
     payments: (_: any, __: any, context: any) => getPayments(context),
     profilePicture: (obj: any, _: any, context: any) =>
       obj.profilePicture &&

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -42,11 +42,12 @@ export function getPasswordLastUpdate(context: Context) {
   const url = paths.getUser(account)
   const parsedCookies = parse(cookie)
   const userCookie: string = parsedCookies[`VtexIdclientAutCookie_${account}`]
-  return makeRequest(context.vtex, url, 'GET', undefined, userCookie).then(
-    (response: any) => {
-      return response.data.passwordLastUpdate
-    }
-  )
+
+  if (!userCookie) return null
+
+  return makeRequest(context.vtex, url, 'GET', undefined, userCookie).then((response: any) => {
+    return response.data.passwordLastUpdate
+  })
 }
 
 export function getAddresses(context: Context) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Title is self-explanatory

#### What problem is this solving?

If it was an impersonated user, an error would be thrown, not allowing him/her to access personal data.

#### How should this be manually tested?

https://arthur--recorrenciaqa.myvtexdev.com/_v/vtex.store-graphql@2.73.3/graphiql/v1

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
