### PR TITLE
Clear OrderForm data when a Telemarketing user logout from a customer account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Clear cart when Telemarketing user ends customer's session
+
 ## [2.118.0] - 2020-02-27
 
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -803,7 +803,10 @@ type Mutation {
   """
   Depersonify a customer
   """
-  depersonify: Boolean @withOrderFormId
+  depersonify: Boolean
+    @withOrderFormId
+    @withSegment
+    @cacheControl(scope: PRIVATE)
 
   """
   Document

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -162,14 +162,6 @@ export class Checkout extends JanusClient {
     )
   }
 
-  public orderFormWithoutCookies = () => {
-    return this.http.post<OrderForm>(
-      this.routes.orderForm,
-      { expectedOrderFormSections: ['items'] },
-      { metric: 'checkout-orderForm-without-cookies' }
-    )
-  }
-
   public orderFormRaw = () => {
     return this.postRaw<OrderForm>(
       this.routes.orderForm,

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -162,20 +162,20 @@ export class Checkout extends JanusClient {
     )
   }
 
-  public newOrderForm = () => {
-    return this.http.postRaw<OrderForm>(
-      this.routes.orderForm,
-      { expectedOrderFormSections: ['items'] },
-      { metric: 'checkout-orderForm-new' }
-    )
-  }
-
   public orderFormRaw = () => {
     return this.postRaw<OrderForm>(
       this.routes.orderForm,
       { expectedOrderFormSections: ['items'] },
       { metric: 'checkout-orderForm' }
     )
+  }
+
+  public newOrderForm = () => {
+    return this.http
+      .postRaw<OrderForm>(this.routes.orderForm, undefined, {
+        metric: 'checkout-newOrderForm',
+      })
+      .catch(statusToError) as Promise<IOResponse<OrderForm>>
   }
 
   public changeToAnonymousUser = () => {

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -21,10 +21,15 @@ export class Checkout extends JanusClient {
   }
 
   private getCommonHeaders = () => {
-    const { orderFormId, segmentToken, sessionToken } = this.context as CustomIOContext
+    const { orderFormId, segmentToken, sessionToken } = this
+      .context as CustomIOContext
     const checkoutCookie = orderFormId ? checkoutCookieFormat(orderFormId) : ''
-    const segmentTokenCookie = segmentToken ? `vtex_segment=${segmentToken};` : ''
-    const sessionTokenCookie = sessionToken ? `vtex_session=${sessionToken};` : ''
+    const segmentTokenCookie = segmentToken
+      ? `vtex_segment=${segmentToken};`
+      : ''
+    const sessionTokenCookie = sessionToken
+      ? `vtex_session=${sessionToken};`
+      : ''
     return {
       Cookie: `${checkoutCookie}${segmentTokenCookie}${sessionTokenCookie}`,
     }
@@ -113,12 +118,13 @@ export class Checkout extends JanusClient {
 
   public updateOrderFormClientPreferencesData = (
     orderFormId: string,
-    clientPreferencesData: OrderFormClientPreferencesData,
+    clientPreferencesData: OrderFormClientPreferencesData
   ) => {
     // The API default value of `optinNewsLetter` is `null`, but it doesn't accept a POST with its value as `null`
-    const filteredClientPreferencesData = clientPreferencesData.optinNewsLetter === null
-      ? { locale: clientPreferencesData.locale }
-      : clientPreferencesData
+    const filteredClientPreferencesData =
+      clientPreferencesData.optinNewsLetter === null
+        ? { locale: clientPreferencesData.locale }
+        : clientPreferencesData
 
     return this.post(
       this.routes.attachmentsData(orderFormId, 'clientPreferencesData'),

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -162,6 +162,14 @@ export class Checkout extends JanusClient {
     )
   }
 
+  public orderFormWithoutCookies = () => {
+    return this.http.post<OrderForm>(
+      this.routes.orderForm,
+      { expectedOrderFormSections: ['items'] },
+      { metric: 'checkout-orderForm-without-cookies' }
+    )
+  }
+
   public orderFormRaw = () => {
     return this.postRaw<OrderForm>(
       this.routes.orderForm,

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -162,6 +162,14 @@ export class Checkout extends JanusClient {
     )
   }
 
+  public newOrderForm = () => {
+    return this.http.postRaw<OrderForm>(
+      this.routes.orderForm,
+      { expectedOrderFormSections: ['items'] },
+      { metric: 'checkout-orderForm-new' }
+    )
+  }
+
   public orderFormRaw = () => {
     return this.postRaw<OrderForm>(
       this.routes.orderForm,

--- a/node/package.json
+++ b/node/package.json
@@ -18,7 +18,7 @@
     "querystring": "^0.2.0",
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
-    "typescript": "3.7.3",
+    "typescript": "3.8.3",
     "unorm": "^1.5.0",
     "url-parse": "^1.2.0"
   },

--- a/node/resolvers/session/index.ts
+++ b/node/resolvers/session/index.ts
@@ -88,10 +88,11 @@ export const mutations = {
     return queries.getSession({}, {}, ctx)
   },
 
-  depersonify: async (_: any, __: any, ctx: Context) => {
+  depersonify: async (_: any, __: any, ctx: any) => {
     const {
       clients: { customSession, checkout },
       cookies,
+      vtex: { orderFormId }
     } = ctx
 
     await customSession.updateSession(
@@ -101,6 +102,15 @@ export const mutations = {
       cookies.get(VTEX_SESSION)!,
       vtexIdCookies(ctx)
     )
+
+    const { items }: OrderForm = await checkout.orderForm()
+    const emptyItems = items.map(({ id, seller }: OrderFormItem, index) => ({
+      id,
+      seller,
+      quantity: 0,
+      index
+    }))
+    await checkout.updateItems(orderFormId, emptyItems)
 
     try {
       await checkout.changeToAnonymousUser()

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6480,7 +6480,12 @@ typescript@3.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
   integrity sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==
 
-typescript@3.7.3, typescript@^3.7.3:
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+typescript@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==


### PR DESCRIPTION
#### What problem is this solving?
Clear OrderForm data when a Telemarketing user logout from a customer account

#### How should this be manually tested?
1. Enter https://dev14101--unimarcdev.myvtex.com/
2. Login with the user "casenssi@gmail.com"
3. Add a product to Cart
4. Logout the customer account on the telemarketing's logout button

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Discuss link: https://github.com/vtex-apps/store-discussion/issues/228