### PR TITLE
Translates categories slug and href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Translated `slug` and `href` fields from the Category type
 
 ## [2.133.0] - 2020-09-21
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.133.0",
+  "version": "2.133.1-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "vtex.messages": "1.x",
+    "vtex.rewriter": "1.x",
     "vtex.catalog-api-proxy": "0.x",
     "vtex.file-manager": "0.x"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -151,6 +151,9 @@
         "host": "portal.vtexcommercestable.com.br",
         "path": "/api/profile-system/*"
       }
+    },
+    {
+      "name": "vtex.rewriter:resolve-graphql"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -49,7 +49,7 @@ interface CatalogPageTypeResponse {
 export class Catalog extends AppClient {
   private basePath: string
   public constructor(ctx: IOContext, opts?: InstanceOptions) {
-    super('vtex.catalog-api-proxy', ctx, opts)
+    super('vtex.catalog-api-proxy@0.x', ctx, opts)
     this.basePath = ctx.sessionToken ? '/proxy/authenticated/catalog' : '/proxy/catalog'
   }
 

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -9,6 +9,7 @@ import { OMS } from './oms'
 import { Portal } from './portal'
 import { LogisticsClient } from './logistics'
 import { Session } from './session'
+import { Rewriter } from './rewriter'
 
 export class Clients extends IOClients {
   public get masterdata() {
@@ -45,5 +46,9 @@ export class Clients extends IOClients {
 
   public get customSession() {
     return this.getOrSet('customSession', Session)
+  }
+
+  public get rewriter() {
+    return this.getOrSet('rewriter', Rewriter)
   }
 }

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -31,8 +31,8 @@ class CustomGraphQLError extends Error {
 }
 export function throwOnGraphQLErrors<T extends Serializable>(message: string) {
   return function maybeGraphQLResponse(response: GraphQLResponse<T>) {
-    if (response && response.errors && response.errors.length > 0) {
-      throw new CustomGraphQLError(message, response.errors)
+    if (response?.errors?.length || 0 > 0) {
+      throw new CustomGraphQLError(message, response.errors!)
     }
 
     return response

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -1,0 +1,68 @@
+import { AppGraphQLClient, IOContext, InstanceOptions, GraphQLResponse, Serializable } from "@vtex/api"
+
+const getRouteQuery = `query GetRoute($id: String!, $type: String!) {
+  internal {
+    routes(locator: {id:$id, type:$type}) {
+      route
+      binding
+    }
+  }
+}
+`
+
+interface Route {
+  route: string
+  binding: string
+}
+
+interface GetRoutesResponse {
+  internal: {
+    routes: Route[]
+  }
+}
+
+class CustomGraphQLError extends Error {
+  public graphQLErrors: any
+
+  public constructor(message: string, graphQLErrors: any[]) {
+    super(message)
+    this.graphQLErrors = graphQLErrors
+  }
+}
+export function throwOnGraphQLErrors<T extends Serializable>(message: string) {
+  return function maybeGraphQLResponse(response: GraphQLResponse<T>) {
+    if (response && response.errors && response.errors.length > 0) {
+      throw new CustomGraphQLError(message, response.errors)
+    }
+
+    return response
+  }
+}
+
+export class Rewriter extends AppGraphQLClient {
+  public constructor(context: IOContext, options?: InstanceOptions) {
+    super('vtex.rewriter@1.x', context, {
+      ...options,
+      headers: {
+        ...options?.headers,
+      }
+    })
+  }
+
+  public getRoute = async (id: string, type: string, bindingId: string) => {
+    const data = await this.graphql.query<GetRoutesResponse, { id: string, type: string }>({
+      query: getRouteQuery,
+      variables: { id, type },
+    },
+      {
+        metric: 'search-get-route'
+      }
+    )
+      .then(throwOnGraphQLErrors('Error getting route data from vtex.rewriter'))
+      .then(data => {
+        return data.data!.internal.routes
+      })
+
+    return data.find(route => route.binding === bindingId)?.route
+  }
+}

--- a/node/package.json
+++ b/node/package.json
@@ -35,7 +35,7 @@
     "@types/ramda": "0.26.39",
     "@types/unorm": "^1.3.27",
     "@types/url-parse": "^1.4.3",
-    "@vtex/api": "^3.57.1",
+    "@vtex/api": "^3.0.0",
     "@vtex/test-tools": "2.1.1",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -60,6 +60,8 @@ export const resolvers = {
         url = category.url
       }
       const path = cleanUrl(url)
+      // Won't translate href if current locale is the same as the default locale
+      // or account isn't in the tenant system, or binding data isn't present
       return tenant && binding && binding.id && tenant.locale !== binding.locale
         ? await rewriter.getRoute(id.toString(), getTypeForCategory(path), binding.id) || url
         : path
@@ -84,6 +86,8 @@ export const resolvers = {
         const category = await getCategoryInfo(catalog, id, 4)
         url = category.url
       }
+      // Won't translate slug if current locale is the same as the default locale
+      // or account isn't in the tenant system, or binding data isn't present
       if (!tenant || !binding || tenant?.locale === binding?.locale || !binding.id ) {
         return catalogSlugify(name).toLowerCase()
       }

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -16,7 +16,7 @@ const getTypeForCategory = (url: string) => {
 }
 
 const lastSegment = (route: string) => {
-  const splittedSegments = route.includes('/') ? route.split('/') : route
+  const splittedSegments = route.split('/')
   return splittedSegments[splittedSegments.length - 1]
 }
 

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -1,12 +1,25 @@
-import { compose, last, prop, split } from 'ramda'
+import { prop } from 'ramda'
 
 import { getCategoryInfo } from './utils'
 import { formatTranslatableProp } from '../../utils/i18n'
+import { catalogSlugify } from './slug'
 
-const lastSegment = compose<string, string[], string>(
-  last,
-  split('/')
-)
+const getTypeForCategory = (url: string) => {
+  const correctUrl = url.startsWith('/') ? url : `/${url}`
+  switch (correctUrl.split('/').length) {
+    case 2:
+      return 'department'
+    case 3:
+      return 'category'
+    default:
+      return 'subcategory'
+  }
+}
+
+const lastSegment = (route: string) => {
+  const splittedSegments = route.includes('/') ? route.split('/') : route
+  return splittedSegments[splittedSegments.length - 1]
+}
 
 function cleanUrl(url: string) {
   return url.replace(/^.*(vtexcommercestable\.com\.br)/, '')
@@ -65,15 +78,19 @@ export const resolvers = {
     ),
 
     slug: async (
-      { id, url }: SafeCategory,
+      { name, id, url }: SafeCategory,
       _: any,
-      { clients: { catalog } }: Context
+      { vtex: { tenant, binding }, clients: { catalog, rewriter } }: Context
     ) => {
       if (url == null) {
         const category = await getCategoryInfo(catalog, id, 4)
         url = category.url
       }
-      return url ? lastSegment(url) : null
+      if (!tenant || !binding || tenant?.locale === binding?.locale || !binding.id ) {
+        return catalogSlugify(name).toLowerCase()
+      }
+      const translatedRoute = await rewriter.getRoute(id.toString(), getTypeForCategory(url), binding.id) || url
+      return lastSegment(translatedRoute)
     },
 
     children: async (

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -5,7 +5,7 @@ import { formatTranslatableProp } from '../../utils/i18n'
 import { catalogSlugify } from './slug'
 
 const getTypeForCategory = (url: string) => {
-  const correctUrl = url.startsWith('/') ? url : `/${url}`
+  const correctUrl = url.split('.com.br')[1]
   switch (correctUrl.split('/').length) {
     case 2:
       return 'department'

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1663,10 +1663,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@^3.57.1":
-  version "3.57.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.57.1.tgz#30dfbe5f6095c1940e393c60b10a26fdb5469c3f"
-  integrity sha512-DXL/+bSCUkMA5aCojIL+BqGZiN/VHSKtKHxmpi354k+WQdXvi+73+K6RNz1xJeX1Cj8zGS7y9Y/n84aEly1t2w==
+"@vtex/api@^3.0.0":
+  version "3.75.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.75.1.tgz#9a5fb639b2b572f751f43b8d35917650c2b5b71b"
+  integrity sha512-swUApBdr/nQpu189DDMq8Gbv/ibxhrx9eS1msddtn7YKO+QWNJjw1TFmbmSw26xH3ba47RZnLC4zzPP9hlwIDA==
   dependencies:
     "@types/koa" "^2.0.48"
     "@types/koa-compose" "^3.2.3"
@@ -1700,6 +1700,7 @@
     semver "^5.5.1"
     stats-lite vtex/node-stats-lite#dist
     tar-fs "^2.0.0"
+    xss "^1.0.6"
 
 "@vtex/test-tools@2.1.1":
   version "2.1.1"
@@ -2654,6 +2655,11 @@ commander@^2.11.0, commander@~2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+commander@^2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -2766,6 +2772,11 @@ css@^2.2.3:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.8"
@@ -6105,7 +6116,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -6771,6 +6782,14 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xss@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.8.tgz#32feb87feb74b3dcd3d404b7a68ababf10700535"
+  integrity sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 y18n@^4.0.0:
   version "4.0.0"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6116,7 +6116,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Currently the slug and href fields from the Category type were not being translated according to the user's binding this caused a problem in the category menu component where the text of the menu item was translated but when clicked it sent the user to the page in the default language.

#### How should this be manually tested?

You can test the category menu component  that uses the categories query:
https://fox--powerplanet.myvtex.com/toys---hobbies?__bindingAddress=b2c.powerplanet.com/fr

All menu items should send you to the translated url

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
