### PR TITLE
fix for when sending empty utmParams and already having marketingData…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix problem of updating order form marketing data with invalid fields and breaking addItem mutation in some ocasions.
 
 ## [2.113.3] - 2020-01-07
 ### Fixed

--- a/node/__tests__/checkout/index.test.ts
+++ b/node/__tests__/checkout/index.test.ts
@@ -121,3 +121,32 @@ it.each<any>([
   expect(checkoutClient.addItem.mock.calls[0][1]).toMatchObject([itemToAdd])
   expect(checkoutClient.updateOrderFormMarketingData).toBeCalledTimes(0)
 })
+
+it.each([
+  [undefined, undefined],
+  [{}, {}]
+])('empty utmParams and utmiParams do not call updateOrderFormMarketingData', async (utmParams, utmiParams) => {
+  const itemToAdd = {
+    id: 100,
+    quantity: 1,
+    seller: '1'
+  }
+
+  const checkoutClient = mockContext.clients.checkout
+  checkoutClient.orderForm.mockImplementationOnce(() => ({
+    ...orderForm,
+    marketingData: { coupon: null, marketingTags: [] }
+  }))
+
+  await mutations.addItem({}, {
+    orderFormId: orderForm.orderFormId,
+    items: [itemToAdd],
+    utmParams,
+    utmiParams,
+  }, mockContext as any)
+
+
+  expect(checkoutClient.addItem.mock.calls[0][0]).toBe(orderForm.orderFormId)
+  expect(checkoutClient.addItem.mock.calls[0][1]).toMatchObject([itemToAdd])
+  expect(checkoutClient.updateOrderFormMarketingData).toBeCalledTimes(0)
+})

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -305,7 +305,7 @@ export const mutations: Record<string, Resolver> = {
       }
 
       const atLeastOneValidField = Object.values(newMarketingData).some(value => {
-        if (!value || (Array.isArray(value) && value.length === 0)) {
+        if (value == null || value === '' && (Array.isArray(value) && value.length === 0)) {
           return false
         }
         return true

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -305,7 +305,7 @@ export const mutations: Record<string, Resolver> = {
       }
 
       const atLeastOneValidField = Object.values(newMarketingData).some(value => {
-        if (value == null || value === '' && (Array.isArray(value) && value.length === 0)) {
+        if ((value == null || value === '') && (Array.isArray(value) && value.length === 0)) {
           return false
         }
         return true

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -305,7 +305,10 @@ export const mutations: Record<string, Resolver> = {
       }
 
       const atLeastOneValidField = Object.values(newMarketingData).some(value => {
-        if ((value == null || value === '') && (Array.isArray(value) && value.length === 0)) {
+        if (value == null || value === '') {
+          return false
+        }
+        if (Array.isArray(value) && value.length === 0) {
           return false
         }
         return true

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -74,6 +74,11 @@ const shouldUpdateMarketingData = (
     utmipage = null,
   } = orderFormMarketingTags || {}
 
+  if (!utmParams?.campaign && !utmParams?.medium && !utmParams?.campaign && !utmiParams?.campaign && !utmiParams?.page && !utmiParams?.part) {
+    // Avoid updating at any costs if all fields are invalid
+    return false
+  }
+
   return (
     ((utmParams?.source ?? null) !== utmSource) ||
     ((utmParams?.medium ?? null) !== utmMedium) ||
@@ -299,7 +304,17 @@ export const mutations: Record<string, Resolver> = {
         )
       }
 
-      await checkout.updateOrderFormMarketingData(orderFormId, newMarketingData)
+      const atLeastOneValidField = Object.values(newMarketingData).some(value => {
+        if (!value || (Array.isArray(value) && value.length === 0)) {
+          return false
+        }
+        return true
+      })
+
+      // If all fields of newMarketingData are invalid, it causes checkout to answer with an error 400
+      if (atLeastOneValidField) {
+        await checkout.updateOrderFormMarketingData(orderFormId, newMarketingData)
+      }
     }
 
     const cleanItems = items.map(({ options, ...rest }) => rest)


### PR DESCRIPTION
… in session

Caso queira testar:
criar um orderForm e atualizar o marketingData, modelo de request abaixo:
```
curl -X POST \
  'http://portal.vtexcommercestable.com.br/api/checkout/pub/orderForm/b983e4d2990c48878d9249a45021b163/attachments/marketingData?an=boticario' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/json' \
  -H 'postman-token: f1ce3cec-0fcf-80fa-ecf9-4cc5236afde3' \
  -H 'vtexidclientautcookie: eyJhbGciOiJFUzI1NiIsImtpZCI6IkU0OUI2NzYxNjk5NUJGMzNBQjkxM0VCQzJCREMxMEFCNURBQkZERTMiLCJ0eXAiOiJqd3QifQ.eyJzdWIiOiJqb2FvLmZpZGVsaXNAdnRleC5jb20uYnIiLCJhY2NvdW50IjoiX192dGV4X2FkbWluIiwic2NvcGUiOiJiaXNjb2luZDphZG1pbiIsImF1dGhvcml6YWJsZXMiOlsidnJuOmlhbTpfX3Z0ZXhfYWRtaW46dXNlcnMvam9hby5maWRlbGlzQHZ0ZXguY29tLmJyIl0sImV4cCI6MTU3ODU3NzQyNiwib0F1dGhVc2VySW5mbyI6MTExODY0ODQsIm9BdXRoVXNlckluZm9MaXN0IjpbMTExODY0ODRdLCJ1c2VySWQiOiIxOTg2MWVmZi1mMDVjLTQwOTktOTBlMS0wMDY2NTNlN2ZjMjMiLCJpYXQiOjE1Nzg0OTEwMjYsImlzcyI6InRva2VuLWVtaXR0ZXIiLCJqdGkiOiI2NzZmMTZhOC1iNGZmLTQ5OWYtOGI3Yy03N2E5OTQ1ZDZkZTcifQ.QV5tqlqxl6LFQ9KsCqhw2PU09-lJuXXrLDdl4eBTR7GtdyM00bsq6dIyMowB4_PtA2lJlyLEwnqxmNRpPIl7WA' \
  -d '{"utmCampaign": "fidelis"}'
```

Vá em algum produto em https://storeadd--boticario.myvtex.com/kit-presente-quasar-pais_76848/p

Adicione um item no carrinho. Veja que deu certo.
Faça um get no order form e veja que o marketingData continua identico ao que você modificou no post anterior.