### PR TITLE
Add status and statusDescription as Order fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Add `status` and `statusDescription` field
+- Add `status` and `statusDescription` field.
 
 ## [2.119.0] - 2020-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- deprecate `state` field in `Order` type
+### Added
 - Add `status` and `statusDescription` field
 
 ## [2.119.0] - 2020-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- deprecate `state` field in `Order` type
+- Add `status` and `statusDescription` field
 
 ## [2.119.0] - 2020-03-18
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,19 +19,24 @@ This project is a GraphQL API build in our [VTEX IO Platform](https://vtex.io/) 
 
 ## Table of Content
 
-- [Depreaction Notices](#depreaction-notices)
-- [Usage](#usage)
-- [Queries](#queries)
-  - [Catalog](#catalog)
-  - [Logistics](#logistics)
-  - [Checkout](#checkout)
-  - [OMS](#oms)
-  - [Profile System](#profile-system)
-- [Mutations](#mutations)
-  - [Checkout](#checkout-1)
-  - [Profile System](#profile-system-1)
-- [Contributing](#contributing)
-- [Troubleshooting](#troubleshooting)
+- [VTEX Store GraphQL](#vtex-store-graphql)
+  - [Description](#description)
+  - [Release schedule](#release-schedule)
+  - [Table of Content](#table-of-content)
+    - [Depreaction Notices](#depreaction-notices)
+  - [Usage](#usage)
+  - [Queries](#queries)
+    - [Catalog](#catalog)
+    - [Logistics](#logistics)
+    - [Checkout](#checkout)
+    - [OMS](#oms)
+    - [Profile System](#profile-system)
+  - [Mutations](#mutations)
+    - [Checkout](#checkout-1)
+    - [Profile System](#profile-system-1)
+  - [Contributing](#contributing)
+  - [Troubleshooting](#troubleshooting)
+  - [Contributors](#contributors)
 
 ### Depreaction Notices
 
@@ -66,6 +71,7 @@ TODO
 
 - `orders` - Returns user orders details
 - `order` - Returns a specified user order
+- `userLastOrder` - Returns the last order made by a logged in customer
 
 ### Profile System
 

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -2,7 +2,7 @@ type Order {
   allowCancellation: Boolean
   orderId: String
   orderGroup: String
-  state: String
+  status: String
   value: Float
   salesChannel: String
   creationDate: String

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -2,6 +2,7 @@ type Order {
   allowCancellation: Boolean
   orderId: String
   orderGroup: String
+  state: String
   status: String
   statusDescription: String
   value: Float
@@ -116,4 +117,3 @@ type OrderItemShippingDataAddress {
   complement: String
   reference: String
 }
-

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -3,6 +3,7 @@ type Order {
   orderId: String
   orderGroup: String
   status: String
+  statusDescription: String
   value: Float
   salesChannel: String
   creationDate: String


### PR DESCRIPTION
#### What problem is this solving?
When a user wants to retrieve the last order of a user, the name of the field containing the state of the order is status. This contribution also adds the field `statusDescription` as well

<!--- What is the motivation and context for this change? -->
A customer in Spain wanted to use the `userLastOrder` query, but it was not retrieving the `status` field correctly.

#### How should this be manually tested?

[test](https://devdocs--demostore.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
I was confused about the decision if it is better to have one `state` variable that is smart to check if it has `status` or `state` as response. What do you think about it?