### PR TITLE
fix category http regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Update regex to remove vtexcommercestable in Category resolvers to remove if http as well.
 
 ## [2.122.0] - 2020-04-28
 ### Added

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -8,7 +8,7 @@ const lastSegment = compose<string, string[], string>(
 )
 
 function cleanUrl(url: string) {
-  return url.replace(/(https|http):\/\/[A-z0-9]+\.vtexcommercestable\.com\.br/, '')
+  return url.replace(/^.*(vtexcommercestable\.com\.br)/, '')
 }
 
 export const pathToCategoryHref = (path: string) => {

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -8,7 +8,7 @@ const lastSegment = compose<string, string[], string>(
 )
 
 function cleanUrl(url: string) {
-  return url.replace(/https:\/\/[A-z0-9]+\.vtexcommercestable\.com\.br/, '')
+  return url.replace(/(https|http):\/\/[A-z0-9]+\.vtexcommercestable\.com\.br/, '')
 }
 
 export const pathToCategoryHref = (path: string) => {


### PR DESCRIPTION
#### What problem is this solving?

Possibly due to an issue in catalog, category urls were being answered with http and were not being erased by the resolver.

#### How should this be manually tested?

https://adkjhsadks--minisomx.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
