### PR TITLE
Implement query documentPublicSchema to fetch public schemas from MD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `documentSchemaV2` to `documentPublicSchema`, as the query only works with public schemas without authentication.
+
 ## [2.117.0] - 2020-02-19
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -399,7 +399,7 @@ type Query {
     schema: String
   ): DocumentSchema
 
-  documentSchemaV2(
+  documentPublicSchema(
     """
     Data entity name.
     """

--- a/node/clients/masterdata.ts
+++ b/node/clients/masterdata.ts
@@ -31,6 +31,11 @@ export class MasterData extends ExternalClient {
       metric: 'masterdata-getSchema',
     })
 
+  public getPublicSchema = <T>(dataEntity: string, schema: string) =>
+    this.get<T>(this.routes.publicSchema(dataEntity, schema), {
+      metric: 'masterdata-getPublicSchema',
+    })
+
   public getDocument = <T>(acronym: string, id: string, fields: string[]) =>
     this.get<T>(this.routes.document(acronym, id), {
       metric: 'masterdata-getDocument',
@@ -43,17 +48,21 @@ export class MasterData extends ExternalClient {
     this.post<DocumentResponse>(this.routes.documents(acronym), fields, {
       metric: 'masterdata-createDocument',
       params: {
-        ...schema? {_schema: schema} : null
-      }
+        ...(schema ? { _schema: schema } : null),
+      },
     })
 
-
-  public updateDocument = (acronym: string, id: string, fields: object, schema?: string) =>
+  public updateDocument = (
+    acronym: string,
+    id: string,
+    fields: object,
+    schema?: string
+  ) =>
     this.patch(this.routes.document(acronym, id), fields, {
       metric: 'masterdata-updateDocument',
       params: {
-        ...schema? {_schema: schema} : null
-      }
+        ...(schema ? { _schema: schema } : null),
+      },
     })
 
   public searchDocuments = <T>(
@@ -62,16 +71,17 @@ export class MasterData extends ExternalClient {
     where: string,
     pagination: PaginationArgs,
     schema?: string
-  ) =>{
+  ) => {
     return this.get<T[]>(this.routes.search(acronym), {
       headers: paginationArgsToHeaders(pagination),
       metric: 'masterdata-searchDocuments',
       params: {
         _fields: generateFieldsArg(fields),
         _where: where,
-        ...schema ? {_schema: schema} : null
+        ...(schema ? { _schema: schema } : null),
       },
-    })}
+    })
+  }
 
   public deleteDocument = (acronym: string, id: string) =>
     this.delete(this.routes.document(acronym, id), {
@@ -111,7 +121,10 @@ export class MasterData extends ExternalClient {
         `${acronym}/documents/${id}/${fields}/attachments`,
       document: (acronym: string, id: string) => `${acronym}/documents/${id}`,
       documents: (acronym: string) => `${acronym}/documents`,
-      schema: (acronym: string, schema: string) => `${acronym}/schemas/${schema}`,
+      schema: (acronym: string, schema: string) =>
+        `${acronym}/schemas/${schema}`,
+      publicSchema: (acronym: string, schema: string) =>
+        `${acronym}/schemas/${schema}/public`,
       search: (acronym: string) => `${acronym}/search`,
     }
   }

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -57,7 +57,7 @@ export const queries = {
     return { ...data, name: data ? args.schema : null }
   },
 
-  documentSchemaV2: async (
+  documentPublicSchema: async (
     _: any,
     args: DocumentSchemaArgs,
     context: Context
@@ -68,7 +68,7 @@ export const queries = {
       clients: { masterdata },
     } = context
 
-    const data = await masterdata.getSchema<object>(dataEntity, schema)
+    const data = await masterdata.getPublicSchema<object>(dataEntity, schema)
 
     return { schema: data }
   },


### PR DESCRIPTION
#### What problem is this solving?

Add query to fetch public schema from Master Data V2

#### How should this be manually tested?

[Workspace](https://helena--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.116.1/graphiql/v1?query=%7B%0A%20%20documentPublicSchema(dataEntity%3A%20%22Test%22%2C%20schema%3A%20%22personV2%22)%20%7B%0A%20%20%20%20schema%0A%20%20%7D%0A%7D%0A)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
