### PR TITLE
Add support for productCategoryIds in OrderItem type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `productCategoryIds` into `OrderItem` type
 
 ## [2.84.1] - 2019-06-25
 

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -32,6 +32,7 @@ type OrderItem {
   rewardValue: Float
   additionalInfo: OrderItemAdditionalInfo
   preSaleDate: String
+  productCategoryIds: String
   handling: Boolean
   isGift: Boolean
   quantity: Int


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adding support for `productCategoryIds` in `OrderItem` type.

#### What problem is this solving?
Currently there's no way to tell if the items of an order match a certain category.
With the `productCategoryIds` we can validate and show specific options related to that item.

#### How should this be manually tested?
1. Go to the [GraphiQL](https://form--tokstok.myvtex.com/_v/vtex.store-graphql@2.80.3/graphiql/v1?query=query%20orders%20%7B%0A%20%20orders%20%7B%0A%20%20%20%20items%20%7B%0A%20%20%20%20%20%20productCategoryIds%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=orders);
2. Login to https://form--tokstok.myvtex.com/login
3. Execute the Query.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/1207017/60182972-b9205480-97fb-11e9-9b46-534c704d7cb9.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.