### PR TITLE
Adding deliveryIds fields in ShippingSimulation Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Field `deliveryIds` to ShippingSLA in the shipping Query.
+
 ## [2.81.0] - 2019-06-12
 
 ### Added

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -27,6 +27,15 @@ type ShippingSLA {
   price: Float
   shippingEstimate: String
   shippingEstimateDate: String
+  deliveryIds: [DeliveryIds]
+}
+
+type DeliveryIds {
+  courierId: String
+  warehouseId: String
+  dockId: String
+  courierName: String
+  quantity: Int
 }
 
 input ShippingItem {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Exito needs to get the deliveryIds in the Query for Shipping simulation to know if the product can be delivered in pick up points.

#### How should this be manually tested?
[The query can be tested here in graphiql](https://vtexexito--prueba1.myvtex.com/_v/vtex.store-graphql@2.81.0/graphiql/v1?query=query%20getShippingEstimates(%24items%3A%20%5BShippingItem%5D%2C%20%24postalCode%3A%20String%2C%20%24country%3A%20String)%20%7B%0A%20%20shipping(items%3A%20%24items%2C%20postalCode%3A%20%24postalCode%2C%20country%3A%20%24country)%20%7B%0A%20%20%20%20logisticsInfo%20%7B%0A%20%20%20%20%20%20itemIndex%0A%20%20%20%20%20%20slas%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20price%0A%20%20%20%20%20%20%20%20shippingEstimate%0A%20%20%20%20%20%20%20%20shippingEstimateDate%0A%20%20%20%20%20%20%20%20deliveryIds%20%7B%0A%20%20%20%20%20%20%20%20%20%20warehouseId%0A%20%20%20%20%20%20%20%20%20%20courierId%0A%20%20%20%20%20%20%20%20%20%20dockId%0A%20%20%20%20%20%20%20%20%20%20courierName%0A%20%20%20%20%20%20%20%20%20%20quantity%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=getShippingEstimates&variables=%7B%0A%20%20%22country%22%3A%20%22COL%22%2C%0A%20%20%20%20%22items%22%3A%20%5B%0A%20%20%20%20%09%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22id%22%3A%20%221324255%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22quantity%22%3A%20%221%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22seller%22%3A%20%221%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%5D%2C%0A%20%20%20%20%22postalCode%22%3A%20%2205088%22%0A%7D)

#### Screenshots or example usage
Don't affect the defaut behavior of the Shipping simulator component.
![image](https://user-images.githubusercontent.com/20094423/59482352-21e7f400-8e2e-11e9-9be5-fa2315acc6ff.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
