### PR TITLE
Call messagesGraphQL client to translate instead of messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.102.1] - 2019-08-29
+### Changed
+- Translate terms with `messagesGraphQL` client(instead of `messages` client) before sending them to search api for `productSearch` and `facets` resolvers.
+
 ## [2.104.0] - 2019-08-28
 
 ## [2.103.1] - 2019-08-27

--- a/node/package.json
+++ b/node/package.json
@@ -35,7 +35,7 @@
     "@types/ramda": "types/npm-ramda#dist",
     "@types/unorm": "^1.3.27",
     "@types/url-parse": "^1.4.3",
-    "@vtex/api": "^3.40.0",
+    "@vtex/api": "^3.41.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",
     "http2": "^3.3.7",

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -238,7 +238,7 @@ const translateToStoreDefaultLanguage = async (
     segment.getSegment(),
   ])
   return from && from !== to
-    ? messagesGraphQL.translate(toSearchTerm(term, from, to)).then(head)
+    ? messagesGraphQL.translate(toSearchTerm(term, from, to) as any).then(head)
     : term
 }
 

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -232,13 +232,13 @@ const translateToStoreDefaultLanguage = async (
   clients: Context['clients'],
   term: string
 ): Promise<string> => {
-  const { segment, messages } = clients
+  const { segment, messagesGraphQL } = clients
   const [{ cultureInfo: to }, { cultureInfo: from }] = await all([
     segment.getSegmentByToken(null),
     segment.getSegment(),
   ])
   return from && from !== to
-    ? messages.translate(to, [toSearchTerm(term, from)]).then(head)
+    ? messagesGraphQL.translate(toSearchTerm(term, from, to)).then(head)
     : term
 }
 

--- a/node/utils/ioMessage.ts
+++ b/node/utils/ioMessage.ts
@@ -54,9 +54,12 @@ export const toSpecificationIOMessage = (field: string) => (segment: Segment, co
   `Specification-id.${id}::${field}`
 )
 
-export const toSearchTerm = (term: string, from: string, description: string = '') => ({
-  id: `Search::${Slugify(term)}`,
-  description,
-  content: term,
+export const toSearchTerm = (term: string, from: string, to: string, description: string = '') => ({
+  messages:[{
+    id: `Search::${Slugify(term)}`,
+    content: term,
+    description
+  }],
   from,
+  to
 })

--- a/node/utils/ioMessage.ts
+++ b/node/utils/ioMessage.ts
@@ -56,9 +56,12 @@ export const toSpecificationIOMessage = (field: string) => (segment: Segment, co
 
 export const toSearchTerm = (term: string, from: string, to: string, description: string = '') => ({
   messages:[{
-    id: `Search::${Slugify(term)}`,
-    content: term,
-    description
+    provider: 'Search',
+    messages: [{
+      id: Slugify(term),
+      content: term,
+      description
+    }]
   }],
   from,
   to

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2141,7 +2141,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -347,10 +347,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@^3.40.0":
-  version "3.41.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.41.1.tgz#5c5b4bb54e7a9929f7111335a63f029dac8b3932"
-  integrity sha512-E8ZZKbEe23uz5EVfSxWwQ35Dv+4CiByb7PIY40Uaje//EEIcMe76jxCUIOfOz0J30e6FEYH4wZrWQRcPmE9EnA==
+"@vtex/api@^3.41.0":
+  version "3.46.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.46.0.tgz#f43a58ce15e08dfa366daf44a4c2ec4928527236"
+  integrity sha512-Dqlu/LE6mn1oUIb744bjj+RgNbb+xMSB0C6H6RcUvVGOQPJgY4OfqNY11jae6qjInWXIVVyBkRKFwnFpUNqfxA==
   dependencies:
     "@types/koa" "^2.0.48"
     "@types/koa-compose" "^3.2.3"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2141,7 +2141,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

The client messages shouldn't be used by store-graphql in order to translate slugs before sending them to search-api. In fact, this old translate route will be removed soon and thus only the translate method from messagesGraphQL client should be used.

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
