### PR TITLE
Add field `CustomData` in Order Graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add field `CustomData` in Order Graphql.
 
 ## [2.123.4] - 2020-06-22
 ### Fixed

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -1,14 +1,3 @@
-scalar CustomFields
-
-type CustomData {
-  customApps: [CustomApp]
-}
-type CustomApp {
-  fields: CustomFields
-  id: String
-  major: Int
-}
-
 type Order {
   allowCancellation: Boolean
   orderId: String

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -1,3 +1,14 @@
+scalar CustomFields
+
+type CustomData {
+  customApps: [CustomApp]
+}
+type CustomApp {
+  fields: CustomFields
+  id: String
+  major: Int
+}
+
 type Order {
   allowCancellation: Boolean
   orderId: String
@@ -8,6 +19,7 @@ type Order {
   value: Float
   salesChannel: String
   creationDate: String
+  customData: CustomData
   lastChange: String
   timeZoneCreationDate: String
   timeZoneLastChange: String
@@ -72,9 +84,9 @@ type OrderItemPaymentData {
 }
 
 type OrderItemTransactions {
-  isActive: Boolean,
-  merchantName: String,
-  payments: [OrderItemPayment],
+  isActive: Boolean
+  merchantName: String
+  payments: [OrderItemPayment]
   transactionId: String
 }
 
@@ -94,7 +106,9 @@ type OrderItemPaymentConnectorResponse {
   tid: String
   returnCode: String
   message: String
-  """Payment Connector Additional Data Response"""
+  """
+  Payment Connector Additional Data Response
+  """
   additionalData: ConnectorAdditionalData
 }
 


### PR DESCRIPTION
#### What problem is this solving?
Have access to the custom data information on order graphql 

#### How should this be manually tested?

[Graphql](https://liquid--destdiscount.myvtex.com/_v/private/vtex.store-graphql@2.123.4/graphiql/v1?operationName=order&query=query%20order(%24id%3A%20String!)%20%7B%0A%09order(id%3A%20%24id)%20%7B%0A%20%20%20%20allowCancellation%20%0A%20%20%20%20salesChannel%0A%20%20%20%20customData%20%7B%0A%20%20%20%20%20%20customApps%20%7B%0A%20%20%20%20%20%20%20%20fields%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%09%7D%0A%7D%0A&variables=%7B%0A%09%22id%22%3A%20%221041891542562-01%22%0A%7D%0A)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
