### PR TITLE
Add field spotPrice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Field `spotPrice` to Product type.
 
 ## [2.123.4] - 2020-06-22
 ### Fixed

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -168,6 +168,7 @@ type Offer {
   Installments (criteria: InstallmentsCriteria = ALL, rates: Boolean = true): [Installment]
   Price: Float
   ListPrice: Float
+  spotPrice: Float
   PriceWithoutDiscount: Float
   RewardValue: Float
   PriceValidUntil: String

--- a/node/resolvers/catalog/offer.ts
+++ b/node/resolvers/catalog/offer.ts
@@ -35,5 +35,12 @@ export const resolvers = {
     teasers: propOr([], 'Teasers'),
     giftSkuIds: propOr([], 'GiftSkuIds'),
     discountHighlights: propOr([], 'DiscountHighLight'),
+    spotPrice: (offer: Seller["commertialOffer"]) => {
+      const sellingPrice = offer.Price
+      const spotPrice: number | undefined = offer.Installments.find(({ NumberOfInstallments, Value }) => {
+        return (NumberOfInstallments === 1 && Value < sellingPrice)
+      })?.Value;
+      return spotPrice || sellingPrice
+    }
   },
 }


### PR DESCRIPTION
#### What problem is this solving?

Add spotPrice as it was done in:
https://github.com/vtex-apps/search-graphql/pull/70
https://github.com/vtex-apps/search-graphql/pull/72

(I copied from the code in master, not from the PRs)

We need this feature in store-graphql because stores in vtex.store@1.x use store-graphql instead of search-graphql.

Related to PR https://github.com/vtex-apps/store/pull/470

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.123.4/graphiql/v1?operationName=Product&variables=%7B%0A%20%20%22slug%22%3A%20%22classic-shoes%22%0A%7D

![image](https://user-images.githubusercontent.com/284515/86388290-e8696d00-bc6a-11ea-85cf-ac15df236dd7.png)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
