### PR TITLE
check if type of category is correct, if not, get from category tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix for bug when fetching ids of categories with same names of departments. Fallback to get category tree in this case.
 
 ## [2.88.4] - 2019-07-02
 

--- a/node/resolvers/catalog/utils.ts
+++ b/node/resolvers/catalog/utils.ts
@@ -114,10 +114,13 @@ export const searchContextGetCategory = async (
   if (!department && !category && !subcategory) {
     return null
   }
-  const url = [department, category, subcategory].filter(Boolean).join('/')
+
+  const validParams = [department, category, subcategory].filter(Boolean)
+  const url = validParams.join('/')
   const pageType = await catalog.pageType(url)
 
-  if (!typesPossible.includes(pageType.pageType)) {
+  const correctTypeIndex = validParams.length - 1
+  if (pageType.pageType !== typesPossible[correctTypeIndex]) {
     return getIdFromTree(args, catalog)
   }
   return pageType.id


### PR DESCRIPTION
https://fidelis--boticario.myvtex.com/_v/vtex.store-graphql@2.88.4/graphiql/v1?query=query%20%7B%0A%20%20%23%20categories%20%7B%0A%20%20%23%20%20%20slug%0A%20%20%23%20%20%20name%0A%20%20%23%20%20%20href%0A%20%20%23%20%20%20id%0A%20%20%23%20%20%20children%20%7B%0A%20%20%23%20%20%20%20%20id%0A%20%20%23%20%20%20%20%20name%0A%20%20%23%20%20%20%20%20slug%0A%20%20%23%20%20%20%20%20href%0A%20%20%23%20%20%20%7D%0A%20%20%23%20%7D%0A%20%20searchContextFromParams(brand%3A%22make-b%22)%20%7B%0A%20%20%20%20brand%0A%20%20%20%20category%0A%20%20%20%20contextKey%0A%20%20%7D%0A%20%20intense%3A%20searchContextFromParams(brand%3A%22intense%22)%20%7B%0A%20%20%20%20brand%0A%20%20%20%20category%0A%20%20%20%20contextKey%0A%20%20%7D%0A%20%20%0A%20%20department%3A%20searchContextFromParams(brand%3A%22intense%22%2C%20department%3A%22maquiagem%22)%20%7B%0A%20%20%20%20brand%0A%20%20%20%20category%0A%20%20%20%20contextKey%0A%20%20%7D%0A%20%20category%3A%20searchContextFromParams(brand%3A%22intense%22%2C%20department%3A%22maquiagem%22%2C%20category%3A%20%22rosto%22)%20%7B%0A%20%20%20%20brand%0A%20%20%20%20category%0A%20%20%20%20contextKey%0A%20%20%7D%0A%20%20sub%3A%20searchContextFromParams(brand%3A%22intense%22%2C%20department%3A%22maquiagem%22%2C%20category%3A%20%22rosto%22%2C%20subcategory%3A%20%22blush%22)%20%7B%0A%20%20%20%20brand%0A%20%20%20%20category%0A%20%20%20%20contextKey%0A%20%20%7D%0A%7D

check that it is the same result of store-graphql@2.88.3