### PR TITLE
Create new pagetype query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New pagetype query to identify by path and query the search page (brand, department..).
 
 ## [2.87.1] - 2019-06-27
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ TODO
 * `categories` - Returns categories tree
 * `brand` - Returns a specified brand
 * `brands` - Returns brands list
+* `pagetype` - Returns the page type based on path and query
 
 ### Logistics 
 * `shipping` - Returns orderForm shipping simulation

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -364,7 +364,21 @@ type Query {
     department: String
     category: String
     subcategory: String
-  ): SearchContext
+  ): SearchContext @deprecated(reason: "Use the 'pageType' query")
+
+  """
+  Get search page type
+  """
+  pageType(
+    """
+    URL's pathname
+    """
+    path: String!,
+    """
+    URL's querystring including '?'
+    """
+    query: String
+  ): PageType @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
   """
   Get logistics information about the store

--- a/graphql/types/PageType.graphql
+++ b/graphql/types/PageType.graphql
@@ -1,0 +1,12 @@
+type PageType {
+  id: String
+  type: PageEntityIdentifier
+}
+
+enum PageEntityIdentifier {
+  brand
+  department
+  category
+  subcategory
+  search
+}

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -32,12 +32,32 @@ interface CategoryWithNulls
   children: null
 }
 
+interface CatalogPageTypeResponse {
+  id: string
+  pageType: string
+}
+
 /** Catalog API
  * Docs: https://documenter.getpostman.com/view/845/catalogsystem-102/Hs44
  */
 export class Catalog extends AppClient {
   public constructor(ctx: IOContext, opts?: InstanceOptions) {
     super('vtex.catalog-api-proxy', ctx, opts)
+  }
+
+  public pageType = (path: string, query: string = '') => {
+    const pageTypePath = path.startsWith('/')
+      ? path.substr(1)
+      : path
+
+    const pageTypeQuery = !query || query.startsWith('?')
+      ? query
+      : `?${query}`
+
+    return this.get<CatalogPageTypeResponse>(
+      `/pub/portal/pagetype/${pageTypePath}${pageTypeQuery}`,
+      { metric: 'catalog-pagetype' }
+    )
   }
 
   public product = (slug: string) =>

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -28,7 +28,8 @@ import { catalogSlugify, Slugify } from './slug'
 import {
   CatalogCrossSellingTypes,
   findCategoryInTree,
-  getBrandFromSlug
+  getBrandFromSlug,
+  translatePageType
 } from './utils'
 
 interface SearchContext {
@@ -52,6 +53,11 @@ interface ProductIndentifier {
 interface ProductArgs {
   slug?: string
   identifier?: ProductIndentifier
+}
+
+interface PageTypeArgs {
+  path: string
+  query: string
 }
 
 enum CrossSellingInput {
@@ -496,6 +502,18 @@ export const queries = {
     }
 
     return response
+  },
+
+  pageType: async (
+    _: any,
+    {path, query}: PageTypeArgs,
+    ctx: Context
+  ) => {
+    const response = await ctx.clients.catalog.pageType(path, query)
+    return {
+      id: response.id,
+      type: translatePageType(response.pageType)
+    }
   },
 
   productRecommendations: async (

--- a/node/resolvers/catalog/utils.ts
+++ b/node/resolvers/catalog/utils.ts
@@ -10,6 +10,16 @@ export enum CatalogCrossSellingTypes {
   suggestions = 'suggestions',
 }
 
+const pageTypeMapping: Record<string, string> = {
+  Brand: 'brand',
+  Department: 'department',
+  Category: 'category',
+  SubCategory: 'subcategory',
+  NotFound: 'search',
+  FullText: 'search',
+  Search: 'search',
+}
+
 const lastSegment = compose<string, string[], string>(
   last,
   split('/')
@@ -78,4 +88,8 @@ function appendToMap(mapCategories: CategoryMap, category: Category) {
   mapCategories = category.children.reduce(appendToMap, mapCategories)
 
   return mapCategories
+}
+
+export function translatePageType(catalogPageType: string): string {
+  return pageTypeMapping[catalogPageType] || 'search'
 }


### PR DESCRIPTION
#### What problem is this solving?
The current algorithm to discover page type needs to fetch brand list and category tree, which can be huge, throwing timeouts or increasing the latency.

#### How should this be manually tested?
You can try it here: https://pagetype--storecomponents.myvtex.com/_v/vtex.store-graphql@2.87.1/graphiql/v1?query=%7B%0A%20%20pageType(path%3A%20%22%2Felectronics%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20type%0A%20%20%7D%0A%7D

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
