### PR TITLE
Add condition field to checkProfileAllowed query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New field `condition` to `checkProfileAllowed`.
+
+### Changed
+- Deprecate field `allowed` from `checkProfileAllowed`.
 
 ## [2.112.0] - 2019-12-20
 

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -230,7 +230,14 @@ input ProfileInput {
 }
 
 type UserCondition {
-  allowed: Boolean
+  condition: UserConditionType
+  allowed: Boolean @deprecated(reason: "Use condition field instead")
+}
+
+enum UserConditionType {
+  authorized
+  unauthorized
+  forbidden
 }
 
 input AddressInput {

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -72,7 +72,7 @@ export const queries = {
     )
 
     if (!email) {
-      return { allowed: false }
+      return { allowed: false, condition: 'unauthorized' }
     }
 
     const availableSalesChannels = await catalog
@@ -82,7 +82,10 @@ export const queries = {
     // Checking with `==` since `sc.Id` is an Integer and salesChannel a string
     const available = availableSalesChannels.find(sc => sc.Id == salesChannel)
 
-    return { allowed: Boolean(available) }
+    return {
+      allowed: Boolean(available),
+      condition: available ? 'authorized' : 'forbidden',
+    }
   },
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Previously it was not possible to verify if the user was not allowed because it was not logged in or if it was forbidden.

#### How should this be manually tested?

1. Open https://breno--gympassus.myvtex.com/
2. Log in with a Brazilian account
3. Be redirected to `/error-sign-up`

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
