### PR TITLE
Add sellers attribute to OrderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Adds `sellers` to `orderForm` schema.
+- `sellers` to `orderForm` schema.
   
 ## [2.121.0] - 2020-04-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Adds `sellers` to `orderForm` schema.
+  
 ## [2.121.0] - 2020-04-27
 ### Added
 - Add `sort` field to `documents` query

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -18,11 +18,17 @@ type OrderForm {
   ignoreProfileData: Boolean
   totalizers: [Totalizer]
   clientProfileData: ClientProfile
+  sellers: [OrderFormSeller]
   shippingData: OrderFormShippingData
   storePreferencesData: StorePreferencesData
   itemMetadata: ItemMetadata
   checkedInPickupPointId: String
   pickupPointCheckedIn: PickupPoint
+}
+
+type OrderFormSeller {
+  id: String
+  name: String
 }
 
 type CustomData {


### PR DESCRIPTION
#### What problem is this solving?
Adds `sellers` attribute for the orderForm schema

#### How should this be manually tested?

[https://sellersattribute--codeby.myvtex.com/_v/private/vtex.store-graphql@2.120.2/graphiql/v1?operationName=orderForm](https://sellersattribute--codeby.myvtex.com/_v/private/vtex.store-graphql@2.120.2/graphiql/v1?operationName=orderForm)

Use the following query to retrieve the expected information:
```
query orderForm {
  orderForm {
    sellers {
      id
      name
    }
  }
}
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
