### PR TITLE
Add invoicedDate to Order type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `invoicedDate` into Order type
 
 ## [2.85.0] - 2019-06-26
 ### Added

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -9,6 +9,7 @@ type Order {
   lastChange: String
   timeZoneCreationDate: String
   timeZoneLastChange: String
+  invoicedDate: String
   isCompleted: Boolean
   items: [OrderItem]
   sellers: [OrderItemSeller]


### PR DESCRIPTION
#### What is the purpose of this pull request?
Some Apps have to verify if `invoicedDate` is between some date to validate the order to continue the flow like a "Returning Products" or similar.

#### What problem is this solving?
With the `invoicedDate` we can validate and show when the order was invoiced.

#### How should this be manually tested?
1. Go to [GraphiQL](https://troca--tokstok.myvtex.com/_v/acupula.tokstok-troca-e-devolucao@0.1.0/graphiql/v1?operationName=order&query=query%20order%20%7B%0A%20%20%20%20order(id%3A%20%22882823036831-01%22)%20%7B%0A%20%20%20%20%20%20%09invoicedDate%0A%20%20%20%20%7D%20%0A%7D)(link with the order query and order ID)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/29849615/59298296-9f5e0980-8c60-11e9-8895-a8a56ea2d682.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
