### PR TITLE
CHK-104: Remove orderFormId parameter from checkout mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use value in cookie instead of parameter `orderFormId` in Checkout mutations.
+
+### Deprecated
+- Parameter `orderFormId` from Checkout-related mutations.
 
 ## [2.126.0] - 2020-07-09
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -551,7 +551,7 @@ type Mutation {
     """
     Id of orderForm you want to mutate
     """
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     """
     List of items you want to add and their properties
     """
@@ -566,11 +566,11 @@ type Mutation {
     utmiParams: OrderFormInputUTMIParams
   ): OrderForm @withSegment @withOrderFormId
   cancelOrder(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     reason: String
   ): Boolean @withOrderFormId
   updateItems(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     items: [OrderFormItemInput]
   ): OrderForm @withSegment @withOrderFormId @cacheControl(scope: PRIVATE)
 
@@ -671,39 +671,39 @@ type Mutation {
   Order Form
   """
   updateOrderFormProfile(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     fields: OrderFormProfileInput
   ): OrderForm @withOrderFormId
   updateOrderFormShipping(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     address: OrderFormAddressInput
   ): OrderForm @withOrderFormId
   updateOrderFormPayment(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     payments: [OrderFormPaymentInput]
   ): OrderForm @withOrderFormId
   updateOrderFormIgnoreProfile(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     ignoreProfileData: Boolean
   ): OrderForm @withOrderFormId
   addOrderFormPaymentToken(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     paymentToken: OrderFormPaymentTokenInput
   ): OrderForm @withOrderFormId
   setOrderFormCustomData(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     appId: String
     field: String
     value: String
   ): OrderForm @withOrderFormId
   addAssemblyOptions(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     itemId: String
     assemblyOptionsId: String
     options: [AssemblyOptionInput]
   ): OrderForm @withOrderFormId
   updateOrderFormCheckin(
-    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     checkin: OrderFormCheckinInput
   ): OrderForm @withOrderFormId @cacheControl(scope: PRIVATE)
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -551,7 +551,7 @@ type Mutation {
     """
     Id of orderForm you want to mutate
     """
-    orderFormId: String
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
     """
     List of items you want to add and their properties
     """
@@ -565,11 +565,14 @@ type Mutation {
     """
     utmiParams: OrderFormInputUTMIParams
   ): OrderForm @withSegment @withOrderFormId
-  cancelOrder(orderFormId: String, reason: String): Boolean @withOrderFormId
-  updateItems(orderFormId: String, items: [OrderFormItemInput]): OrderForm
-    @withSegment
-    @withOrderFormId
-    @cacheControl(scope: PRIVATE)
+  cancelOrder(
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    reason: String
+  ): Boolean @withOrderFormId
+  updateItems(
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
+    items: [OrderFormItemInput]
+  ): OrderForm @withSegment @withOrderFormId @cacheControl(scope: PRIVATE)
 
   """
   Used to update the CL entity on masterData.
@@ -668,39 +671,39 @@ type Mutation {
   Order Form
   """
   updateOrderFormProfile(
-    orderFormId: String
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
     fields: OrderFormProfileInput
   ): OrderForm @withOrderFormId
   updateOrderFormShipping(
-    orderFormId: String
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
     address: OrderFormAddressInput
   ): OrderForm @withOrderFormId
   updateOrderFormPayment(
-    orderFormId: String
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
     payments: [OrderFormPaymentInput]
   ): OrderForm @withOrderFormId
   updateOrderFormIgnoreProfile(
-    orderFormId: String
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
     ignoreProfileData: Boolean
   ): OrderForm @withOrderFormId
   addOrderFormPaymentToken(
-    orderFormId: String
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
     paymentToken: OrderFormPaymentTokenInput
   ): OrderForm @withOrderFormId
   setOrderFormCustomData(
-    orderFormId: String
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
     appId: String
     field: String
     value: String
   ): OrderForm @withOrderFormId
   addAssemblyOptions(
-    orderFormId: String
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
     itemId: String
     assemblyOptionsId: String
     options: [AssemblyOptionInput]
   ): OrderForm @withOrderFormId
   updateOrderFormCheckin(
-    orderFormId: String
+    orderFormId: String @deprecated(reason: "Use the checkout cookie instead")
     checkin: OrderFormCheckinInput
   ): OrderForm @withOrderFormId @cacheControl(scope: PRIVATE)
 

--- a/node/__tests__/checkout/index.test.ts
+++ b/node/__tests__/checkout/index.test.ts
@@ -149,7 +149,7 @@ it.each<any>([
   }
 )
 
-it.each([
+it.each<any>([
   [undefined, undefined],
   [{}, {}],
 ])(

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -1,3 +1,4 @@
+import { UserInputError } from '@vtex/api'
 import { compose, forEach, reject, path } from 'ramda'
 
 import { headers, withAuthToken } from '../headers'
@@ -17,7 +18,7 @@ import paymentTokenResolver from './paymentTokenResolver'
 import { fieldResolvers as shippingFieldResolvers } from './shipping'
 
 import { CHECKOUT_COOKIE, parseCookie } from '../../utils'
-import { UserInputError } from '@vtex/api'
+
 import { LogisticPickupPoint } from '../logistics/types'
 import logisticPickupResolvers from '../logistics/fieldResolvers'
 
@@ -325,16 +326,21 @@ interface UTMIParams {
 }
 
 export const mutations: Record<string, Resolver> = {
-  addItem: async (_, { orderFormId, items, utmParams, utmiParams }: AddItemArgs, ctx: Context) => {
+  addItem: async (_, { orderFormId: paramsOrderFormId, items, utmParams, utmiParams }: AddItemArgs, ctx: Context) => {
     const {
       clients: { checkout },
+      vtex
     } = ctx
-    if (orderFormId == null || items == null) {
-      throw new UserInputError('No order form id or items to add provided')
+    const orderFormId = vtex.orderFormId
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
+    if (items == null) {
+      throw new UserInputError('No items to add provided')
     }
 
-    if (ctx.vtex.orderFormId !== orderFormId) {
-      ctx.vtex.logger.warn(`Different orderFormId found: provided=${orderFormId} and in cookies=${ctx.vtex.orderFormId}`)
+    if (orderFormId !== paramsOrderFormId) {
+      ctx.vtex.logger.warn(`Different orderFormId found: provided=${paramsOrderFormId} and in cookies=${orderFormId}`)
     }
 
     const { marketingData, items: previousItems } = await checkout.orderForm()
@@ -425,47 +431,67 @@ export const mutations: Record<string, Resolver> = {
 
   setOrderFormCustomData: (
     _,
-    { orderFormId, appId, field, value },
-    { clients: { checkout } }
+    { appId, field, value },
+    { clients: { checkout }, vtex: { orderFormId } }
   ) => {
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
     return checkout.setOrderFormCustomData(orderFormId, appId, field, value)
   },
 
-  updateItems: (_, { orderFormId, items }, { clients: { checkout }, vtex }) => {
-    if (vtex.orderFormId !== orderFormId) {
-      vtex.logger.warn(`Different orderFormId found: provided=${orderFormId} and in cookies=${vtex.orderFormId}`)
+  updateItems: (_, { orderFormId: paramsOrderFormId, items }, { clients: { checkout }, vtex }) => {
+    const orderFormId = vtex.orderFormId
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
+    if (orderFormId !== paramsOrderFormId) {
+      vtex.logger.warn(`Different orderFormId found: provided=${paramsOrderFormId} and in cookies=${vtex.orderFormId}`)
     }
     return checkout.updateItems(orderFormId, items)
   },
 
   updateOrderFormIgnoreProfile: (
     _,
-    { orderFormId, ignoreProfileData },
-    { clients: { checkout } }
+    { ignoreProfileData },
+    { clients: { checkout }, vtex: { orderFormId } }
   ) => {
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
     return checkout.updateOrderFormIgnoreProfile(orderFormId, ignoreProfileData)
   },
 
   updateOrderFormPayment: (
     _,
-    { orderFormId, payments },
-    { clients: { checkout } }
+    { payments },
+    { clients: { checkout }, vtex: { orderFormId } }
   ) => {
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
     return checkout.updateOrderFormPayment(orderFormId, payments)
   },
 
   updateOrderFormProfile: (
     _,
-    { orderFormId, fields },
-    { clients: { checkout } }
+    { fields },
+    { clients: { checkout }, vtex: { orderFormId } }
   ) => {
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
     return checkout.updateOrderFormProfile(orderFormId, fields)
   },
 
-  updateOrderFormShipping: async (_, { orderFormId, address }, ctx) => {
+  updateOrderFormShipping: async (_, { address }, ctx) => {
     const {
       clients: { checkout },
+      vtex: { orderFormId }
     } = ctx
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
     return checkout.updateOrderFormShipping(orderFormId, {
       clearAddressIfPostalCodeNotFound: false,
       selectedAddresses: [address],
@@ -474,9 +500,12 @@ export const mutations: Record<string, Resolver> = {
 
   addAssemblyOptions: (
     _,
-    { orderFormId, itemId, assemblyOptionsId, options },
-    { clients: { checkout } }
+    { itemId, assemblyOptionsId, options },
+    { clients: { checkout }, vtex: { orderFormId } }
   ) => {
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
     const body = {
       composition: {
         items: options,
@@ -493,9 +522,12 @@ export const mutations: Record<string, Resolver> = {
 
   updateOrderFormCheckin: (
     _,
-    { orderFormId, checkin }: any,
-    { clients: { checkout } }
+    { checkin }: any,
+    { clients: { checkout }, vtex: { orderFormId } }
   ) => {
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
     return checkout.updateOrderFormCheckin(orderFormId, checkin)
   },
 }


### PR DESCRIPTION
#### What problem is this solving?

Currently, there is two ways to provide the orderFormId which an mutation related to the cart will operate on. The first is the `orderFormId` parameter which exists in all of these mutations, and the other is to provide a `checkout.vtex.com` cookie with the format `__ofid=XXX` (where `XXX` is the actual order form ID).

This inconsistency can cause (and has caused) some issues where you would supply both the cookie and the parameter to the mutation but those two values weren't the same. With this, we would be operating (e.g. adding a product) to a different cart than what the user is seeing on the store. Also, when they effectively go to checkout, the order form they'll see is the one which the value in the cookie references, not whatever the minicart provides in the mutation argument, causing the issue where you'd add a product to cart, go to checkout, and see an empty cart page.

#### How should this be manually tested?

[Workspace](https://minicart1--storecomponents.myvtex.com/).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->