### PR TITLE
Profile client uses storeUserAuthToken as vtexIdClientAutCookie

### DIFF
--- a/node/clients/profile.ts
+++ b/node/clients/profile.ts
@@ -15,7 +15,7 @@ export class ProfileClient extends JanusClient {
       ...options,
       headers: {
         ...(options && options.headers),
-        VtexIdClientAutCookie: context.authToken,
+        ...context.storeUserAuthToken ? { VtexIdClientAutCookie: context.storeUserAuthToken } : null,
       },
       timeout: FIVE_SECONDS_MS,
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?
We are currently using the app's authToken as vtexIdClientAutCookie. We should actually use the storeUserAuthToken since the user is logged in and has the right permissions

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
