### PR TITLE
Fix items with assembly options being added to the OrderForm and getting split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Assembly options with inputValues were being split when an item is added to the `orderForm`.
 
 ## [2.123.1] - 2020-05-12
 ### Changed

--- a/node/resolvers/checkout/attachmentsHelper.ts
+++ b/node/resolvers/checkout/attachmentsHelper.ts
@@ -69,6 +69,7 @@ const addAssemblyBody = (option: OptionRequestUnit) => {
   }
 
   if (option.inputValues) {
+    body.noSplitItem = true
     body.inputValues = Object.keys(option.inputValues)
       .reduce<Record<string, string>>((acc, key) => {
         // Transforming boolean values to string


### PR DESCRIPTION
#### What problem is this solving?

When we add more than one SKU to the cart it splits into two or more columns and the one who was split loses its attachment value. 

What is odd is when we just add one, go to the cart, and at the cart change the item quantity to more than two it works fine. That's why I believe it is something related to the action to add to the cart.

#### How should this be manually tested?

Add this item to the cart, with a quantity greater than 1, and the items 

[Workspace](https://oldminicartdebug--worldwidegolf.myvtex.com/titleist-pro-v1-enhanced-alignment-custom-golf-balls-600000755/p?skuId=6002994)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

This is related to this Slack thread: https://vtex.slack.com/archives/C9P4RMW6Q/p1589406757496000
