### PR TITLE
Add Attachments, AttachmentType and Attachment Content in type OrderFormItem 

### DIFF
--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -115,6 +115,12 @@ type OrderFormItem {
   """
   unitMultiplier: Float
   canHaveAttachment: Boolean
+  attachments: [AttachmentItem]
+}
+scalar AttachmentContent
+type AttachmentItem {
+  name: String
+  content: AttachmentContent
 }
 
 type ItemAdditionalInfo {


### PR DESCRIPTION
#### What problem is this solving?
This addition resolves the issue of using the attachments for each orderform item

#### How should this be manually tested?
Can be tested when using the orderForm query in the GraphQL IDE, for example, where item attachments will be returned

https://prattach--benscycle.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->


This pull request is also related to another pull request in the app 'store-resources', which will make use of this new type in orderForm:
https://github.com/vtex-apps/store-resources/pull/137