### PR TITLE
decrease cpu to 30

### DIFF
--- a/node/service.json
+++ b/node/service.json
@@ -5,5 +5,5 @@
   "timeout": 40,
   "minReplicas": 10,
   "maxReplicas": 100,
-  "cpu": 50
+  "cpu": 30
 }


### PR DESCRIPTION
Decrease CPU to 30.

The idea is that app's maintainers will be able to manually tune this parameter.

cpu unit is a percentage of total CPU time.
cpu should be larger or equal than 5 and smaller or equal than 80.

IO will scale your app in order to keep the average CPU usage close to the cpu provided in service.json.
minReplicas/maxReplicas have precedence over the scaling policy.
Considering the maxReplicas parameter, if your app tries to use more CPU than it requested then IO will try to accommodate that demand, but will not guarantee.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
