### PR TITLE
Added product category ids on OrderFormItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.83.0] - 2019-06-14
+
 ### Added
 
 - `customData` attachment to type `orderForm`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `customData` attachment to type `orderForm`.
+- Fields `productCategoryIds`, `priceTags` and `measurementUnit` to type `OrderFormItem`.
+
 ## [2.82.0] - 2019-06-14
 
 ### Added

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -66,7 +66,7 @@ type OrderFormItem {
   """ Category ids on orderFormItem """
   productCategoryIds: String
   """ Price tags on orderFormItem """
-  priceTags: []
+  priceTags: [String]
   """ measurementUnit on orderFormItem """
   measurementUnit: String
 }

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -67,6 +67,8 @@ type OrderFormItem {
   productCategoryIds: String
   """ Price tags on orderFormItem """
   priceTags: []
+  """ measurementUnit on orderFormItem """
+  measurementUnit: String
 }
 
 type AssemblyOptionItem {

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -65,6 +65,8 @@ type OrderFormItem {
   cartIndex: Int
   """ Category ids on orderFormItem """
   productCategoryIds: String
+  """ Price tags on orderFormItem """
+  priceTags: []
 }
 
 type AssemblyOptionItem {

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -81,9 +81,17 @@ type OrderFormItem {
   """ Category ids on orderFormItem """
   productCategoryIds: String
   """ Price tags on orderFormItem """
-  priceTags: [String]
+  priceTags: [PriceTags]
   """ measurementUnit on orderFormItem """
   measurementUnit: String
+}
+
+type PriceTags {
+  identifier: String
+  isPercentual: Boolean
+  name: String
+  rawValue: Int
+  value: Int
 }
 
 type AssemblyOptionItem {

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -24,18 +24,16 @@ type OrderForm {
 }
 
 type CustomData {
-  customApps: [CustomApps]
+  customApps: [CustomApp]
 }
 
-type CustomApps {
-  fields: Fields
+scalar CustomFields
+type CustomApp {
+  fields: CustomFields
   id: String
   major: Int
 }
 
-type Fields {
-  substituteType: String
-}
 
 type StorePreferencesData {
   countryCode: String

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -63,6 +63,8 @@ type OrderFormItem {
   seller: String
   """ Item index on cart """
   cartIndex: Int
+  """ Category ids on orderFormItem """
+  productCategoryIds: String
 }
 
 type AssemblyOptionItem {

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -2,6 +2,7 @@ type OrderForm {
   """ orderFormId is used as cacheId """
   cacheId: ID
   orderFormId: String
+  customData: CustomData
   value: Float
   items: [OrderFormItem]
   salesChannel: String
@@ -20,6 +21,20 @@ type OrderForm {
   itemMetadata: ItemMetadata
   checkedInPickupPointId: String
   pickupPointCheckedIn: PickupPoint
+}
+
+type CustomData {
+  customApps: [CustomApps]
+}
+
+type CustomApps {
+  fields: Fields
+  id: String
+  major: Int
+}
+
+type Fields {
+  substituteType: String
 }
 
 type StorePreferencesData {

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "vendor": "vtex",
+  "vendor": "codeby",
   "name": "store-graphql",
   "version": "2.82.0",
   "title": "GraphQL API for the VTEX store APIs",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.82.0",
+  "version": "2.83.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "vendor": "codeby",
+  "vendor": "vtex",
   "name": "store-graphql",
   "version": "2.82.0",
   "title": "GraphQL API for the VTEX store APIs",

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -58,7 +58,7 @@ declare global {
     parentItemIndex: number
     parentAssemblyBinding: string
     productCategoryIds: string
-    priceTags: []
+    priceTags: string[]
     measurementUnit: string
   }
 

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -59,6 +59,7 @@ declare global {
     parentAssemblyBinding: string
     productCategoryIds: string
     priceTags: []
+    measurementUnit: string
   }
 
   interface UserAddress {

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -57,6 +57,7 @@ declare global {
     isGift: boolean
     parentItemIndex: number
     parentAssemblyBinding: string
+    productCategoryIds: string
   }
 
   interface UserAddress {

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -58,6 +58,7 @@ declare global {
     parentItemIndex: number
     parentAssemblyBinding: string
     productCategoryIds: string
+    priceTags: []
   }
 
   interface UserAddress {

--- a/node/resolvers/checkout/orderFormItem.ts
+++ b/node/resolvers/checkout/orderFormItem.ts
@@ -16,8 +16,5 @@ export const resolvers = {
     listPrice: ({ listPrice }: Params) => listPrice / 100,
     price: ({ price }: Params) => price / 100,
     sellingPrice: ({ sellingPrice }: Params) => sellingPrice / 100,
-    productCategoryIds: ({ productCategoryIds }: Params) => productCategoryIds,
-    priceTags: ({ priceTags }: Params) => priceTags,
-    measurementUnit: ({ measurementUnit }: Params) => measurementUnit,
   }
 }

--- a/node/resolvers/checkout/orderFormItem.ts
+++ b/node/resolvers/checkout/orderFormItem.ts
@@ -17,5 +17,6 @@ export const resolvers = {
     price: ({ price }: Params) => price / 100,
     sellingPrice: ({ sellingPrice }: Params) => sellingPrice / 100,
     productCategoryIds: ({ productCategoryIds }: Params) => productCategoryIds,
+    priceTags: ({ priceTags }: Params) => priceTags,
   }
 }

--- a/node/resolvers/checkout/orderFormItem.ts
+++ b/node/resolvers/checkout/orderFormItem.ts
@@ -18,5 +18,6 @@ export const resolvers = {
     sellingPrice: ({ sellingPrice }: Params) => sellingPrice / 100,
     productCategoryIds: ({ productCategoryIds }: Params) => productCategoryIds,
     priceTags: ({ priceTags }: Params) => priceTags,
+    measurementUnit: ({ measurementUnit }: Params) => measurementUnit,
   }
 }

--- a/node/resolvers/checkout/orderFormItem.ts
+++ b/node/resolvers/checkout/orderFormItem.ts
@@ -16,5 +16,6 @@ export const resolvers = {
     listPrice: ({ listPrice }: Params) => listPrice / 100,
     price: ({ price }: Params) => price / 100,
     sellingPrice: ({ sellingPrice }: Params) => sellingPrice / 100,
+    productCategoryIds: ({ productCategoryIds }: Params) => productCategoryIds,
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Added ProductCategoryIds in each item of an OrderFormItem

#### What problem is this solving?
Allows the category id in the items

#### How should this be manually tested?
we can add productCategoryIds section to item in OrderForm graphql query and run that query in graphql console

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
