### PR TITLE
Fix category tree when product has no category

### DIFF
--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -82,7 +82,9 @@ const productCategoriesToCategoryTree = async (
   const level = Math.max(...reversedIds.map(getCategoryLevel))
   const categoriesTree = await catalog.categories(level)
   const categoryMap = buildCategoryMap(categoriesTree)
-  return reversedIds.map(id => categoryMap[parseId(id)])
+  const mappedCategories = reversedIds.map(id => categoryMap[parseId(id)]).filter(Boolean)
+
+  return mappedCategories.length ? mappedCategories : null
 }
 
 export const resolvers = {


### PR DESCRIPTION
#### What problem is this solving?
GoCommerce allow users to save products without categories, but VTEX doesn't, so we send a generic category (`/Home/`) when editing a product. This category will be returned by the search api, but not by the category api, because it doesn't exist on the product. The result is that the store front receives an array with a `null`, causing a break (example: https://mystore.mygocommerce.com/teste-produto/p).

#### How should this be manually tested?
https://augusto--mystore.mygocommerce.com/variacoes/p

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
