### PR TITLE
[BUGFIX] Removed comma from query url on dataentities request

### DIFF
--- a/node/clients/masterdata.ts
+++ b/node/clients/masterdata.ts
@@ -118,7 +118,7 @@ function paginationArgsToHeaders({ page, pageSize }: PaginationArgs) {
 }
 
 function generateFieldsArg(fields: string[]) {
-  return fields.reduce((previous, current) => `${previous}${current},`, '')
+  return fields.join(',')
 }
 
 interface PaginationArgs {


### PR DESCRIPTION
#### What is the purpose of this pull request?
To fix an extra comma on the dataentities query parameters url

#### What problem is this solving?
Dataentities request had an extra comma at the end of the fields query url, which produced an `Cannot read private fields` error.

#### How should this be manually tested?
Create a query on Graphiql and see the url request path produced. At the _fields query param, you should see no extra comma before the _where param. 

#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
