### PR TITLE
Avoid calling session if no cookie is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Get session request, add validation before making the request to retrieve the user's session.
 
 ## [2.123.3] - 2020-05-19
 ### Changed

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -4,7 +4,7 @@ import { SchemaDirectiveVisitor } from 'graphql-tools'
 import jwtDecode from 'jwt-decode'
 
 import { AuthenticationError, ResolverError } from '@vtex/api'
-import { queries as sessionQueries } from '../resolvers/session'
+import { getSession } from '../resolvers/session/service'
 import { SessionFields } from '../resolvers/session/sessionResolver'
 
 export class WithCurrentProfile extends SchemaDirectiveVisitor {
@@ -34,7 +34,7 @@ export class WithCurrentProfile extends SchemaDirectiveVisitor {
 function getCurrentProfileFromSession(
   context: Context
 ): Promise<CurrentProfile | null> {
-  return sessionQueries.getSession(null, null, context).then(currentSession => {
+  return getSession(context).then(currentSession => {
     const session = currentSession as SessionFields
 
     if (!session || !session.id) {
@@ -127,7 +127,7 @@ async function validatedProfile(
 function isValidCallcenterOperator(context: Context, email: string) {
   const {
     clients: { callCenterOperator, licenseManager },
-    vtex: { authToken }
+    vtex: { authToken },
   } = context
 
   return licenseManager

--- a/node/resolvers/session/index.ts
+++ b/node/resolvers/session/index.ts
@@ -1,11 +1,10 @@
 import { serialize } from 'cookie'
 import { identity } from 'ramda'
-import { sessionFields } from './sessionResolver'
+
 import { fieldResolvers as sessionPickupResolvers } from './sessionPickup'
 import { vtexIdCookies } from '../../utils/vtexId'
 import { setCheckoutCookies, syncWithStoreLocale } from '../checkout'
-
-const VTEX_SESSION = 'vtex_session'
+import { VTEX_SESSION, getSession } from './service'
 
 const IMPERSONATED_EMAIL = 'vtex-impersonated-customer-email'
 // maxAge of 1-day defined in vtex-impersonated-customer-email cookie
@@ -33,15 +32,7 @@ export const queries = {
    * @return Session
    */
   getSession: async (_: any, __: any, ctx: Context) => {
-    const {
-      clients: { customSession },
-      cookies,
-    } = ctx
-    const { sessionData } = await customSession.getSession(
-      cookies.get(VTEX_SESSION)!,
-      ['*']
-    )
-    return sessionFields(sessionData)
+    return getSession(ctx)
   },
 }
 

--- a/node/resolvers/session/service.ts
+++ b/node/resolvers/session/service.ts
@@ -1,0 +1,22 @@
+import { ResolverError } from '@vtex/api'
+import { sessionFields } from './sessionResolver'
+
+export const VTEX_SESSION = 'vtex_session'
+
+export async function getSession(context: Context) {
+  const {
+    clients: { customSession },
+    cookies,
+  } = context
+
+  const sessionCookie = cookies.get(VTEX_SESSION)
+
+  if (sessionCookie === undefined)
+    throw new ResolverError(
+      `Invalid request for session, the ${VTEX_SESSION} wasn't provided!`
+    )
+
+  const { sessionData } = await customSession.getSession(sessionCookie, ['*'])
+
+  return sessionFields(sessionData)
+}


### PR DESCRIPTION
#### What problem is this solving?

- Reduce number of errors on the session API:

- http://monitoring.vtex.com/api/pvt/evidence?app=session&hash=c0d0df45e40d6cd0f0800415064bf80d

#### How should this be manually tested?
- remove the `vtex_session` cookie and execute the query

![image](https://user-images.githubusercontent.com/3926634/85165800-c02a4900-b23c-11ea-9c2b-b69bd2e1754b.png)

[Workspace](https://felipe--recorrenciaqa.myvtex.com/_v/private/vtex.store-graphql@2.123.3/graphiql/v1?query=query%20%7B%0A%20%20getSession%20%7B%0A%20%20%20%20address%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->