### PR TITLE
fix update session logging user out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Update session does not logout the user anymore.
+- Fix unexpected deletion of cookies from session
 
 ### Added
 - Temporary custom session client with update session fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Update session does not logout the user anymore.
+
+### Added
+- Temporary custom session client with update session fix.
 
 ## [2.115.0] - 2020-02-13
 ### Added

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -8,6 +8,7 @@ import { ProfileClient } from './profile'
 import { OMS } from './oms'
 import { Portal } from './portal'
 import { LogisticsClient } from './logistics'
+import { Session } from './session'
 
 export class Clients extends IOClients {
   public get masterdata() {
@@ -40,5 +41,9 @@ export class Clients extends IOClients {
 
   public get logistics() {
     return this.getOrSet('logistics', LogisticsClient)
+  }
+
+  public get customSession() {
+    return this.getOrSet('customSession', Session)
   }
 }

--- a/node/clients/session.ts
+++ b/node/clients/session.ts
@@ -1,0 +1,74 @@
+import { JanusClient } from '@vtex/api'
+import parseCookie from 'cookie'
+import { prop } from 'ramda'
+
+interface VtexIdCookies {
+  account: string | null
+  id: string | null
+}
+
+const SESSION_COOKIE = 'vtex_session'
+
+const routes = {
+  base: '/api/sessions',
+}
+
+export class Session extends JanusClient {
+  /**
+   * Get the session data using the given token
+   */
+  public getSession = async (token: string, items: string[]) => {
+    const {
+      data: sessionData,
+      headers: {
+        'set-cookie': [setCookies],
+      },
+    } = await this.http.getRaw<any>(routes.base, ({
+      headers: {
+        'Content-Type': 'application/json',
+        'Cookie': `vtex_session=${token};`,
+      },
+      metric: 'session-get',
+      params: {
+        items: items.join(','),
+      },
+    }))
+
+    const parsedCookie = parseCookie.parse(setCookies)
+    const sessionToken = prop(SESSION_COOKIE, parsedCookie)
+
+    return {
+      sessionData,
+      sessionToken,
+    }
+  }
+
+  /**
+   * Update the public portion of this session
+   */
+  public updateSession = (key: string, value: any, items: string[], token: any, vtexIdCookies: VtexIdCookies) => {
+    const data = { public: { [key]: { value } } }
+    let cookies = `vtex_session=${token};`
+    if (vtexIdCookies.account) {
+      cookies += `${vtexIdCookies.account};`
+    }
+    if (vtexIdCookies.id) {
+      cookies += `${vtexIdCookies.id};`
+    }
+
+    console.log('teste SENDING COOKIES: ', cookies)
+
+    const config = {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cookie': cookies,
+      },
+      metric: 'session-update',
+      params: {
+        items: items.join(','),
+      },
+    }
+
+    return this.http.post(routes.base, data, config)
+  }
+}

--- a/node/clients/session.ts
+++ b/node/clients/session.ts
@@ -56,8 +56,6 @@ export class Session extends JanusClient {
       cookies += `${vtexIdCookies.id};`
     }
 
-    console.log('teste SENDING COOKIES: ', cookies)
-
     const config = {
       headers: {
         'Content-Type': 'application/json',

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -55,13 +55,13 @@ export const queries = {
 
   checkProfileAllowed: async (_: any, __: any, context: Context) => {
     const {
-      clients: { catalog, session },
+      clients: { catalog, customSession },
       vtex: { segment },
       cookies,
     } = context
     const salesChannel = segment ? segment.channel : null
 
-    const { sessionData } = await session.getSession(
+    const { sessionData } = await customSession.getSession(
       cookies.get('vtex_session')!,
       ['*']
     )

--- a/node/resolvers/session/index.ts
+++ b/node/resolvers/session/index.ts
@@ -53,7 +53,6 @@ export const queries = {
       cookies.get(VTEX_SESSION)!,
       ['*']
     )
-    console.log('teste profile: ', sessionData.namespaces.profile)
     return sessionFields(sessionData)
   },
 }

--- a/node/resolvers/session/index.ts
+++ b/node/resolvers/session/index.ts
@@ -2,10 +2,9 @@ import { serialize } from 'cookie'
 import { identity } from 'ramda'
 import { sessionFields } from './sessionResolver'
 import { fieldResolvers as sessionPickupResolvers } from './sessionPickup'
+import { vtexIdCookies } from '../../utils/vtexId'
 
 const VTEX_SESSION = 'vtex_session'
-const vtexIdAccount = (account: string) => `VtexIdclientAutCookie_${account}`
-const VTEX_ID = 'VtexIdclientAutCookie'
 
 const IMPERSONATED_EMAIL = 'vtex-impersonated-customer-email'
 // maxAge of 1-day defined in vtex-impersonated-customer-email cookie
@@ -25,18 +24,6 @@ const convertCheckoutAddressToProfile = (
   const { geoCoordinates, ...rest } = checkoutAddress
   return { ...rest, geoCoordinate: geoCoordinates }
 }
-
-const vtexIdCookies = (ctx: Context) => {
-  const { cookies, vtex: { account }} = ctx
-  const vtexIdAccountCookieValue = cookies.get(vtexIdAccount(account))
-  const vtexIdValue = cookies.get(VTEX_ID)
-
-  return {
-    account: vtexIdAccountCookieValue ? `${vtexIdAccount(account)}=${vtexIdAccountCookieValue}` : null,
-    id: vtexIdValue ? `${VTEX_ID}=${vtexIdValue}` : null,
-  }
-}
-
 
 // Disclaimer: These queries and mutations assume that vtex_session was passed in cookies.
 export const queries = {

--- a/node/utils/vtexId.ts
+++ b/node/utils/vtexId.ts
@@ -1,0 +1,13 @@
+const vtexIdAccount = (account: string) => `VtexIdclientAutCookie_${account}`
+const VTEX_ID = 'VtexIdclientAutCookie'
+
+export const vtexIdCookies = (ctx: Context) => {
+  const { cookies, vtex: { account }} = ctx
+  const vtexIdAccountCookieValue = cookies.get(vtexIdAccount(account))
+  const vtexIdValue = cookies.get(VTEX_ID)
+
+  return {
+    account: vtexIdAccountCookieValue ? `${vtexIdAccount(account)}=${vtexIdAccountCookieValue}` : null,
+    id: vtexIdValue ? `${VTEX_ID}=${vtexIdValue}` : null,
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

https://fidelis2--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.115.0/graphiql/v1?query=mutation%20%7B%0A%20%20savePickupInSession(name%3A%20%22teste2%22%2C%20address%3A%20%7BaddressId%3A%22teste3%22%7D)%20%7B%0A%20%20%20%20id%0A%20%20%20%20favoritePickup%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A%23%20query%20%7B%0A%23%20%20%20getSession%7B%0A%23%20%20%20%20%20id%0A%23%20%20%20%20%20adminUserId%0A%23%20%20%20%7D%0A%23%20%7D

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
