### PR TITLE
throw errors when calling deprecated queries on dev wks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make deprecated queries return errors when working on development workspaces.
 
 ## [2.111.1] - 2019-12-06
 ### Changed

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -1,5 +1,5 @@
 import { Functions } from '@gocommerce/utils'
-import { NotFoundError, ResolverWarning, UserInputError } from '@vtex/api'
+import { NotFoundError, ResolverWarning, UserInputError, ResolverError } from '@vtex/api'
 import { all } from 'bluebird'
 import {
   compose,
@@ -286,6 +286,9 @@ const isValidProductIdentifier = (identifier: ProductIndentifier | undefined) =>
 
 export const queries = {
   autocomplete: async (_: any, args: any, ctx: Context) => {
+    if (!ctx.vtex.production) {
+      throw new ResolverError('Query was deprecated and will not work in development workspaces. Use vtex.search-graphql queries.')
+    }
     const {
       clients: { catalog },
       clients,
@@ -309,6 +312,9 @@ export const queries = {
     { facets, query, map, hideUnavailableItems }: FacetsArgs,
     ctx: Context
   ) => {
+    if (!ctx.vtex.production) {
+      throw new ResolverError('Query was deprecated and will not work in development workspaces. Use vtex.search-graphql queries.')
+    }
     const {
       clients: { catalog },
       clients,
@@ -344,6 +350,9 @@ export const queries = {
   },
 
   product: async (_: any, rawArgs: ProductArgs, ctx: Context) => {
+    if (!ctx.vtex.production) {
+      throw new ResolverError('Query was deprecated and will not work in development workspaces. Use vtex.search-graphql queries.')
+    }
     const {
       vtex: { account },
       clients: { catalog },
@@ -391,6 +400,9 @@ export const queries = {
   },
 
   products: async (_: any, args: SearchArgs, ctx: Context) => {
+    if (!ctx.vtex.production) {
+      throw new ResolverError('Query was deprecated and will not work in development workspaces. Use vtex.search-graphql queries.')
+    }
     const {
       clients: { catalog },
     } = ctx
@@ -415,6 +427,9 @@ export const queries = {
     args: ProductsByIdentifierArgs,
     ctx: Context
   ) => {
+    if (!ctx.vtex.production) {
+      throw new ResolverError('Query was deprecated and will not work in development workspaces. Use vtex.search-graphql queries.')
+    }
     const {
       clients: { catalog },
     } = ctx
@@ -445,6 +460,9 @@ export const queries = {
   },
 
   productSearch: async (_: any, args: SearchArgs, ctx: Context) => {
+    if (!ctx.vtex.production) {
+      throw new ResolverError('Query was deprecated and will not work in development workspaces. Use vtex.search-graphql queries.')
+    }
     const {
       clients,
       clients: { catalog },
@@ -575,6 +593,9 @@ export const queries = {
     { identifier, type }: ProductRecommendationArg,
     ctx: Context
   ) => {
+    if (!ctx.vtex.production) {
+      throw new ResolverError('Query was deprecated and will not work in development workspaces. Use vtex.search-graphql queries.')
+    }
     if (identifier == null || type == null) {
       throw new UserInputError('Wrong input provided')
     }
@@ -588,6 +609,9 @@ export const queries = {
   },
 
   searchMetadata: async (_: any, args: SearchMetadataArgs, ctx: Context) => {
+    if (!ctx.vtex.production) {
+      throw new ResolverError('Query was deprecated and will not work in development workspaces. Use vtex.search-graphql queries.')
+    }
     const { clients } = ctx
     const queryTerm = args.query
     if (queryTerm == null || test(/[?&[\]=]/, queryTerm)) {


### PR DESCRIPTION
#### What problem is this solving?

There are still third party apps calling the deprecated queries.
Now we will throw an error if production is false

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
