### PR TITLE
LogisticItem type on shipping query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `LogisticItem` type on `shipping` query
+
 ## [2.126.1] - 2020-07-14
 ### Changed
 - Use value in cookie instead of parameter `orderFormId` in Checkout mutations.

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -46,6 +46,7 @@ type LogisticsItem {
   requestIndex: Int
   quantity: Int
   seller: String
+  sellerChain: [String]
   tax: Int
   priceValidUntil: String
   price: Int

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -1,4 +1,5 @@
 type ShippingData {
+  items: [LogisticsItem]
   logisticsInfo: [LogisticsInfo]
   messages: [MessageInfo]
 }
@@ -38,6 +39,22 @@ type DeliveryIds {
   dockId: String
   courierName: String
   quantity: Int
+}
+
+type LogisticsItem {
+  id: String
+  requestIndex: Int
+  quantity: Int
+  seller: String
+  tax: Int
+  priceValidUntil: String
+  price: Int
+  listPrice: Int
+  rewardValue: Int
+  sellingPrice: Int
+  measurementUnit: String
+  unitMultiplier: Int
+  availability: String
 }
 
 input ShippingItem {


### PR DESCRIPTION
#### What problem is this solving?
In one of our customizations we have a simulation to a lot of sellers and we have to ordenated each ones and send to each components the respectives logisticItems, and the only way to do that is identificate each logisticItem with its logisticInfo.

#### How should this be manually tested?
https://gus--carrefourbrqa.myvtex.com/admin/graphql-ide

variables:
```json
{
  "shippingItems": [
    { "id": "310118535", "quantity": "1", "seller": "5993" },
    { "id": "310118535", "quantity": "1", "seller": "4642" }
  ],
  "country": "BRA",
  "postalCode": "12942-210"
}
```
query:
```graphql
query SIMULATE_SHIPPING($shippingItems: [ShippingItem], $postalCode: String, $country: String) {
	shipping(items: $shippingItems, postalCode: $postalCode, country: $country) {
		items {
			seller
		}
		logisticsInfo {
			itemIndex
			slas {
				id
				name
				price
				shippingEstimate
				shippingEstimateDate
				friendlyName
			}
		}
	}
}
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
