### PR TITLE
Translates correctly categories result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Translate correctly categories result
 
 ## [2.131.1] - 2020-09-14
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.131.1",
+  "version": "2.131.2-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -1,6 +1,7 @@
 import { compose, last, prop, split } from 'ramda'
 
 import { getCategoryInfo } from './utils'
+import { formatTranslatableProp } from '../../utils/i18n'
 
 const lastSegment = compose<string, string[], string>(
   last,
@@ -30,6 +31,11 @@ interface SafeCategory
 
 export const resolvers = {
   Category: {
+    name: formatTranslatableProp<SafeCategory, 'name', 'id'>(
+      'name',
+      'id'
+    ),
+
     cacheId: prop('id'),
 
     href: async (
@@ -48,9 +54,15 @@ export const resolvers = {
       return pathToCategoryHref(path)
     },
 
-    metaTagDescription: prop('MetaTagDescription'),
+    metaTagDescription: formatTranslatableProp<SafeCategory, 'MetaTagDescription', 'id'>(
+      'MetaTagDescription',
+      'id'
+    ),
 
-    titleTag: prop('Title'),
+    titleTag: formatTranslatableProp<SafeCategory, 'Title', 'id'>(
+      'Title',
+      'id'
+    ),
 
     slug: async (
       { id, url }: SafeCategory,

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -12,15 +12,6 @@ export const formatTranslatableProp = <R, P extends keyof R, I extends keyof R>(
     ctx
   )
 
-interface BaseMessage {
-  content: string
-  from?: string
-}
-
-export interface Message extends BaseMessage {
-  context?: string
-}
-
 export const addContextToTranslatableString = (message: Message, ctx: Context) => {
   const { vtex: { tenant } } = ctx
   const { locale } = tenant!

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -12,6 +12,15 @@ export const formatTranslatableProp = <R, P extends keyof R, I extends keyof R>(
     ctx
   )
 
+interface BaseMessage {
+  content: string
+  from?: string
+}
+
+export interface Message extends BaseMessage {
+  context?: string
+}
+
 export const addContextToTranslatableString = (message: Message, ctx: Context) => {
   const { vtex: { tenant } } = ctx
   const { locale } = tenant!

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -1,0 +1,42 @@
+import {
+  formatTranslatableStringV2,
+  parseTranslatableStringV2,
+} from '@vtex/api'
+
+export const formatTranslatableProp = <R, P extends keyof R, I extends keyof R>(prop: P, idProp: I) =>
+  (root: R, _: unknown, ctx: Context) => addContextToTranslatableString(
+    {
+      content: root[prop] as unknown as string,
+      context: root[idProp] as unknown as string
+    },
+    ctx
+  )
+
+interface BaseMessage {
+  content: string
+  from?: string
+}
+
+export interface Message extends BaseMessage {
+  context?: string
+}
+
+export const addContextToTranslatableString = (message: Message, ctx: Context) => {
+  const { vtex: { tenant } } = ctx
+  const { locale } = tenant!
+
+  if (!message.content) {
+    return message.content
+  }
+
+  const {
+    content,
+    context: originalContext,
+    from: originalFrom
+  } = parseTranslatableStringV2(message.content)
+
+  const context = (originalContext || message.context)?.toString()
+  const from = originalFrom || message.from || locale
+
+  return formatTranslatableStringV2({ content, context, from })
+}


### PR DESCRIPTION
#### What problem is this solving?

Currently any translatable prop is not returning with the correct formatting, causing some data to not be translated. This PR fixes it for the categories, since it is used by the app `vtex.category-menu` and causing issues for cross-border stores.

#### How should this be manually tested?

This can be tested by making any category request in a different binding. An easy way is going to this page in this workspace:

https://fox--powerplanet.myvtex.com/smartphones-e-acessorios?__bindingAddress=b2c.powerplanet.com/pt

and check if the category menu is translated
#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
