### PR TITLE
Feature/add account field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `account` field on `documents` query. 
 
 ## [2.123.4] - 2020-06-22
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -369,6 +369,10 @@ type Query {
     Defines the Master Data schema to be used
     """
     schema: String
+    """
+    Defines which account will be required
+    """
+    account: String
   ): [Document]
 
   """

--- a/node/clients/masterdata.ts
+++ b/node/clients/masterdata.ts
@@ -82,7 +82,7 @@ export class MasterData extends ExternalClient {
         _where: where,
         _sort: sort,
         ...(schema ? { _schema: schema } : null),
-        ...(account ? {an: account } : null ),
+        ...(account ? { an: account } : null),
       },
     })
   }

--- a/node/clients/masterdata.ts
+++ b/node/clients/masterdata.ts
@@ -71,7 +71,8 @@ export class MasterData extends ExternalClient {
     where: string,
     pagination: PaginationArgs,
     schema?: string,
-    sort?: string
+    sort?: string,
+    account?: string
   ) => {
     return this.get<T[]>(this.routes.search(acronym), {
       headers: paginationArgsToHeaders(pagination),
@@ -81,6 +82,7 @@ export class MasterData extends ExternalClient {
         _where: where,
         _sort: sort,
         ...(schema ? { _schema: schema } : null),
+        ...(account ? {an: account } : null ),
       },
     })
   }

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -142,6 +142,7 @@ declare global {
     where: string
     sort: string
     schema?: string
+    account?: string
   }
 
   interface CreateDocumentArgs {

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -6,7 +6,16 @@ import { resolvers as documentSchemaResolvers } from './documentSchema'
 
 export const queries = {
   documents: async (_: any, args: DocumentsArgs, context: Context) => {
-    const { acronym, fields, page, pageSize, where, schema, sort, account } = args
+    const {
+      acronym,
+      fields,
+      page,
+      pageSize,
+      where,
+      schema,
+      sort,
+      account,
+    } = args
     const {
       clients: { masterdata },
     } = context

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -6,7 +6,7 @@ import { resolvers as documentSchemaResolvers } from './documentSchema'
 
 export const queries = {
   documents: async (_: any, args: DocumentsArgs, context: Context) => {
-    const { acronym, fields, page, pageSize, where, schema, sort } = args
+    const { acronym, fields, page, pageSize, where, schema, sort, account } = args
     const {
       clients: { masterdata },
     } = context
@@ -20,7 +20,8 @@ export const queries = {
         pageSize,
       },
       schema,
-      sort
+      sort,
+      account
     )) as any
     return map((document: any) => ({
       cacheId: document.id,


### PR DESCRIPTION
#### What problem is this solving?

Allow us to choose which account in a multi-account environment will be used during the query `documents`

#### How should this be manually tested?
Query:
```
query documents($acronym: String, $fields: [String], $page: Int = 1, $pageSize: Int = 15, $where: String, $sort: String, $schema: String, $account: String){
  documents(acronym: $acronym, fields: $fields, page: $page, pageSize: $pageSize, where: $where, sort: $sort, schema: $schema, account: $account){
    cacheId
    id
    fields{
      key
      value
    }
  }
}
```
Variables:
```
{
  "acronym": "AR",
  "fields": ["franchiseAccount", "postalCodeBegin", "postalCodeEnd"],
  "account": "carrefourbr"
}
```
https://ecom1649--carrefourbrfood.myvtex.com/admin/graphql-ide

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
https://nimb.ws/M6HO2a
#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
