### PR TITLE
Sync OrderForm locale with the locale currently being used by the store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Sync OrderForm locale with the locale currently being used by the store.
 
 ## [2.108.1] - 2019-10-09
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -269,7 +269,7 @@ type Query {
   """
   Returns checkout cart details
   """
-  orderForm: OrderForm @cacheControl(scope: PRIVATE) @withOrderFormId
+  orderForm: OrderForm @cacheControl(scope: PRIVATE) @withOrderFormId @withSegment
 
   """
   Returns user orders details

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -111,6 +111,22 @@ export class Checkout extends JanusClient {
       { metric: 'checkout-updateOrderFormMarketingData' }
     )
 
+  public updateOrderFormClientPreferencesData = (
+    orderFormId: string,
+    clientPreferencesData: OrderFormClientPreferencesData,
+  ) => {
+    // The API default value of `optinNewsLetter` is `null`, but it doesn't accept a POST with its value as `null`
+    const filteredClientPreferencesData = clientPreferencesData.optinNewsLetter === null
+      ? { locale: clientPreferencesData.locale }
+      : clientPreferencesData
+
+    return this.post(
+      this.routes.attachmentsData(orderFormId, 'clientPreferencesData'),
+      filteredClientPreferencesData,
+      { metric: 'checkout-updateOrderFormClientPreferencesData' }
+    )
+  }
+
   public addAssemblyOptions = async (
     orderFormId: string,
     itemId: string | number,

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -20,7 +20,6 @@ import { fieldResolvers as shippingFieldResolvers } from './shipping'
 
 import { CHECKOUT_COOKIE, parseCookie } from '../../utils'
 import { UserInputError } from '@vtex/api'
-import { Checkout } from '../../clients/checkout'
 
 const SetCookieWhitelist = [CHECKOUT_COOKIE, '.ASPXAUTH']
 
@@ -164,7 +163,7 @@ const getSession = (ctx: Context) => {
 async function syncWithStoreLocale(
   orderForm: OrderForm,
   cultureInfo: string,
-  checkout: Checkout
+  checkout: Context['clients']['checkout']
 ) {
   const clientPreferencesData = orderForm.clientPreferencesData || {
     locale: cultureInfo,

--- a/node/resolvers/session/sessionResolver.ts
+++ b/node/resolvers/session/sessionResolver.ts
@@ -23,12 +23,17 @@ export interface SessionFields {
   profile?: ProfileFields
   utmParams?: UtmParams
   utmiParams?: UtmiParams
+  store?: StoreFields,
   favoritePickup?: { address: CheckoutAddress; name: string }
   public?: {
     [key: string]: {
       value: string
     }
   }
+}
+
+interface StoreFields {
+  cultureInfo: string
 }
 
 interface UtmParams {
@@ -95,32 +100,37 @@ const setUtmiParams = (publicFields: SessionPublic) => ({
   part: path(['utmi_pc', 'value'], publicFields),
 })
 
+const setStore = (storeFields: SessionStore) => ({
+  cultureInfo: path(['cultureInfo', 'value'], storeFields),
+})
+
 export const sessionFields = (session: Session): SessionFields | {} => {
   const { namespaces } = session
   return namespaces
     ? {
-        address: path(['public', 'address', 'value'], namespaces),
-        adminUserEmail: path(
-          ['authentication', 'adminUserEmail', 'value'],
-          namespaces
-        ),
-        adminUserId: path(
-          ['authentication', 'adminUserId', 'value'],
-          namespaces
-        ),
-        id: session.id,
-        cacheId: session.id,
-        impersonable: convertToBool(
-          path(['impersonate', 'canImpersonate', 'value'], namespaces)
-        ),
-        impersonate: {
-          ...setProfileData(namespaces.profile, namespaces.impersonate),
-        },
-        utmParams: setUtmParams(namespaces.public),
-        utmiParams: setUtmiParams(namespaces.public),
-        orderFormId: path(['public', 'orderFormId', 'value'], namespaces),
-        favoritePickup: path(['public', 'favoritePickup', 'value'], namespaces),
-        ...setProfileData(namespaces.profile, namespaces.authentication),
-      }
+      address: path(['public', 'address', 'value'], namespaces),
+      adminUserEmail: path(
+        ['authentication', 'adminUserEmail', 'value'],
+        namespaces
+      ),
+      adminUserId: path(
+        ['authentication', 'adminUserId', 'value'],
+        namespaces
+      ),
+      id: session.id,
+      cacheId: session.id,
+      impersonable: convertToBool(
+        path(['impersonate', 'canImpersonate', 'value'], namespaces)
+      ),
+      impersonate: {
+        ...setProfileData(namespaces.profile, namespaces.impersonate),
+      },
+      store: setStore(namespaces.store),
+      utmParams: setUtmParams(namespaces.public),
+      utmiParams: setUtmiParams(namespaces.public),
+      orderFormId: path(['public', 'orderFormId', 'value'], namespaces),
+      favoritePickup: path(['public', 'favoritePickup', 'value'], namespaces),
+      ...setProfileData(namespaces.profile, namespaces.authentication),
+    }
     : ({} as any)
 }

--- a/node/resolvers/session/sessionResolver.ts
+++ b/node/resolvers/session/sessionResolver.ts
@@ -23,17 +23,12 @@ export interface SessionFields {
   profile?: ProfileFields
   utmParams?: UtmParams
   utmiParams?: UtmiParams
-  store?: StoreFields,
   favoritePickup?: { address: CheckoutAddress; name: string }
   public?: {
     [key: string]: {
       value: string
     }
   }
-}
-
-interface StoreFields {
-  cultureInfo: string
 }
 
 interface UtmParams {
@@ -100,10 +95,6 @@ const setUtmiParams = (publicFields: SessionPublic) => ({
   part: path(['utmi_pc', 'value'], publicFields),
 })
 
-const setStore = (storeFields: SessionStore) => ({
-  cultureInfo: path(['cultureInfo', 'value'], storeFields),
-})
-
 export const sessionFields = (session: Session): SessionFields | {} => {
   const { namespaces } = session
   return namespaces
@@ -125,7 +116,6 @@ export const sessionFields = (session: Session): SessionFields | {} => {
       impersonate: {
         ...setProfileData(namespaces.profile, namespaces.impersonate),
       },
-      store: setStore(namespaces.store),
       utmParams: setUtmParams(namespaces.public),
       utmiParams: setUtmiParams(namespaces.public),
       orderFormId: path(['public', 'orderFormId', 'value'], namespaces),

--- a/node/typings/Checkout.ts
+++ b/node/typings/Checkout.ts
@@ -153,10 +153,7 @@ interface OrderForm {
     name: string
     logo: string
   }[]
-  clientPreferencesData: {
-    locale: string
-    optinNewsLetter: any | null
-  }
+  clientPreferencesData: OrderFormClientPreferencesData
   commercialConditionData: any | null
   storePreferencesData: {
     countryCode: string
@@ -187,6 +184,11 @@ interface OrderForm {
   }
   subscriptionData: any | null
   itemsOrdination: any | null
+}
+
+interface OrderFormClientPreferencesData {
+  locale: string
+  optinNewsLetter: boolean | null
 }
 
 interface OrderFormItemInput {

--- a/node/typings/Session.ts
+++ b/node/typings/Session.ts
@@ -5,6 +5,7 @@ interface Session {
     impersonate: SessionImpersonate
     authentication: SessionAuthentication
     public: SessionPublic
+    store: SessionStore
   }
 }
 
@@ -21,6 +22,10 @@ interface SessionProfile {
 interface SessionImpersonate {
   storeUserEmail?: ObjValue
   storeUserId?: ObjValue
+}
+
+interface SessionStore {
+  cultureInfo?: ObjValue
 }
 
 interface SessionAuthentication {

--- a/node/typings/Session.ts
+++ b/node/typings/Session.ts
@@ -5,7 +5,6 @@ interface Session {
     impersonate: SessionImpersonate
     authentication: SessionAuthentication
     public: SessionPublic
-    store: SessionStore
   }
 }
 
@@ -22,10 +21,6 @@ interface SessionProfile {
 interface SessionImpersonate {
   storeUserEmail?: ObjValue
   storeUserId?: ObjValue
-}
-
-interface SessionStore {
-  cultureInfo?: ObjValue
 }
 
 interface SessionAuthentication {


### PR DESCRIPTION
#### What problem is this solving?

1. Store uses a Locale Switcher
2. User change the language from English to Portuguese
3. User goes to Checkout page
4. Checkout page is in English

This PR changes the orderForm data to change the user language to the one selected in the its session.

So, in the scenario above the user would encounter the Checkout page in Portuguese.

#### How should this be manually tested?

1. Open the store
2. Add something to the cart
3. Open the Checkout page
4. See that Checkout uses the default language of the store
5. Go back to the store
6. Depending on the store do:
  6.1 **Store Components:** Add the query string `?cultureInfo=pt-BR`
  6.2 **Spazio Lusso:** Change the language to English using the Locale Switcher
7. Open the Checkout page
8. Check if the language is right

[Spazio Lusso, store with Locale Switcher](https://breno--spaziolusso.myvtex.com/)
[Store Components](https://breno--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
