### PR TITLE
Allow not logged in users to visit open trade policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make `checkProfileAllowed` return `authorized` if the user is not logged in but is in an open trade policy.
 
 ## [2.113.2] - 2020-01-06
 ### Changed

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -62,9 +62,11 @@ export class Catalog extends AppClient {
     )
   }
 
-  public salesChannelAvailable = (email: string) =>
+  public salesChannelAvailable = (email?: string) =>
     this.get<SalesChannelAvailable[]>(
-      `/pub/saleschannel/available?email=${encodeURIComponent(email)}`,
+      `/pub/saleschannel/available${
+        email ? `?email=${encodeURIComponent(email)}` : ''
+      }`,
       {
         metric: 'catalog-sales-channel-available',
       }

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -65,6 +65,7 @@ export class Catalog extends AppClient {
   public salesChannelAvailable = (email?: string) =>
     this.get<SalesChannelAvailable[]>(
       `/pub/saleschannel/available${
+        // If we dont pass the email query string, it will return all open Trade Policies
         email ? `?email=${encodeURIComponent(email)}` : ''
       }`,
       {

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -71,10 +71,6 @@ export const queries = {
       sessionData
     )
 
-    if (!email) {
-      return { allowed: false, condition: 'unauthorized' }
-    }
-
     const availableSalesChannels = await catalog
       .salesChannelAvailable(email)
       .catch(() => [])
@@ -84,7 +80,11 @@ export const queries = {
 
     return {
       allowed: Boolean(available),
-      condition: available ? 'authorized' : 'forbidden',
+      condition: available
+        ? 'authorized'
+        : email
+        ? 'forbidden'
+        : 'unauthorized',
     }
   },
 }

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -83,8 +83,8 @@ export const queries = {
       condition: available
         ? 'authorized'
         : email
-        ? 'forbidden'
-        : 'unauthorized',
+        ? 'forbidden' // The user is logged in and not allowed
+        : 'unauthorized', // We don't know the user identity
     }
   },
 }


### PR DESCRIPTION
#### What problem is this solving?

Previously we would short circuit the allowed check if the user is not logged in and return `unauthorized`.

Now if the user is not logged in, we still check for open Trade Policies. If the current Trade Policy is open, we return `authorized`. 

#### How should this be manually tested?

Working in a closed Trade Policy (no regression)
https://breno--gympassus.myvtex.com/

Working in an open Trade Policy (new scenario)
https://breno--powerplanet.myvtex.com/

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ x Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
n/a

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
