### PR TITLE
Feature/account field query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `account` field on `document` query. 
 
 ## [2.131.2] - 2020-09-15
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -398,7 +398,7 @@ type Query {
     """
     id: String
     """
-    Defines which account will be required
+    Defines in wich account the request will be made
     """
     account: String
   ): Document

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -398,7 +398,7 @@ type Query {
     """
     id: String
     """
-    Defines in wich account the request will be made
+    Defines in which account the request will be made
     """
     account: String
   ): Document

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -397,6 +397,10 @@ type Query {
     Document id
     """
     id: String
+    """
+    Defines which account will be required
+    """
+    account: String
   ): Document
 
   """
@@ -889,6 +893,6 @@ type Mutation {
   """
   Set new orderForm.
   """
-  
+
   newOrderForm(orderFormId: String): OrderForm @cacheControl(scope: PRIVATE) @withOrderFormId
 }

--- a/node/clients/masterdata.ts
+++ b/node/clients/masterdata.ts
@@ -36,11 +36,12 @@ export class MasterData extends ExternalClient {
       metric: 'masterdata-getPublicSchema',
     })
 
-  public getDocument = <T>(acronym: string, id: string, fields: string[]) =>
+  public getDocument = <T>(acronym: string, id: string, fields: string[], account?: string) =>
     this.get<T>(this.routes.document(acronym, id), {
       metric: 'masterdata-getDocument',
       params: {
         _fields: generateFieldsArg(fields),
+        ...(account ? { an: account } : null),
       },
     })
 

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -127,6 +127,7 @@ declare global {
     acronym: string
     fields: string[]
     id: string
+    account?: string
   }
 
   interface DocumentSchemaArgs {

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -40,15 +40,16 @@ export const queries = {
   },
 
   document: async (_: any, args: DocumentArgs, context: Context) => {
-    const { acronym, fields, id } = args
+    const { acronym, fields, id, account } = args
     const {
       clients: { masterdata },
     } = context
-    const data = await masterdata.getDocument(acronym, id, fields)
+    const data = await masterdata.getDocument(acronym, id, fields, account)
     return {
       cacheId: id,
       id,
       fields: mapKeyAndStringifiedValues(data),
+      account,
     }
   },
 

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -49,7 +49,6 @@ export const queries = {
       cacheId: id,
       id,
       fields: mapKeyAndStringifiedValues(data),
-      account,
     }
   },
 


### PR DESCRIPTION
#### What problem is this solving?

The inability to choose which account in a multi-account environment will be used when calling the query document

#### How should this be manually tested?

Using the query:
```graphql
query GET_DOCUMENT($acronym: String, $fields: [String], $id: String, $account: String) {
  document(acronym: $acronym, fields: $fields, id: $id, account: $account) {
    fields {
      key
      value
    }
  }
}

```
Sample variables:
```json
{
  "acronym": "CL",
  "fields": ["isWhatsAppOptIn", "isSmsOptIn", "isNewsletterOptIn"],
  "id": "1c96f18d-b4ab-11ea-8343-1220c723d087",
  "account": "carrefourbrqa"
}
```

[Workspace](https://ecom6918--carrefourbr.myvtex.com/_v/private/vtex.store-graphql@2.131.2/graphiql/v1)

#### Test-proof

Acessing account "carrefourbrqa" masterdata when logged on "carrefourbr"
![image](https://user-images.githubusercontent.com/51974587/93389076-0a25c980-f842-11ea-93b0-5d52cae2e9e2.png)



#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
