### PR TITLE
not needed to call the whole category tree in some resolvers anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Performace improvements on category resolvers when fetching by id.
 
 ## [2.113.1] - 2019-12-30
 ### Fixed

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -22,9 +22,8 @@ export const pathToCategoryHref = (path: string) => {
 interface SafeCategory
   extends Pick<
   Category,
-  'id' | 'name' | 'hasChildren' | 'MetaTagDescription' | 'Title'
+  'id' | 'name' | 'hasChildren' | 'MetaTagDescription' | 'Title' | 'url'
   > {
-  url: string | null
   children: Category[] | null
 }
 
@@ -32,35 +31,15 @@ export const resolvers = {
   Category: {
     cacheId: prop('id'),
 
-    href: async (
-      { id, url }: SafeCategory,
-      _: any,
-      { clients: { catalog } }: Context
-    ) => {
-      if (url == null) {
-        const category = await getCategoryInfo(catalog, id, 4)
-        url = category.url
-      }
-      const path = cleanUrl(url)
-
-      // If the path is `/clothing`, we know that's a department
-      // But if it is `/clothing/shirts`, it's not.
-      return pathToCategoryHref(path)
+    href: async ({ url }: SafeCategory) => {
+      return cleanUrl(url)
     },
 
     metaTagDescription: prop('MetaTagDescription'),
 
     titleTag: prop('Title'),
 
-    slug: async (
-      { id, url }: SafeCategory,
-      _: any,
-      { clients: { catalog } }: Context
-    ) => {
-      if (url == null) {
-        const category = await getCategoryInfo(catalog, id, 4)
-        url = category.url
-      }
+    slug: async ({ url }: SafeCategory) => {
       return url ? lastSegment(url) : null
     },
 
@@ -70,7 +49,7 @@ export const resolvers = {
       { clients: { catalog } }: Context
     ) => {
       if (children == null) {
-        const category = await getCategoryInfo(catalog, id, 4)
+        const category = await getCategoryInfo(catalog, id, 5)
         children = category.children
       }
       return children

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -31,17 +31,13 @@ export const resolvers = {
   Category: {
     cacheId: prop('id'),
 
-    href: async ({ url }: SafeCategory) => {
-      return cleanUrl(url)
-    },
+    href: ({ url }: SafeCategory) => cleanUrl(url),
 
     metaTagDescription: prop('MetaTagDescription'),
 
     titleTag: prop('Title'),
 
-    slug: async ({ url }: SafeCategory) => {
-      return url ? lastSegment(url) : null
-    },
+    slug: ({ url }: SafeCategory) => url ? lastSegment(url) : null,
 
     children: async (
       { id, children }: SafeCategory,


### PR DESCRIPTION
#### What problem is this solving?

These changes are already made in search-graphql. its copied from there.
The catalog fixed a bug and we now have these fields in the category by id api

https://fidelis--biscoind.myvtex.com/_v/private/vtex.store-graphql@2.113.1/graphiql/v1?query=query%20%7B%0A%20%20category(id%3A137)%20%7B%0A%20%20%20%20id%0A%20%20%20%20name%0A%20%20%20%20slug%0A%20%20%20%20href%0A%20%20%20%20children%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20slug%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20href%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
