### PR TITLE
Corrected query string formats for catalog client methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Corrected query string formats for `productByEan` and `productByReference` catalog client methods 
+
 ## [2.80.0] - 2019-06-07
 
 ### Changed

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -26,7 +26,7 @@ export class Catalog extends AppClient {
   )
 
   public productByEan = (id: string) => this.get<Product[]>(
-    `/pub/products/search?fq=alternateIds_Ean=${id}`,
+    `/pub/products/search?fq=alternateIds_Ean:${id}`,
     {metric: 'catalog-productByEan'}
   )
 
@@ -36,7 +36,7 @@ export class Catalog extends AppClient {
   )
 
   public productByReference = (id: string) => this.get<Product[]>(
-    `/pub/products/search?fq=alternateIds_RefId=${id}`,
+    `/pub/products/search?fq=alternateIds_RefId:${id}`,
     {metric: 'catalog-productByReference'}
   )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow product graphQL queries to work correctly when using EAN and Reference identifiers.

#### What problem is this solving?
`productByEan` and `productByReference` were incorrectly using a "=" character instead of a ":" when sending a request to the catalog API.

#### How should this be manually tested?
Checkout this branch, link to a workspace, then use GraphiQL to query a product using EAN or Reference Code. For example this query on account alssports:

```
query product {
  product(identifier: { field: reference, value: "PAT24020"}) {
    productName
  }
}
```

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
