### PR TITLE
Add `selectedSla` to `LogisticInfo` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
-- Add `invoicedDate` into Order type
+
+- `invoicedDate` into Order type
+- `selectedSla` to `LogisticInfo` type
 
 ## [2.85.0] - 2019-06-26
+
 ### Added
-- Add `productCategoryIds` into `OrderItem` type
+
+- `productCategoryIds` into `OrderItem` type
 
 ## [2.84.1] - 2019-06-25
 

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -18,6 +18,7 @@ type MessageFields {
 
 type LogisticsInfo {
   itemIndex: String
+  selectedSla: String
   slas: [ShippingSLA]
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make `selectedSla` available in `LogisticInfo` type;

#### What problem is this solving?
Some apps need to validate and display which delivery method was selected.

#### How should this be manually tested?
1. Follow this [GraphiQL](https://selectedmethod--tokstok.myvtex.com/_v/vtex.store-graphql@2.80.3/graphiql/v1?operationName=order&query=query%20order%20%7B%0A%20%20order(id%3A%20%22939031623492-01%22)%20%7B%0A%20%20%20%20shippingData%20%7B%0A%20%20%20%20%20%20logisticsInfo%20%7B%0A%20%20%20%20%20%20%20%20selectedSla%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A) link;
2. This page is ready with the query and the order ID.

#### Screenshots or example usage
![image](https://gitlab.com/acct.global/acct.apps/vtex.io/vtex.store-graphql/uploads/b9e140c6df4565a1fc2395ef8635bc37/image.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
