### PR TITLE
get recordsFiltered and products from same catalog query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Eliminate two queries to catalog at the productSearch for products and recordFiltered.
 
 ## [2.76.0] - 2019-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.76.1] - 2019-05-23
 ### Fixed
 
 - Eliminate two queries to catalog at the productSearch for products and recordFiltered.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.76.0",
+  "version": "2.76.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/dataSources/catalog.ts
+++ b/node/dataSources/catalog.ts
@@ -58,10 +58,13 @@ export class CatalogDataSource extends IODataSource {
     {metric: 'catalog-productBySku'}
   )
 
-  public products = (args: ProductsArgs) => this.get<Product[]>(
-    this.productSearchUrl(args),
-    {metric: 'catalog-products'}
-  )
+  public products = (args: ProductsArgs, useRaw = false) => {
+    const method = useRaw ? this.getRaw : this.get
+    return method<Product[]>(
+      this.productSearchUrl(args),
+      {metric: 'catalog-products'}
+    )
+  } 
 
   public productsQuantity = async (args: ProductsArgs) => {
     const {headers: {resources}} = await this.getRaw(this.productSearchUrl(args))

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -243,6 +243,12 @@ export const queries = {
       clients,
       dataSources:{catalog}
     } = ctx
+    const queryTerm = args.query
+    if (queryTerm == null || test(/[?&[\]=]/, queryTerm)) {
+      throw new UserInputError(
+        `The query term contains invalid characters. query=${queryTerm}`
+      )
+    }
     const query = await translateToStoreDefaultLanguage(clients, args.query)
     const translatedArgs = {
       ...args,

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -241,20 +241,21 @@ export const queries = {
   productSearch: async (_: any, args: ProductsArgs, ctx: Context) => {
     const {
       clients,
+      dataSources:{catalog}
     } = ctx
     const query = await translateToStoreDefaultLanguage(clients, args.query)
     const translatedArgs = {
       ...args,
       query,
     }
-    const [products, searchMetaData] = await all([
-      queries.products(_, translatedArgs, ctx),
+    const [productsRaw, searchMetaData] = await all([
+      catalog.products(args, true),
       getSearchMetaData(_, translatedArgs, ctx),
     ])
     return {
       translatedArgs,
       searchMetaData,
-      products,
+      productsRaw,
     }
   },
 


### PR DESCRIPTION
Every search we would do the same query twice at the catalog, one for the products and other just to get the response header and get the records filtered.

This PR makes both resolver get the data from the same query.

https://prodsearch--invictastores.myvtex.com/_v/vtex.store-graphql@2.76.0/graphiql/v1?query=query%20%7B%0A%20%20productSearch%20(query%3A%20%22collections%22%2C%20map%3A%22c%22)%20%7B%0A%20%20%20%20products%20%7B%0A%20%20%20%20%20%20productName%0A%20%20%20%20%7D%0A%20%20%20%20recordsFiltered%0A%20%20%20%20breadcrumb%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20href%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D

<img width="1481" alt="Screen Shot 2019-05-23 at 12 14 15 PM" src="https://user-images.githubusercontent.com/4925068/58264479-521f0400-7d54-11e9-9628-756cc7025529.png">

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
