### PR TITLE
Feature: adding canonical and internal routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [2.102.1] - 2019-08-12
+### Added
+- Routes fetching and parsing framework
+- Routes resolver for Product
+- Routes resolver for Brand 
+
+## [2.102.1] - 2019-08-12
 ### Fixed
 - Fix `titleTag` prop of the `Brand` type that was removed in the last release.
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,3 +1,15 @@
+interface RoutesEntity {
+  """
+  Canonical Route
+  """
+  canonicalRoute: String
+
+  """
+  Internal, system route
+  """
+  internalRoute: String
+}
+
 type Query {
   """
   Returns a specified product

--- a/graphql/types/Brand.graphql
+++ b/graphql/types/Brand.graphql
@@ -1,4 +1,4 @@
-type Brand {
+type Brand implements RoutesEntity {
   """ slug is used as cacheId """
   cacheId: ID
   """ Brand id """
@@ -15,4 +15,7 @@ type Brand {
   metaTagDescription: String @translatable
   """ Brand is active """
   active: Boolean
+  """ Routes """
+  canonicalRoute: String
+  internalRoute: String
 }

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -1,4 +1,9 @@
-type Product {
+interface Entiy {
+  canonicaRoute: String
+  systemRoute: String
+}
+
+type Product implements Entity {
   """ Brand of the product """
   brand: String @translatable
   """ Id of the brand of the product """

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -1,9 +1,4 @@
-interface Entiy {
-  canonicaRoute: String
-  systemRoute: String
-}
-
-type Product implements Entity {
+type Product implements RoutesEntity {
   """ Brand of the product """
   brand: String @translatable
   """ Id of the brand of the product """
@@ -51,6 +46,9 @@ type Product implements Entity {
   itemMetadata: ItemMetadata
    """ Array of product SpecificationGroup """
   specificationGroups: [SpecificationGroup]
+  """ Routes """
+  canonicalRoute: String
+  internalRoute: String
 }
 
 type OnlyProduct {

--- a/manifest.json
+++ b/manifest.json
@@ -147,6 +147,9 @@
         "host": "portal.vtexcommercestable.com.br",
         "path": "/api/profile-system/*"
       }
+    },
+    {
+      "name": "read-workspace-apps"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/index.ts
+++ b/node/index.ts
@@ -14,6 +14,9 @@ const TEN_SECONDS_MS = 10 * 1000
 
 // Segments are small and immutable.
 const MAX_SEGMENT_CACHE = 10000
+const SMALL_CACHE = 1000
+
+const appsCache = new LRUCache<string, any>({ max: SMALL_CACHE })
 const segmentCache = new LRUCache<string, any>({ max: MAX_SEGMENT_CACHE })
 const catalogCache = new LRUCache<string, any>({max: 4000})
 const messagesCache = new LRUCache<string, any>({max: 2000})

--- a/node/index.ts
+++ b/node/index.ts
@@ -11,6 +11,7 @@ const TWO_SECONDS_MS = 2 * 1000
 const THREE_SECONDS_MS = 3 * 1000
 const SIX_SECONDS_MS = 6 * 1000
 const TEN_SECONDS_MS = 10 * 1000
+const ONE_HALF_SECOND_MS = 1500
 
 // Segments are small and immutable.
 const MAX_SEGMENT_CACHE = 10000
@@ -31,6 +32,12 @@ export default new Service<Clients, void, CustomContext>({
   clients: {
     implementation: Clients,
     options: {
+      apps: {
+        concurrency: 20,
+        memoryCache: appsCache,
+        retries: 1,
+        timeout: ONE_HALF_SECOND_MS,
+      },
       checkout: {
         concurrency: 10,
         timeout: TEN_SECONDS_MS,

--- a/node/package.json
+++ b/node/package.json
@@ -2,6 +2,7 @@
   "name": "vtex.store-graphql",
   "dependencies": {
     "@gocommerce/utils": "^0.6.11",
+    "@types/route-parser": "^0.1.3",
     "apollo-datasource-rest": "^0.1.5",
     "apollo-server-errors": "^2.0.2",
     "axios": "^0.19.0",
@@ -16,6 +17,7 @@
     "qs": "^6.6.0",
     "querystring": "^0.2.0",
     "ramda": "^0.24.1",
+    "route-parser": "^0.0.5",
     "slugify": "^1.2.6",
     "typescript": "3.5.2",
     "unorm": "^1.5.0",

--- a/node/resolvers/catalog/brand.ts
+++ b/node/resolvers/catalog/brand.ts
@@ -2,6 +2,7 @@ import { prop } from 'ramda'
 
 import { Slugify } from './slug'
 import { toBrandIOMessage } from './../../utils/ioMessage'
+import { getRoute } from './../../utils/routes'
 
 export const resolvers = {
   Brand: {
@@ -29,5 +30,16 @@ export const resolvers = {
 
     slug: (brand: any) => Slugify(brand.name),
 
+    canonicalRoute: (brand: any, _: any, {clients: {apps}}: Context ) =>
+      getRoute(apps, 'brand', 'canonical', {
+        ...brand,
+        brand: Slugify(brand.name),
+      }),
+
+    internalRoute: async (brand: any, _: any, {clients: {apps}}: Context ) =>
+      getRoute(apps, 'brand', 'internal', {
+        ...brand,
+        brand: Slugify(brand.name),
+      }),
   }
 }

--- a/node/resolvers/catalog/brand.ts
+++ b/node/resolvers/catalog/brand.ts
@@ -30,14 +30,14 @@ export const resolvers = {
 
     slug: (brand: any) => Slugify(brand.name),
 
-    canonicalRoute: (brand: any, _: any, {clients: {apps}}: Context ) =>
-      getRoute(apps, 'brand', 'canonical', {
+    canonicalRoute: (brand: any, _: any, ctx: Context ) =>
+      getRoute(ctx, 'brand', 'canonical', {
         ...brand,
         brand: Slugify(brand.name),
       }),
 
-    internalRoute: async (brand: any, _: any, {clients: {apps}}: Context ) =>
-      getRoute(apps, 'brand', 'internal', {
+    internalRoute: async (brand: any, _: any, ctx: Context ) =>
+      getRoute(ctx, 'brand', 'internal', {
         ...brand,
         brand: Slugify(brand.name),
       }),

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -17,6 +17,8 @@ import { queries as benefitsQueries } from '../benefits'
 import { toBrandIOMessage, toProductIOMessage, toSpecificationIOMessage } from './../../utils/ioMessage'
 import { buildCategoryMap, hashMD5 } from './utils'
 
+const ROUTES_JSON_PATH = '/dist/vtex.store-graphql/build.json'
+
 const objToNameValue = (
   keyName: string,
   valueName: string,
@@ -90,6 +92,14 @@ const productCategoriesToCategoryTree = async (
 
 export const resolvers = {
   Product: {
+    canonicalRoutes: ({ productName }: any, _: any, {clients: { apps }}: Context ) => {
+      // Pegar rotas
+      // parsear (traduzido)
+    },
+    systemRoutes: ({ productName }: any, _: any, {clients: { apps }}: Context ) => {
+      // Pegar rotas
+      // parsear
+    },
     benefits: ({ productId }: any, _: any, ctx: Context) =>
       benefitsQueries.benefits(_, { id: productId }, ctx),
 
@@ -166,11 +176,11 @@ export const resolvers = {
         (groupName: string) => ({
           name: toSpecificationIOMessage('groupName')(segment, groupName, hashMD5(groupName)),
           specifications: (product[groupName] || []).map(
-            (name: string) => ({ 
-              name: toSpecificationIOMessage('specificationName')(segment, name, hashMD5(name)), 
+            (name: string) => ({
+              name: toSpecificationIOMessage('specificationName')(segment, name, hashMD5(name)),
               values: (product[name] || []).map(
                 (value: string) => toSpecificationIOMessage('specificationValue')(segment, value, hashMD5(value))
-              ) 
+              )
             })
           )
         })
@@ -187,12 +197,12 @@ export const resolvers = {
           let fieldValues = new Array() as [Promise<TranslatableMessage>]
           (product[specification] || []).forEach(
             (value: string) => {
-              fieldValues.push(toSpecificationIOMessage('fieldValue')(segment, value, hashMD5(value))) 
+              fieldValues.push(toSpecificationIOMessage('fieldValue')(segment, value, hashMD5(value)))
             }
           )
-          
+
           productSpecifications.push({
-            fieldName: toSpecificationIOMessage('fieldName')(segment, specification, hashMD5(specification)), 
+            fieldName: toSpecificationIOMessage('fieldName')(segment, specification, hashMD5(specification)),
             fieldValues
           })
         }

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -12,12 +12,12 @@ import {
 } from 'ramda'
 
 import { Functions } from '@gocommerce/utils'
+import { Slugify } from './slug'
 
 import { queries as benefitsQueries } from '../benefits'
 import { toBrandIOMessage, toProductIOMessage, toSpecificationIOMessage } from './../../utils/ioMessage'
 import { buildCategoryMap, hashMD5 } from './utils'
-
-const ROUTES_JSON_PATH = '/dist/vtex.store-graphql/build.json'
+import { getRoute } from './../../utils/routes'
 
 const objToNameValue = (
   keyName: string,
@@ -92,14 +92,19 @@ const productCategoriesToCategoryTree = async (
 
 export const resolvers = {
   Product: {
-    canonicalRoutes: ({ productName }: any, _: any, {clients: { apps }}: Context ) => {
-      // Pegar rotas
-      // parsear (traduzido)
-    },
-    systemRoutes: ({ productName }: any, _: any, {clients: { apps }}: Context ) => {
-      // Pegar rotas
-      // parsear
-    },
+    canonicalRoute: async (product: any, _: any, {clients: {apps}}: Context ) =>
+      getRoute(apps, 'product', 'canonical', {
+        ...product,
+        slug: Slugify(product.productName),
+      }),
+
+    internalRoute: async (product: any, _: any, {clients: {apps}}: Context ) =>
+      getRoute(apps, 'product', 'internal', {
+        ...product,
+        slug: Slugify(product.productName),
+        id: product.productId,
+      }),
+
     benefits: ({ productId }: any, _: any, ctx: Context) =>
       benefitsQueries.benefits(_, { id: productId }, ctx),
 

--- a/node/resolvers/catalog/product.ts
+++ b/node/resolvers/catalog/product.ts
@@ -92,14 +92,14 @@ const productCategoriesToCategoryTree = async (
 
 export const resolvers = {
   Product: {
-    canonicalRoute: async (product: any, _: any, {clients: {apps}}: Context ) =>
-      getRoute(apps, 'product', 'canonical', {
+    canonicalRoute: async (product: any, _: any, ctx: Context ) =>
+      getRoute(ctx, 'product', 'canonical', {
         ...product,
         slug: Slugify(product.productName),
       }),
 
-    internalRoute: async (product: any, _: any, {clients: {apps}}: Context ) =>
-      getRoute(apps, 'product', 'internal', {
+    internalRoute: async (product: any, _: any, ctx: Context ) =>
+      getRoute(ctx, 'product', 'internal', {
         ...product,
         slug: Slugify(product.productName),
         id: product.productId,

--- a/node/utils/routes.ts
+++ b/node/utils/routes.ts
@@ -1,0 +1,33 @@
+import { Apps } from '@vtex/api'
+import { pluck } from 'ramda'
+import Route from 'route-parser'
+
+const ROUTES_JSON_PATH = 'dist/vtex.store-graphql/build.json'
+
+interface ContentTypeDefinition {
+  internal: string
+  canonical: string
+}
+
+const getRoutesJSON = async (apps: Apps) => {
+  const metaInfos = await apps.getAppsMetaInfos('vtex.store-graphql')
+  const appIds = pluck('id', metaInfos)
+  const storeAppId = appIds.find((appId: string) => /^vtex\.store@/.test(appId))
+  if (!storeAppId) {
+    // THROW?
+    // log
+    return null
+  }
+  // CACHE
+  return apps.getAppJSON(storeAppId, ROUTES_JSON_PATH, true) as Promise<Record<string, ContentTypeDefinition> | null>
+}
+
+export const getRoute = async (apps: Apps, scope: string, routeType: 'canonical' | 'internal', reverseObj: any = {}) => {
+  const routesJSON = await getRoutesJSON(apps)
+  if (!routesJSON || !routesJSON[scope] || !routesJSON[scope][routeType]) {
+    //log
+    return null
+  }
+  const route = new Route(routesJSON[scope][routeType])
+  return route.reverse(reverseObj)
+}

--- a/node/utils/routes.ts
+++ b/node/utils/routes.ts
@@ -1,5 +1,5 @@
-import { Apps } from '@vtex/api'
 import { pluck } from 'ramda'
+import { LRUCache } from '@vtex/api'
 import Route from 'route-parser'
 
 const ROUTES_JSON_PATH = 'dist/vtex.store-graphql/build.json'
@@ -9,23 +9,30 @@ interface ContentTypeDefinition {
   canonical: string
 }
 
-const getRoutesJSON = async (apps: Apps) => {
+const routesCache = new LRUCache<string, any>({max: 4000})
+metrics.trackCache('routes JSON', routesCache)
+
+const getRoutesJSON = async ({clients: {apps}, vtex: {logger}}: Context) => {
   const metaInfos = await apps.getAppsMetaInfos('vtex.store-graphql')
   const appIds = pluck('id', metaInfos)
   const storeAppId = appIds.find((appId: string) => /^vtex\.store@/.test(appId))
   if (!storeAppId) {
-    // THROW?
-    // log
+    logger.error({message:'vtex.store not found.'})
     return null
   }
-  // CACHE
-  return apps.getAppJSON(storeAppId, ROUTES_JSON_PATH, true) as Promise<Record<string, ContentTypeDefinition> | null>
+  if (routesCache.has(storeAppId)) return routesCache.get(storeAppId)
+
+  const routesJSON = await apps.getAppJSON(storeAppId, ROUTES_JSON_PATH, true) as Record<string, ContentTypeDefinition> | null
+
+  routesCache.set(storeAppId, routesJSON)
+  return routesJSON
 }
 
-export const getRoute = async (apps: Apps, scope: string, routeType: 'canonical' | 'internal', reverseObj: any = {}) => {
-  const routesJSON = await getRoutesJSON(apps)
+export const getRoute = async (ctx: Context, scope: string, routeType: 'canonical' | 'internal', reverseObj: any = {}) => {
+  const { vtex: { logger } } = ctx
+  const routesJSON = await getRoutesJSON(ctx)
   if (!routesJSON || !routesJSON[scope] || !routesJSON[scope][routeType]) {
-    //log
+    logger.error(`routesJSON does not conform with params: ${scope} and ${routeType}.`)
     return null
   }
   const route = new Route(routesJSON[scope][routeType])

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -283,6 +283,11 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/route-parser@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@types/route-parser/-/route-parser-0.1.3.tgz#f8af16886ebe0b525879628c04f81433ac617af0"
+  integrity sha512-1AQYpsMbxangSnApsyIHzck5TP8cfas8fzmemljLi2APssJvlZiHkTar/ZtcZwOtK/Ory/xwLg2X8dwhkbnM+g==
+
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
@@ -2053,6 +2058,11 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+route-parser@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/route-parser/-/route-parser-0.0.5.tgz#7d1d09d335e49094031ea16991a4a79b01bbe1f4"
+  integrity sha1-fR0J0zXkkJQDHqFpkaSnmwG74fQ=
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -2164,7 +2174,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

This PR adds a framework for getting canonical and internal routes from store's `build.json`. And creates resolvers for the `Product` and `Brand` types. 

#### How should this be manually tested?

This PR depends on https://github.com/vtex/builder-hub/pull/672 . With this version of builder-hub just build the store app and test if the `canonicalRoute` and `internalRoute` fields from the `Product` and `Brand` queries are correct according to `routes.json` file in `vtex.store`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
