### PR TITLE
add cpu to service.json

### DIFF
--- a/node/service.json
+++ b/node/service.json
@@ -4,5 +4,6 @@
   "ttl": 30,
   "timeout": 40,
   "minReplicas": 10,
-  "maxReplicas": 100
+  "maxReplicas": 100,
+  "cpu": 50
 }


### PR DESCRIPTION
Add cpu to service.json.
I am being conservative now.
The idea is that app's maintainers will be able to manually tune this parameter.
IO Platform team will soon provide an automated way to optimize these kind of parameters, e.g., cpu, minReplicas, etc.

cpu unit is a percentage of total CPU time.
cpu should be larger or equal than 5 and smaller or equal than 80.

IO will scale your app in order to keep the average CPU usage close to the cpu provided in service.json.
minReplicas/maxReplicas have precedence over the scaling policy.
Considering the maxReplicas parameter, if your app tries to use more CPU than it requested then IO will try to accommodate that demand, but will not guarantee.

You can check your app's metrics here: [grafana](http://grafana.ingress.vtex.io/d/0FbY1kRWk/io-deployments?orgId=1&var-datasource=prometheus%20stores-1a&var-deployment_namespace=vendor-vtex&var-deployment_name=vtex-render-ssr-2-11-1-c1e87a977b3e376)

This parameter will only be used when I deploy the Infra apps that handle it.

Disclaimer: these strategies/values can change in the near future.