### PR TITLE
create friendlyName resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Create friendly name resolver to ShippingSLA type.
 
 ## [2.105.0] - 2019-09-02
 ### Added

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -1,12 +1,12 @@
 type ShippingData {
-  logisticsInfo: [LogisticsInfo],
+  logisticsInfo: [LogisticsInfo]
   messages: [MessageInfo]
 }
 
 type MessageInfo {
-  code: String,
-  text: String,
-  status: String,
+  code: String
+  text: String
+  status: String
   fields: MessageFields
 }
 
@@ -29,6 +29,7 @@ type ShippingSLA {
   shippingEstimate: String
   shippingEstimateDate: String
   deliveryIds: [DeliveryIds]
+  friendlyName: String
 }
 
 type DeliveryIds {
@@ -40,7 +41,7 @@ type DeliveryIds {
 }
 
 input ShippingItem {
-  id: String,
-  quantity: String,
+  id: String
+  quantity: String
   seller: String
 }

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -15,6 +15,7 @@ import {
 } from './attachmentsHelper'
 import { resolvers as orderFormItemResolvers } from './orderFormItem'
 import paymentTokenResolver from './paymentTokenResolver'
+import { fieldResolvers as shippingFieldResolvers } from './shipping'
 
 import { CHECKOUT_COOKIE, parseCookie } from '../../utils'
 import { UserInputError } from '@vtex/api'
@@ -131,6 +132,7 @@ export const fieldResolvers = {
   },
   ...assemblyOptionsItemResolvers,
   ...orderFormItemResolvers,
+  ...shippingFieldResolvers,
 }
 
 const replaceDomain = (host: string) => (cookie: string) =>

--- a/node/resolvers/checkout/shipping.ts
+++ b/node/resolvers/checkout/shipping.ts
@@ -1,0 +1,10 @@
+export const fieldResolvers = {
+  ShippingSLA: {
+    friendlyName: ({ name, pickupStoreInfo, deliveryChannel }: SLA) => {
+      if (deliveryChannel === 'pickup-in-point') {
+        return pickupStoreInfo.friendlyName
+      }
+      return name
+    },
+  },
+}

--- a/node/typings/Checkout.ts
+++ b/node/typings/Checkout.ts
@@ -84,37 +84,7 @@ interface OrderForm {
       selectedSla: string
       selectedDeliveryChannel: string
       addressId: string
-      slas: {
-        id: string
-        deliveryChannel: string
-        name: string
-        deliveryIds: {
-          courierId: string
-          warehouseId: string
-          dockId: string
-          courierName: string
-          quantity: number
-        }[]
-        shippingEstimate: string
-        shippingEstimateDate: string | null
-        lockTTL: string | null
-        availableDeliveryWindows: any[]
-        deliveryWindow: string | null
-        price: number
-        listPrice: number
-        tax: number
-        pickupStoreInfo: {
-          isPickupStore: boolean
-          friendlyName: string | null
-
-          address: CheckoutAddress | null
-          additionalInfo: any | null
-          dockId: string | null
-        }
-        pickupPointId: string | null
-        pickupDistance: number
-        polygonName: string | null
-      }[]
+      slas: SLA[]
       shipsTo: string[]
       itemId: string
       deliveryChannels: { id: string }[]
@@ -259,4 +229,35 @@ interface SimulationPayload {
   isCheckedIn?: boolean
   priceTables?: string[]
   marketingData?: Record<string, string>
+}
+
+interface SLA {
+  id: string
+  deliveryChannel: string
+  name: string
+  deliveryIds: {
+    courierId: string
+    warehouseId: string
+    dockId: string
+    courierName: string
+    quantity: number
+  }[]
+  shippingEstimate: string
+  shippingEstimateDate: string | null
+  lockTTL: string | null
+  availableDeliveryWindows: any[]
+  deliveryWindow: string | null
+  price: number
+  listPrice: number
+  tax: number
+  pickupStoreInfo: {
+    isPickupStore: boolean
+    friendlyName: string | null
+    address: CheckoutAddress | null
+    additionalInfo: any | null
+    dockId: string | null
+  }
+  pickupPointId: string | null
+  pickupDistance: number
+  polygonName: string | null
 }


### PR DESCRIPTION
Fixes https://app.clubhouse.io/vtex/story/19689/pickup-point-id-shouldn-t-show-on-shipping-simulator

#### What problem is this solving?

When the SLA is a pickup point, its name value was displaying a weird value with ID.

Solution: create a friendlyName resolver that outputs the correct value depending on the SLA. For now, the only variation is with pickup point, it will get the friendlyName from the pickupStoreInfo object.

#### How should this be manually tested?
![image](https://user-images.githubusercontent.com/4925068/64371490-0dfbfa80-cff7-11e9-8f4c-d400485dc871.png)


https://fidelis--paguemenos.myvtex.com/clareador-facial-active-unify-isdin-fps99-sem-cor-50ml/p

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
