### PR TITLE
Fix installments returning array with null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Returning an array of installments with `[null]`.
 
 ## [2.100.0] - 2019-08-06
 ### Added

--- a/node/resolvers/catalog/offer.ts
+++ b/node/resolvers/catalog/offer.ts
@@ -17,11 +17,16 @@ export const resolvers = {
         : filter(({ InterestRate }) => !InterestRate, Installments)
 
       const compareFunc = criteria === InstallmentsCriteria.MAX ? gte : lte
-      const byNumberOfInstallments = comparator((previous: any, next) => compareFunc(previous.NumberOfInstallments, next.NumberOfInstallments))
-      return [head(sort(byNumberOfInstallments, filteredInstallments))]
+      const byNumberOfInstallments = comparator((previous: any, next) =>
+        compareFunc(previous.NumberOfInstallments, next.NumberOfInstallments)
+      )
+      const installments = head(
+        sort(byNumberOfInstallments, filteredInstallments)
+      )
+      return installments ? [installments] : null
     },
     teasers: propOr([], 'Teasers'),
     giftSkuIds: propOr([], 'GiftSkuIds'),
     discountHighlights: propOr([], 'DiscountHighLight'),
-  }
+  },
 }


### PR DESCRIPTION
#### What problem is this solving?

When the product have no payment method an error explodes:
> TypeError: Cannot read property 'NumberOfInstallments' of null

#### How should this be manually tested?

The issue:
![image](https://user-images.githubusercontent.com/284515/62737149-8033ec00-ba05-11e9-8bfd-af666f0734ea.png)

[Workspace](https://nardi--pilateslovers.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [X] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
