### PR TITLE
Transform geoCoordinates into geoCoordinate when creating address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Transform `geoCoordinates` prop passed to `createAddress` into `geocoordinate`.
+
 ## [2.105.2] - 2019-09-16
 ### Changed
 - Decrease min replicas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Transform `geoCoordinates` prop passed to `createAddress` into `geocoordinate`.
+- Transform `geoCoordinates` prop passed to `createAddress` into `geoCoordinate`.
 
 ## [2.105.2] - 2019-09-16
 ### Changed

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -70,7 +70,7 @@ declare global {
     reference?: string
     addressName?: string
     addressType?: string
-    geoCoordinate?: string
+    geoCoordinates?: string
   }
 
   interface Profile {
@@ -197,7 +197,7 @@ declare global {
   }
 
   interface Reference {
-    Key: String
-    Value: String
+    Key: string
+    Value: string
   }
 }

--- a/node/resolvers/profile/fieldResolvers.ts
+++ b/node/resolvers/profile/fieldResolvers.ts
@@ -11,6 +11,7 @@ export default {
   Address: {
     cacheId: prop('addressName'),
     id: prop('addressName'),
+    geoCoordinates: prop('geoCoordinate'),
   },
   PaymentProfile: {
     cacheId: prop('id'),
@@ -30,9 +31,7 @@ export default {
     payments: (_: any, __: any, context: any) => getPayments(context),
     profilePicture: (obj: any, _: any, context: any) =>
       obj.profilePicture &&
-      `https://${
-        context.vtex.account
-      }.vteximg.com.br/assets/vtex.store-graphql/image/${obj.profilePicture}`,
+      `https://${context.vtex.account}.vteximg.com.br/assets/vtex.store-graphql/image/${obj.profilePicture}`,
     // the next transformations are necessary since the profile system and
     // this profile graphql query (the same applies to mutations) were built upon different contracts.
     corporateDocument: (obj: any, _: any, __: any) => obj.businessDocument,

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -154,8 +154,11 @@ export function createAddress(context: Context, address: Address) {
 
   const addressesData = {} as any
   const addressName = generateRandomName()
+  const { geoCoordinates, ...addr } = address
+
   addressesData[addressName] = JSON.stringify({
-    ...address,
+    ...addr,
+    geoCoordinate: geoCoordinates,
     addressName,
     userId: currentProfile.userId,
   })


### PR DESCRIPTION
#### What problem is this solving?

Every address related front-end code uses `geoCoordinates` (plural), but the MasterData accepts only `geoCoordinate` (singular). Currently, every query returns `null` for the `geoCoordinates` value.

#### How should this be manually tested?

https://kiwi--storecomponents.myvtex.com/account#/addresses/new

https://kiwi--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.105.2/graphiql/v1?operationName=Addresses&query=query%20Addresses%20%40context(scope%3A%20%22private%22)%20%7B%0A%20%20profile%20%7B%0A%20%20%20%20cacheId%0A%20%20%20%20addresses%3A%20address%20%7B%0A%20%20%20%20%20%20addressId%3A%20id%0A%20%20%20%20%20%20addressType%0A%20%20%20%20%20%20addressName%0A%20%20%20%20%20%20city%0A%20%20%20%20%20%20complement%0A%20%20%20%20%20%20country%0A%20%20%20%20%20%20neighborhood%0A%20%20%20%20%20%20number%0A%20%20%20%20%20%20postalCode%0A%20%20%20%20%20%20geoCoordinates%0A%20%20%20%20%20%20receiverName%0A%20%20%20%20%20%20reference%0A%20%20%20%20%20%20state%0A%20%20%20%20%20%20street%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20logistics%20%7B%0A%20%20%20%20shipsTo%0A%20%20%7D%0A%7D%0A

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
