### PR TITLE
implement breadcrumb field on product search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use better resolver architecture at productSearch query.
+
+### Added
+- breadcrum resolver at productSearch.
 
 ## [2.74.4] - 2019-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.75.0] - 2019-05-20
 ### Changed
 - Use better resolver architecture at productSearch query.
 

--- a/graphql/types/ProductSearch.graphql
+++ b/graphql/types/ProductSearch.graphql
@@ -3,4 +3,10 @@ type ProductSearch {
   recordsFiltered: Int
   titleTag: String
   metaTagDescription: String
+  breadcrumb: [SearchBreadcrumb]
+}
+
+type SearchBreadcrumb {
+  name: String!
+  href: String
 }

--- a/graphql/types/ProductSearch.graphql
+++ b/graphql/types/ProductSearch.graphql
@@ -7,6 +7,6 @@ type ProductSearch {
 }
 
 type SearchBreadcrumb {
-  name: String!
+  name: IOMessage
   href: String
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.74.4",
+  "version": "2.75.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -58,7 +58,7 @@ export class CatalogDataSource extends IODataSource {
     {metric: 'catalog-productBySku'}
   )
 
-  public products = (args: ProductsArgs) => this.get(
+  public products = (args: ProductsArgs) => this.get<Product[]>(
     this.productSearchUrl(args),
     {metric: 'catalog-products'}
   )

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -28,7 +28,7 @@ import { resolvers as searchResolvers } from './search'
 import { resolvers as skuResolvers } from './sku'
 import { resolvers as breadcrumbResolvers } from './searchBreadcrumb'
 import { resolvers as productSearchResolvers } from './productSearch'
-import { CatalogSlugify } from './slug'
+import { catalogSlugify } from './slug'
 import { findCategoryInTree, getBrandFromSlug } from './utils'
 
 interface SearchContext {
@@ -326,7 +326,7 @@ export const queries = {
 
     if (args.brand) {
       const brands = await catalog.brands()
-      const found = brands.find(brand => brand.isActive && CatalogSlugify(brand.name) === args.brand)
+      const found = brands.find(brand => brand.isActive && catalogSlugify(brand.name) === args.brand)
       response.brand = found ? found.id : null
     }
 

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -81,7 +81,7 @@ const categoryMetaData = async (_: any, args: ProductsArgs, ctx: any): Promise<M
  */
 const brandMetaData = async (_: any, args: ProductsArgs, ctx: any): Promise<Metadata> => {
   const brandSlug = toLower(last(args.query.split('/')) || '')
-  const brand = getBrandFromSlug(brandSlug, ctx) || {}
+  const brand = await getBrandFromSlug(brandSlug, ctx) || {}
   return {
     metaTagDescription: path(['metaTagDescription'], brand),
     titleTag: path(['title'], brand) || path(['name'], brand),

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -95,7 +95,7 @@ const brandMetaData = async (_: any, args: ProductsArgs, ctx: any): Promise<Meta
  * @param args
  * @param ctx
  */
-const searchMetaData = async (_: any, args: ProductsArgs, ctx: any) => {
+const getSearchMetaData = async (_: any, args: ProductsArgs, ctx: any) => {
   const { map } = args
   const lastMap = last(map.split(','))
 
@@ -247,10 +247,13 @@ export const queries = {
       ...args,
       query,
     }
-    const products = await queries.products(_, translatedArgs, ctx)
+    const [products, searchMetaData] = await all([
+      queries.products(_, translatedArgs, ctx),
+      getSearchMetaData(_, translatedArgs, ctx),
+    ])
     return {
       translatedArgs,
-      searchMetaData: await searchMetaData(_, translatedArgs, ctx),
+      searchMetaData,
       products,
     }
   },
@@ -300,7 +303,7 @@ export const queries = {
       throw new UserInputError('Search query/map cannot be null')
     }
 
-    const { titleTag, metaTagDescription }: any = await searchMetaData(
+    const { titleTag, metaTagDescription }: any = await getSearchMetaData(
       _,
       args,
       ctx

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -6,7 +6,6 @@ import {
   find,
   head,
   last,
-  merge,
   path,
   prop,
   split,
@@ -57,14 +56,8 @@ const getBrandFromSlug = async (brandSlug: string, {dataSources:{catalog}}: Cont
 }
 
 const findClusterNameFromId = (products: Product[], clusterId: string) => {
-  // Slice only the first fifty to prevent problem if this products array eventually get to thousands of units
-  const allSearchableClusters = 
-    products.slice(0, 50).reduce<Record<string, string>>((acc, prod) => {
-      const { searchableClusters } = prod
-      return merge(acc, searchableClusters)
-    }, 
-    {})
-  return allSearchableClusters[clusterId]
+  const productWithCluster = products.find(({ productClusters }) => !!productClusters[clusterId])
+  return productWithCluster && productWithCluster.productClusters[clusterId]
 }
 
 const buildBreadCrumb = async ({ query, map }: ProductsArgs, products: Product[], ctx: Context) => {

--- a/node/resolvers/catalog/productSearch.ts
+++ b/node/resolvers/catalog/productSearch.ts
@@ -1,0 +1,33 @@
+import { path, zip } from 'ramda'
+export const resolvers = {
+  ProductSearch: {
+    titleTag: path(['searchMetaData', 'titleTag']),
+    metaTagDescription: path(['searchMetaData', 'metaTagDescription']),
+    recordsFiltered: ({ translatedArgs }: { translatedArgs: ProductsArgs }, _: any, {dataSources: { catalog }}: Context) =>
+      catalog.productsQuantity(translatedArgs),
+
+    breadcrumb: async ({ translatedArgs, products }: { translatedArgs: ProductsArgs, products: Product[] }, _: any, ctx: Context) => {
+      const {dataSources: { catalog }} = ctx
+      const queryAndMap = zip(
+        translatedArgs.query
+          .toLowerCase()
+          .split('/')
+          .map(decodeURIComponent),
+        translatedArgs.map.split(',')
+      )
+      const categoriesCount = translatedArgs.map.split(',').filter(m => m === 'c').length
+      const categories = categoriesCount ? (await catalog.categories(categoriesCount)) : []
+      const categoriesSearched = queryAndMap.filter(([_, m]) => m === 'c').map(([q]) => q)
+      return queryAndMap.map(([queryUnit, mapUnit]: [string, string], index: number) => ({
+        queryUnit,
+        mapUnit,
+        index,
+        queryArray: translatedArgs.query.split('/'),
+        mapArray: translatedArgs.map.split(','),
+        categories,
+        categoriesSearched,
+        products,
+      }))
+    }
+  }
+}

--- a/node/resolvers/catalog/searchBreadcrumb.ts
+++ b/node/resolvers/catalog/searchBreadcrumb.ts
@@ -20,7 +20,7 @@ const findClusterNameFromId = (products: Product[], clusterId: string) => {
 
 export const resolvers = {
   SearchBreadcrumb: {
-    name: async (obj: BreadcrumbParams, args: any, ctx: Context) => {
+    name: async (obj: BreadcrumbParams, _: any, ctx: Context) => {
       const {clients: {segment}} = ctx
       const { queryUnit, mapUnit, index, queryArray, categories, categoriesSearched, products } = obj
       let name = queryArray[index]

--- a/node/resolvers/catalog/searchBreadcrumb.ts
+++ b/node/resolvers/catalog/searchBreadcrumb.ts
@@ -39,8 +39,8 @@ export const resolvers = {
         }
       }
       if (mapUnit === 'b') {
-        const brand = await getBrandFromSlug(toLower(queryUnit), ctx) || {}
-        return brand.name || defaultName
+        const brand = await getBrandFromSlug(toLower(queryUnit), ctx)
+        return brand ? brand.name : defaultName
       }
       return defaultName
     },

--- a/node/resolvers/catalog/searchBreadcrumb.ts
+++ b/node/resolvers/catalog/searchBreadcrumb.ts
@@ -30,8 +30,7 @@ export const resolvers = {
         const queryPosition = categoriesSearched.findIndex(cat => cat === queryUnit)
         const category = findCategoryInTree(categories, categoriesSearched.slice(0, queryPosition + 1))
         if (category) {
-          const nameIoMessage = await toCategoryIOMessage('name')(segment, category.name, category.id)
-          return nameIoMessage.content
+          return toCategoryIOMessage('name')(segment, category.name, category.id)
         }
         // if cant find a category, we should try to see if its a product cluster
         const clusterName = findClusterNameFromId(products, queryUnit)

--- a/node/resolvers/catalog/searchBreadcrumb.ts
+++ b/node/resolvers/catalog/searchBreadcrumb.ts
@@ -26,6 +26,12 @@ export const resolvers = {
       const {clients: {segment}} = ctx
       const { queryUnit, mapUnit, index, queryArray, categories, categoriesSearched, products } = obj
       const defaultName = queryArray[index]
+      if (mapUnit === 'productClusterIds') {
+        const clusterName = findClusterNameFromId(products, queryUnit)
+        if (clusterName) {
+          return toClusterIOMessage(segment, clusterName, queryUnit)
+        }
+      }
       if (mapUnit === 'c') {
         const queryPosition = categoriesSearched.findIndex(cat => cat === queryUnit)
         const category = findCategoryInTree(categories, categoriesSearched.slice(0, queryPosition + 1))

--- a/node/resolvers/catalog/searchBreadcrumb.ts
+++ b/node/resolvers/catalog/searchBreadcrumb.ts
@@ -50,7 +50,15 @@ export const resolvers = {
       }
       return defaultName
     },
-    href: ({ index, queryArray, mapArray }: BreadcrumbParams) =>
-      `/${sliceAndJoin(queryArray, index+1, '/')}?map=${sliceAndJoin(mapArray, index+1, ',')}`
+    href: ({ index, queryArray, mapArray, mapUnit, queryUnit }: BreadcrumbParams) => {
+      if (index === 0 && mapUnit === 'c') {
+        return `/${queryUnit}/d`
+      }
+      if (index === 0 && mapUnit === 'b') {
+        return `/${queryUnit}/b`
+      }
+      return `/${sliceAndJoin(queryArray, index+1, '/')}?map=${sliceAndJoin(mapArray, index+1, ',')}`
+    }
+      
   }
 }

--- a/node/resolvers/catalog/searchBreadcrumb.ts
+++ b/node/resolvers/catalog/searchBreadcrumb.ts
@@ -1,0 +1,50 @@
+import { toLower } from 'ramda'
+import { findCategoryInTree, getBrandFromSlug } from "./utils"
+import { toCategoryIOMessage } from "../../utils/ioMessage"
+
+interface BreadcrumbParams {
+  queryUnit: string
+  mapUnit: string
+  index: number
+  queryArray: string[]
+  mapArray: string[]
+  categories: Category[]
+  categoriesSearched: string[]
+  products: Product[]
+}
+
+const findClusterNameFromId = (products: Product[], clusterId: string) => {
+  const productWithCluster = products.find(({ productClusters }) => !!productClusters[clusterId])
+  return productWithCluster && productWithCluster.productClusters[clusterId]
+}
+
+export const resolvers = {
+  SearchBreadcrumb: {
+    name: async (obj: BreadcrumbParams, args: any, ctx: Context) => {
+      const {clients: {segment}} = ctx
+      const { queryUnit, mapUnit, index, queryArray, categories, categoriesSearched, products } = obj
+      let name = queryArray[index]
+      if (mapUnit === 'c') {
+        const queryPosition = categoriesSearched.findIndex(cat => cat === queryUnit)
+        const category = findCategoryInTree(categories, categoriesSearched.slice(0, queryPosition + 1))
+        if (category) {
+          const nameIoMessage = await toCategoryIOMessage('name')(segment, category.name, category.id)
+          name = nameIoMessage.content
+        }
+        // if cant find a category, we should try to see if its a product cluster
+        const clusterName = findClusterNameFromId(products, queryUnit)
+        name = clusterName || name
+      }
+      if (mapUnit === 'b') {
+        const brand = await getBrandFromSlug(toLower(queryUnit), ctx) || {}
+        name = brand.name || name
+      }
+      return name
+    },
+    href: async (obj: BreadcrumbParams) => {
+      const { index, queryArray, mapArray } = obj
+      const isLast = index === mapArray.length - 1
+      return isLast ? null : '/' + queryArray.slice(0, index + 1).join('/') + '?map=' + mapArray.slice(0, index + 1)
+    }
+  }
+}

--- a/node/resolvers/catalog/searchBreadcrumb.ts
+++ b/node/resolvers/catalog/searchBreadcrumb.ts
@@ -23,28 +23,27 @@ export const resolvers = {
     name: async (obj: BreadcrumbParams, _: any, ctx: Context) => {
       const {clients: {segment}} = ctx
       const { queryUnit, mapUnit, index, queryArray, categories, categoriesSearched, products } = obj
-      let name = queryArray[index]
+      const defaultName = queryArray[index]
       if (mapUnit === 'c') {
         const queryPosition = categoriesSearched.findIndex(cat => cat === queryUnit)
         const category = findCategoryInTree(categories, categoriesSearched.slice(0, queryPosition + 1))
         if (category) {
           const nameIoMessage = await toCategoryIOMessage('name')(segment, category.name, category.id)
-          name = nameIoMessage.content
+          return nameIoMessage.content
         }
         // if cant find a category, we should try to see if its a product cluster
         const clusterName = findClusterNameFromId(products, queryUnit)
-        name = clusterName || name
+        return clusterName || defaultName
       }
       if (mapUnit === 'b') {
         const brand = await getBrandFromSlug(toLower(queryUnit), ctx) || {}
-        name = brand.name || name
+        return brand.name || defaultName
       }
-      return name
+      return defaultName
     },
     href: async (obj: BreadcrumbParams) => {
       const { index, queryArray, mapArray } = obj
-      const isLast = index === mapArray.length - 1
-      return isLast ? null : '/' + queryArray.slice(0, index + 1).join('/') + '?map=' + mapArray.slice(0, index + 1)
+      return '/' + queryArray.slice(0, index + 1).join('/') + '?map=' + mapArray.slice(0, index + 1)
     }
   }
 }

--- a/node/resolvers/catalog/searchBreadcrumb.ts
+++ b/node/resolvers/catalog/searchBreadcrumb.ts
@@ -18,6 +18,8 @@ const findClusterNameFromId = (products: Product[], clusterId: string) => {
   return productWithCluster && productWithCluster.productClusters[clusterId]
 }
 
+const sliceAndJoin = (array: string[], max: number, joinChar: string) => array.slice(0, max).join(joinChar)
+
 export const resolvers = {
   SearchBreadcrumb: {
     name: async (obj: BreadcrumbParams, _: any, ctx: Context) => {
@@ -41,9 +43,7 @@ export const resolvers = {
       }
       return defaultName
     },
-    href: async (obj: BreadcrumbParams) => {
-      const { index, queryArray, mapArray } = obj
-      return '/' + queryArray.slice(0, index + 1).join('/') + '?map=' + mapArray.slice(0, index + 1)
-    }
+    href: ({ index, queryArray, mapArray }: BreadcrumbParams) =>
+      `/${sliceAndJoin(queryArray, index+1, '/')}?map=${sliceAndJoin(mapArray, index+1, ',')}`
   }
 }

--- a/node/resolvers/catalog/searchBreadcrumb.ts
+++ b/node/resolvers/catalog/searchBreadcrumb.ts
@@ -1,6 +1,6 @@
 import { toLower } from 'ramda'
 import { findCategoryInTree, getBrandFromSlug } from "./utils"
-import { toCategoryIOMessage } from "../../utils/ioMessage"
+import { toCategoryIOMessage, toClusterIOMessage } from "../../utils/ioMessage"
 
 interface BreadcrumbParams {
   queryUnit: string
@@ -34,7 +34,9 @@ export const resolvers = {
         }
         // if cant find a category, we should try to see if its a product cluster
         const clusterName = findClusterNameFromId(products, queryUnit)
-        return clusterName || defaultName
+        if (clusterName) {
+          return toClusterIOMessage(segment, clusterName, queryUnit)
+        }
       }
       if (mapUnit === 'b') {
         const brand = await getBrandFromSlug(toLower(queryUnit), ctx) || {}

--- a/node/resolvers/catalog/slug.ts
+++ b/node/resolvers/catalog/slug.ts
@@ -5,7 +5,7 @@ export function Slugify(str: any) {
 }
 
 // Parameter "S. Coifman" should output "s--coifman"
-export function CatalogSlugify(str: string) {
+export function catalogSlugify(str: string) {
   // According to Bacelar, the catalog API uses a legacy method for slugifying strings.
   // It replaces all dots and spaces with - and then removes special characters.
   const slugified = slugify(str, { lower: true, remove: /[*+~()'"!:@]/g })

--- a/node/resolvers/catalog/slug.ts
+++ b/node/resolvers/catalog/slug.ts
@@ -3,3 +3,12 @@ import slugify from 'slugify'
 export function Slugify(str: any) {
   return slugify(str, { lower: true, remove: /[*+~.()'"!:@]/g })
 }
+
+// Parameter "S. Coifman" should output "s--coifman"
+export function CatalogSlugify(str: string) {
+  // According to Bacelar, the catalog API uses a legacy method for slugifying strings.
+  // It replaces all dots and spaces with - and then removes special characters.
+  const slugified = slugify(str, { lower: true, remove: /[*+~()'"!:@]/g })
+  // Now replace dots for -
+  return slugified.replace(/\./g, '-')
+}

--- a/node/resolvers/catalog/utils.ts
+++ b/node/resolvers/catalog/utils.ts
@@ -20,7 +20,7 @@ export function findCategoryInTree(tree: Category[], values: string[], index = 0
 
 export const getBrandFromSlug = async (brandSlug: string, {dataSources:{catalog}}: Context)  => {
   const brands = await catalog.brands()
-  return <Brand>find(
+  return find<Brand>(
     compose(
       equals(brandSlug),
       toLower,

--- a/node/resolvers/catalog/utils.ts
+++ b/node/resolvers/catalog/utils.ts
@@ -1,0 +1,32 @@
+import { compose, last, split, find, equals, toLower, prop } from 'ramda'
+import { CatalogSlugify } from './slug';
+const lastSegment = compose<string, string[], string>(
+  last,
+  split('/')
+)
+
+export function findCategoryInTree(tree: Category[], values: string[], index = 0): Category | null {
+  for (const node of tree) {
+    const slug = lastSegment(node.url)
+    if (slug.toUpperCase() === values[index].toUpperCase()) {
+      if (index === values.length - 1) {
+        return node
+      }
+      return findCategoryInTree(node.children, values, index + 1)
+    }
+  }
+  return null
+}
+
+export const getBrandFromSlug = async (brandSlug: string, {dataSources:{catalog}}: Context)  => {
+  const brands = await catalog.brands()
+  return <Brand>find(
+    compose(
+      equals(brandSlug),
+      toLower,
+      CatalogSlugify,
+      prop('name') as any
+    ),
+    brands
+  )
+}

--- a/node/resolvers/catalog/utils.ts
+++ b/node/resolvers/catalog/utils.ts
@@ -1,5 +1,5 @@
 import { compose, last, split, find, equals, toLower, prop } from 'ramda'
-import { CatalogSlugify } from './slug';
+import { catalogSlugify } from './slug';
 const lastSegment = compose<string, string[], string>(
   last,
   split('/')
@@ -24,7 +24,7 @@ export const getBrandFromSlug = async (brandSlug: string, {dataSources:{catalog}
     compose(
       equals(brandSlug),
       toLower,
-      CatalogSlugify,
+      catalogSlugify,
       prop('name') as any
     ),
     brands

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -29,7 +29,10 @@ interface Category {
   id: string
   name: string
   url: string
+  hasChildren: boolean
   children: Category[]
+  MetaTagDescription: string
+  Title: string
 }
 
 interface FacetsArgs {
@@ -37,4 +40,24 @@ interface FacetsArgs {
   query: string
   map: string
   hideUnavailableItems: boolean
+}
+
+interface Product {
+  productId: string
+  productName: string
+  brand: string
+  brandId: number
+  linkText: string
+  productReference: string
+  categoryId: string
+  productTitle: string
+  metaTagDescription: string
+  clusterHighlights: Record<string, string>
+  productClusters: Record<string, string>
+  searchableClusters: Record<string, string>
+  categories: string[]
+  categoriesIds: string[]
+  link: string
+  description: string
+  items: any[]
 }

--- a/node/utils/ioMessage.ts
+++ b/node/utils/ioMessage.ts
@@ -30,6 +30,12 @@ export const toFacetIOMessage = (segment: Segment, content: string, id: string) 
   `SpecificationFilter-id.${id}::${content}`
 )
 
+export const toClusterIOMessage = (segment: Segment, content: string, id: string) => toIOMessage(
+  segment,
+  content,
+  `ProductCluster-id.${id}::${content}`
+)
+
 export const toSearchTerm = (term: string, from: string, description: string = '') => ({
   id: `Search::${Slugify(term)}`,
   description,


### PR DESCRIPTION
https://fidelis--invictastores.myvtex.com/_v/vtex.store-graphql@2.74.3/graphiql/v1

Please try queries like:
https://fidelis--invictastores.myvtex.com/_v/vtex.store-graphql@2.74.3/graphiql/v1?query=query%20%7B%0A%20%20brand%3A%20productSearch(query%3A%20%22collections%2FMens%2FS--Coifman%22%2C%20map%3A%20%22c%2CspecificationFilter_69%2Cb%22)%20%7B%0A%20%20%20%20breadcrumb%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20href%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20cluster%3A%20productSearch(query%3A%20%22collections%2F140%22%2C%20map%3A%20%22c%2Cc%22)%20%7B%0A%20%20%20%20breadcrumb%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20href%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D

With categories, specification filters, brand:
```
query {
  productSearch(query: "collections/Mens/S--Coifman", map: "c,specificationFilter_69,b") {
    breadcrumb {
      name
      href
    }
  }
}
```

Cluster search example:
```
query {
  productSearch(query: "collections/140", map: "c,c") {
    breadcrumb {
      name
      href
    }
  }
}
```

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
