### PR TITLE
Fix/product categories empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Proper fix for bug when trying to get category tree of undefined.
 
 ## [2.83.1] - 2019-06-17
 ### Fixed

--- a/node/package.json
+++ b/node/package.json
@@ -17,7 +17,7 @@
     "querystring": "^0.2.0",
     "ramda": "^0.24.1",
     "slugify": "^1.2.6",
-    "typescript": "^3.3.4000",
+    "typescript": "3.4.3",
     "unorm": "^1.5.0",
     "url-parse": "^1.2.0"
   },

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -38,19 +38,17 @@ const removeTrailingSlashes = (str: string) => str.endsWith('/')
 const productCategoriesToCategoryTree = (
   {categories, categoriesIds}: {categories: string[], categoriesIds: string[]}
 ) => {
-  /** This is a hotfix for a "cannot get length of undefined" bug.
-  * The actual cause should be properly investigated */
-  try {
-    return compose<[string, string][], {id: number, name: string}[], {id: number, name: string}[]>(
-      reverse,
-      map(([idTree, categoryTree]) => ({
-        id: Number(last(split('/', removeTrailingSlashes(idTree)))),
-        name: String(last(split('/', removeTrailingSlashes(categoryTree)))),
-      }))
-    )(zip(categoriesIds, categories))
-  } catch (error) {
+  if (!categories || !categoriesIds) {
     return []
   }
+
+  return compose<[string, string][], {id: number, name: string}[], {id: number, name: string}[]>(
+    reverse,
+    map(([idTree, categoryTree]) => ({
+      id: Number(last(split('/', removeTrailingSlashes(idTree)))),
+      name: String(last(split('/', removeTrailingSlashes(categoryTree)))),
+    }))
+  )(zip(categoriesIds, categories))
 }
 
 export const resolvers = {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4392,10 +4392,10 @@ typescript@3.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
   integrity sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==
 
-typescript@^3.3.4000:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
+  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Proper fix for bug when trying to get category tree of undefined.

The problem was being caused when `productCategoriesToCategoryTree` is run with empty categories. The hotfix involved just wrapping it in a try-catch block, now it properly handles passing empty categories.

The cause for empty categories to be passed is related to hiding kit items from the store on the catalog, and should be handled as well in the future.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
