### PR TITLE
decode segment token locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Decode segment from segment token locally.
 
 ## [2.111.1] - 2019-12-06
 ### Changed

--- a/node/directives/withSegment.ts
+++ b/node/directives/withSegment.ts
@@ -7,11 +7,11 @@ import atob from 'atob'
  * If the getSegment API evolves to do more than a decode we must stop decoding it here and start calling the API once again.
  */
 export class WithSegment extends SchemaDirectiveVisitor {
-  public visitFieldDefinition (field: GraphQLField<any, any>) {
-    const {resolve = defaultFieldResolver} = field
+  public visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field
     field.resolve = async (root, args, ctx: Context, info) => {
-      const {vtex: {segmentToken}} = ctx
-      ctx.vtex.segment = segmentToken ? JSON.parse(atob(segmentToken)) : undefined
+      const { vtex: { segmentToken }, clients: { segment } } = ctx
+      ctx.vtex.segment = segmentToken ? JSON.parse(atob(segmentToken)) : (await segment.getSegment())
       return resolve(root, args, ctx, info)
     }
   }

--- a/node/directives/withSegment.ts
+++ b/node/directives/withSegment.ts
@@ -1,12 +1,17 @@
 import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
+import atob from 'atob'
 
+/**
+ * Warning: we stopped using the segment client to decode the segment token for us because it added unnecessary overhead for now.
+ * If the getSegment API evolves to do more than a decode we must stop decoding it here and start calling the API once again.
+ */
 export class WithSegment extends SchemaDirectiveVisitor {
   public visitFieldDefinition (field: GraphQLField<any, any>) {
     const {resolve = defaultFieldResolver} = field
     field.resolve = async (root, args, ctx: Context, info) => {
-      const {clients: {segment}} = ctx
-      ctx.vtex.segment = await segment.getSegment()
+      const {vtex: {segmentToken}} = ctx
+      ctx.vtex.segment = segmentToken ? JSON.parse(atob(segmentToken)) : undefined
       return resolve(root, args, ctx, info)
     }
   }

--- a/node/package.json
+++ b/node/package.json
@@ -4,6 +4,7 @@
     "@gocommerce/utils": "^0.6.11",
     "apollo-datasource-rest": "^0.1.5",
     "apollo-server-errors": "^2.0.2",
+    "atob": "^2.1.2",
     "axios": "^0.19.0",
     "bluebird": "^3.5.0",
     "camelcase": "^5.0.0",
@@ -22,6 +23,7 @@
     "url-parse": "^1.2.0"
   },
   "devDependencies": {
+    "@types/atob": "^2.1.2",
     "@types/bluebird": "^3.5.0",
     "@types/camelcase": "^4.1.0",
     "@types/cookie": "^0.3.2",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1046,6 +1046,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/atob@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/atob/-/atob-2.1.2.tgz#157eb0cc46264a8c55f2273a836c7a1a644fb820"
+  integrity sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -2012,7 +2017,7 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-atob@^2.1.1:
+atob@^2.1.1, atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==


### PR DESCRIPTION
#### What problem is this solving?

Avoid calling getSegment API. Decode segment from token locally.

#### How should this be manually tested?

https://segment--storecomponents.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
