### PR TITLE
Deprecate mutation logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Deprecate mutation `logout`.
 
 ## [2.120.1] - 2020-04-09
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -789,7 +789,11 @@ type Mutation {
   """
   Invalidate VtexIdclientAutCookie
   """
-  logout: Boolean @cacheControl(scope: PRIVATE)
+  logout: Boolean
+    @cacheControl(scope: PRIVATE)
+    @deprecated(
+      reason: "See https://github.com/vtex-apps/store-graphql/issues/182"
+    )
 
   """
   Impersonate a customer


### PR DESCRIPTION
Related https://github.com/vtex-apps/store-graphql/issues/182

#### What problem is this solving?

Deprecate logout mutation. 

The VTEX ID team recommended against having this mutation ([see Slack thread](https://vtex.slack.com/archives/C90SGTR6U/p1586896034305000))

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.120.1/graphiql/v1?query=mutation%20%7B%0A%20%20logout%0A%7D

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [X] Updated/created tests (important for bug fixes).
- [X] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

