### PR TITLE
Avoid passing wrong value of marketingTags to Checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Avoid breaking call to `updateOrderFormMarketingData` if `marketingTags` is `null`.
 
 ## [2.92.0] - 2019-07-09
 

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -194,13 +194,21 @@ export const mutations: Record<string, Resolver> = {
     if (shouldUpdateMarketingData(marketingData, sessionData)) {
       const newMarketingData = {
         ...(marketingData || {}),
-        utmCampaign: path(['utmParams', 'campaign'], sessionData),
-        utmMedium: path(['utmParams', 'medium'], sessionData),
-        utmSource: path(['utmParams', 'source'], sessionData),
-        utmiCampaign: path(['utmiParams', 'campaign'], sessionData),
-        utmiPart: path(['utmiParams', 'part'], sessionData),
-        utmipage: path(['utmiParams', 'page'], sessionData),
       }
+
+      if (sessionData && Object.keys(sessionData).length > 0) {
+        newMarketingData.utmCampaign = path(['utmParams', 'campaign'], sessionData)
+        newMarketingData.utmMedium = path(['utmParams', 'medium'], sessionData)
+        newMarketingData.utmSource = path(['utmParams', 'source'], sessionData)
+        newMarketingData.utmiCampaign = path(['utmiParams', 'campaign'], sessionData)
+        newMarketingData.utmiPart = path(['utmiParams', 'part'], sessionData)
+        newMarketingData.utmipage = path(['utmiParams', 'page'], sessionData)
+      }
+
+      if (newMarketingData.marketingTags == null) {
+        delete newMarketingData.marketingTags
+      }
+
       await checkout.updateOrderFormMarketingData(orderFormId, newMarketingData)
     }
 


### PR DESCRIPTION
#### What problem is this solving?

`marketingTags`, in some scenarios, were being passed as `null`. This caused an error the Checkout backend.

> `"Object reference not set to an instance of an object."`

#### How should this be manually tested?

[Workspace](https://breno--storecomponents.myvtex.com/?utm_source=foo)

Click to add an item to cart.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

n/a

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
