### PR TITLE
Fix Brand titleTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `titleTag` prop of the `Brand` type that was removed in the last release.
 
 ## [2.102.0] - 2019-08-09
 ### Added
@@ -79,7 +81,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Return the sales channel country as a default country on the `shipsTo` array of countries in **logistics** query.
-- Port LogisticsDataSource to a Janus Client. 
+- Port LogisticsDataSource to a Janus Client.
 
 ## [2.92.0] - 2019-07-09
 
@@ -104,7 +106,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.90.5] - 2019-07-04
 
 ### Added
-- added `teasers` and `discountHighlights` fields in `Product` type. 
+- added `teasers` and `discountHighlights` fields in `Product` type.
 
 ## [2.90.4] - 2019-07-04
 

--- a/graphql/types/Brand.graphql
+++ b/graphql/types/Brand.graphql
@@ -10,7 +10,7 @@ type Brand {
   """ Name of brand """
   name: String @translatable
   """ Title used by html tag"""
-  title: String @translatable
+  titleTag: String @translatable
   """ Description used by html tag"""
   metaTagDescription: String @translatable
   """ Brand is active """

--- a/node/resolvers/catalog/brand.ts
+++ b/node/resolvers/catalog/brand.ts
@@ -11,11 +11,11 @@ export const resolvers = {
       { clients: { segment } }: Context
     ) => toBrandIOMessage('name')(segment, name, id),
 
-    title: (
+    titleTag: (
       { title, id }: any,
       _: any,
       { clients: { segment } }: Context
-    ) => toBrandIOMessage('title')(segment, title, id),
+    ) => toBrandIOMessage('titleTag')(segment, title, id),
 
     metaTagDescription: (
       { metaTagDescription, id }: any,


### PR DESCRIPTION
This PR fixes the `titleTag` prop that was replaced with `title` in  the `Brand` type (#380).


<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
