### PR TITLE
Uses raw slug as fallback in product query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Prefers `ProductUniqueIdentifier` over `slug` in product query
 
 ## [2.88.4] - 2019-07-02
 


### PR DESCRIPTION
#### What problem is this solving?
When using the `product` query, we could specify if we wanted to get the product by it's `slug` or by other parameters (`ProductUniqueIdentifier`). If both `slug` and `ProductUniqueIdentifier` are sent, `slug` was the default method of retrieving the product. 
This PR changes this behavior and adds preference to the `ProductUniqueIdentifier`

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
