### PR TITLE
Feature/discounts and teasers fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- added `teasers` and `discountHighlights` fields in `Product` type. 
 
 ## [2.90.1] - 2019-07-03
 ### Changed

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -161,7 +161,7 @@ type Offer {
   DeliverySlaSamples: [DeliverySlaSamples]
   """List of discount highlights"""
   discountHighlights: [Discount!]
-  teasers: [Teaser]
+  teasers: [Teaser!]
 }
 
 type Teaser {

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -161,6 +161,11 @@ type Offer {
   DeliverySlaSamples: [DeliverySlaSamples]
   """List of discount highlights"""
   discountHighlights: [Discount!]
+  teasers: [Teaser]
+}
+
+type Teaser {
+  name: String
 }
 
 """ Discount object """

--- a/node/resolvers/catalog/discount.ts
+++ b/node/resolvers/catalog/discount.ts
@@ -3,5 +3,8 @@ import { prop } from 'ramda'
 export const resolvers = {
   Discount: {
     name: prop('<Name>k__BackingField')
+  },
+  Teaser: {
+    name: prop('<Name>k__BackingField')
   }
 }

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -14,7 +14,7 @@ import { Functions } from '@gocommerce/utils'
 
 import { queries as benefitsQueries } from '../benefits'
 import { toProductIOMessage } from './../../utils/ioMessage'
-import { buildCategoryMap, DiscountsLabels } from './utils'
+import { buildCategoryMap } from './utils'
 
 const objToNameValue = (
   keyName: string,
@@ -89,34 +89,8 @@ const productCategoriesToCategoryTree = async (
 
 export const resolvers = {
   Offer: {
-    teasers: ({ Teasers }: any) => {
-      const teasers: any = map((teaser: any) => ({
-        name: teaser[DiscountsLabels.name],
-        conditions: {
-          minimumQuantity: teaser[DiscountsLabels.conditions][DiscountsLabels.minimumQuantity],
-          parameters: map((params: any) => ({
-            name: params[DiscountsLabels.name],
-            value: params[DiscountsLabels.value],
-          }))(teaser[DiscountsLabels.conditions][DiscountsLabels.parameters])
-        },
-        effects: {
-          parameters: map((params: any) => ({
-            name: params[DiscountsLabels.name],
-            value: params[DiscountsLabels.value],
-          }))(teaser[DiscountsLabels.effects][DiscountsLabels.parameters])
-        }
-      }))(Teasers)
-
-      return teasers
-    },
-    discountHighlights: ({ DiscountHighLight }: any) => {
-
-      const discountHighlights: any = map((discount: any) => ({
-        name: discount[DiscountsLabels.name]
-      }))(DiscountHighLight);
-
-      return discountHighlights;
-    }
+    teasers: propOr([], 'Teasers'),
+    discountHighlights: propOr([], 'DiscountHighLight')
   },
   Product: {
     benefits: ({ productId }: any, _: any, ctx: Context) =>

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -14,7 +14,7 @@ import { Functions } from '@gocommerce/utils'
 
 import { queries as benefitsQueries } from '../benefits'
 import { toProductIOMessage } from './../../utils/ioMessage'
-import { buildCategoryMap } from './utils'
+import { buildCategoryMap, DiscountsLabels } from './utils'
 
 const objToNameValue = (
   keyName: string,
@@ -88,6 +88,36 @@ const productCategoriesToCategoryTree = async (
 }
 
 export const resolvers = {
+  Offer: {
+    teasers: ({ Teasers }: any) => {
+      const teasers: any = map((teaser: any) => ({
+        name: teaser[DiscountsLabels.name],
+        conditions: {
+          minimumQuantity: teaser[DiscountsLabels.conditions][DiscountsLabels.minimumQuantity],
+          parameters: map((params: any) => ({
+            name: params[DiscountsLabels.name],
+            value: params[DiscountsLabels.value],
+          }))(teaser[DiscountsLabels.conditions][DiscountsLabels.parameters])
+        },
+        effects: {
+          parameters: map((params: any) => ({
+            name: params[DiscountsLabels.name],
+            value: params[DiscountsLabels.value],
+          }))(teaser[DiscountsLabels.effects][DiscountsLabels.parameters])
+        }
+      }))(Teasers)
+
+      return teasers
+    },
+    discountHighlights: ({ DiscountHighLight }: any) => {
+
+      const discountHighlights: any = map((discount: any) => ({
+        name: discount[DiscountsLabels.name]
+      }))(DiscountHighLight);
+
+      return discountHighlights;
+    }
+  },
   Product: {
     benefits: ({ productId }: any, _: any, ctx: Context) =>
       benefitsQueries.benefits(_, { id: productId }, ctx),

--- a/node/resolvers/catalog/utils.ts
+++ b/node/resolvers/catalog/utils.ts
@@ -10,6 +10,15 @@ export enum CatalogCrossSellingTypes {
   suggestions = 'suggestions',
 }
 
+export enum DiscountsLabels {
+  name = '<Name>k__BackingField',
+  conditions = '<Conditions>k__BackingField',
+  minimumQuantity = '<MinimumQuantity>k__BackingField',
+  parameters = '<Parameters>k__BackingField',
+  value = '<Value>k__BackingField',
+  effects = '<Effects>k__BackingField'
+}
+
 const pageTypeMapping: Record<string, string> = {
   Brand: 'brand',
   Department: 'department',

--- a/node/resolvers/catalog/utils.ts
+++ b/node/resolvers/catalog/utils.ts
@@ -10,15 +10,6 @@ export enum CatalogCrossSellingTypes {
   suggestions = 'suggestions',
 }
 
-export enum DiscountsLabels {
-  name = '<Name>k__BackingField',
-  conditions = '<Conditions>k__BackingField',
-  minimumQuantity = '<MinimumQuantity>k__BackingField',
-  parameters = '<Parameters>k__BackingField',
-  value = '<Value>k__BackingField',
-  effects = '<Effects>k__BackingField'
-}
-
 const pageTypeMapping: Record<string, string> = {
   Brand: 'brand',
   Department: 'department',


### PR DESCRIPTION
#### What problem is this solving?

Send Teasers and Discounts in the ProductSearch queries to show Promotions info in the Product Summary.

#### How should this be manually tested?
In the ProductSearch query should send the information about Teasers and Discounts.

![image](https://user-images.githubusercontent.com/20094423/60682532-3af62a80-9e59-11e9-8201-cbf1da1c8bb8.png)

[Account: prueba1 Workspace: vtexexito](https://vtexexito--prueba1.myvtex.com/_v/vtex.store-graphql@2.90.1/graphiql/v1?operationName=Product&variables=%7B%0A%20%20%22slug%22%3A%20%22cartucho-de-tinta-hp-662-negra-original-cz103al-140219%22%0A%7D)

[Used query (too long)](https://paste.ofcode.org/3TWFiU4XLFfV25B2HQ9Ptc)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

