### PR TITLE
Feature/masterdata v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `documentSchemaV2` query, get generic masterdata schema, returned as a `scalar` type as is from the request
+- `createDocumentV2` mutation, upload a `scalar` document to Master Data
+
 ## [2.116.1] - 2020-02-18
 ### Fixed
 - Make order form item image url use https.

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -399,6 +399,17 @@ type Query {
     schema: String
   ): DocumentSchema
 
+  documentSchemaV2(
+    """
+    Data entity name.
+    """
+    dataEntity: String!
+    """
+    MasterData schema name.
+    """
+    schema: String!
+  ): DocumentSchemaV2
+
   """
   Get the benefits associated with a list of products
   """
@@ -814,6 +825,11 @@ type Mutation {
     field: String!
     file: Upload!
   ): AttachmentResponse
+  createDocumentV2(
+    dataEntity: String!
+    document: DocumentInputV2
+    schema: String
+  ): DocumentResponseV2
 
   """
   List

--- a/graphql/types/Document.graphql
+++ b/graphql/types/Document.graphql
@@ -1,3 +1,6 @@
+scalar JSONSchema
+scalar DocumentV2
+
 type Document {
   """
   id is used as cacheId
@@ -22,6 +25,16 @@ type DocumentResponse {
   documentId: String
 }
 
+type DocumentResponseV2 {
+  """
+  documentId is used as cacheId
+  """
+  cacheId: ID
+  id: String
+  href: String
+  documentId: String
+}
+
 type AttachmentResponse {
   filename: String
   mimetype: String
@@ -34,6 +47,10 @@ input FieldInput {
 
 input DocumentInput {
   fields: [FieldInput]
+}
+
+input DocumentInputV2 {
+  document: DocumentV2
 }
 
 type DocProperty {
@@ -55,4 +72,8 @@ type DocumentSchema {
   indexed: [String]
   security: VSecurity
   cache: Boolean
+}
+
+type DocumentSchemaV2 {
+  schema: JSONSchema
 }

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -117,6 +117,12 @@ declare global {
     DocumentId: string
   }
 
+  interface DocumentResponseV2 {
+    Id: string
+    Href: string
+    DocumentId: string
+  }
+
   interface DocumentArgs {
     acronym: string
     fields: string[]
@@ -140,6 +146,12 @@ declare global {
   interface CreateDocumentArgs {
     acronym: string
     document: { fields: KeyValue[] }
+    schema?: string
+  }
+
+  interface CreateDocumentV2Args {
+    dataEntity: string
+    document: { document: any }
     schema?: string
   }
 

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -56,6 +56,22 @@ export const queries = {
 
     return { ...data, name: data ? args.schema : null }
   },
+
+  documentSchemaV2: async (
+    _: any,
+    args: DocumentSchemaArgs,
+    context: Context
+  ) => {
+    const { dataEntity, schema } = args
+
+    const {
+      clients: { masterdata },
+    } = context
+
+    const data = await masterdata.getSchema<object>(dataEntity, schema)
+
+    return { schema: data }
+  },
 }
 
 export const fieldResolvers = {
@@ -88,6 +104,36 @@ export const mutations = {
       id: prop('Id', response),
       href: prop('Href', response),
       documentId: removeAcronymFromId(acronym, response),
+    }
+  },
+
+  createDocumentV2: async (
+    _: any,
+    args: CreateDocumentV2Args,
+    context: Context
+  ) => {
+    const {
+      dataEntity,
+      document: { document },
+      schema,
+    } = args
+
+    const {
+      clients: { masterdata },
+    } = context
+
+    const response = (await masterdata.createDocument(
+      dataEntity,
+      document,
+      schema
+    )) as DocumentResponseV2
+
+    const documentId = removeAcronymFromId(dataEntity, response)
+    return {
+      cacheId: documentId,
+      id: prop('Id', response),
+      href: prop('Href', response),
+      documentId: documentId,
     }
   },
 


### PR DESCRIPTION
#### What problem is this solving?

This change implements fetching a MasterData V2 schema, using `documenSchemaV2` query. It also impllements the mutation `createDocumentV2` for saving a document to a Master Data V2 entity with validation against a specified schema.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

`documentSchemaV2` does not work publicly due to how Master Data currently implements the API
Did not update `README.md` due to it being outdated already.
