### PR TITLE
Add 'name' argument to 'subscribeNewsletter' mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `name` argument to `subscribeNewsletter` mutation.
 
 ## [2.133.0] - 2020-09-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `name` argument to `subscribeNewsletter` mutation.
+- `fields` argument to `subscribeNewsletter` mutation.
 
 ## [2.133.0] - 2020-09-21
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -676,7 +676,7 @@ type Mutation {
   """
   Subscribe to newsletter
   """
-  subscribeNewsletter(email: String, isNewsletterOptIn: Boolean, name: String): Boolean
+  subscribeNewsletter(email: String, isNewsletterOptIn: Boolean, fields: NewsletterFieldsInput): Boolean
     @cacheControl(scope: PRIVATE)
 
   """

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -676,7 +676,7 @@ type Mutation {
   """
   Subscribe to newsletter
   """
-  subscribeNewsletter(email: String, isNewsletterOptIn: Boolean): Boolean
+  subscribeNewsletter(email: String, isNewsletterOptIn: Boolean, name: String): Boolean
     @cacheControl(scope: PRIVATE)
 
   """

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -111,6 +111,11 @@ type ProfileCustomField {
   value: String
 }
 
+input NewsletterFieldsInput {
+  name: String
+  phone: String
+}
+
 """
 Profile information that is receive in session
 """

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -96,6 +96,7 @@ declare global {
 
   interface PersonalPreferences {
     firstName?: string
+    cellPhone?: string
     isNewsletterOptIn?: 'True' | 'False'
   }
 

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -96,7 +96,7 @@ declare global {
 
   interface PersonalPreferences {
     firstName?: string
-    cellPhone?: string
+    homePhone?: string
     isNewsletterOptIn?: 'True' | 'False'
   }
 

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -95,6 +95,7 @@ declare global {
   }
 
   interface PersonalPreferences {
+    firstName?: string
     isNewsletterOptIn?: 'True' | 'False'
   }
 

--- a/node/package.json
+++ b/node/package.json
@@ -18,7 +18,7 @@
     "querystring": "^0.2.0",
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "unorm": "^1.5.0",
     "url-parse": "^1.2.0"
   },

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -72,9 +72,9 @@ export const mutations = {
         updatedPersonalPreferences.firstName = fields.name
       }
 
-      // Prevents 'cellPhone' field from being overridden.
+      // Prevents 'homePhone' field from being overridden.
       if (!userHasPhone && fields.phone) {
-        updatedPersonalPreferences.cellPhone = fields.phone
+        updatedPersonalPreferences.homePhone = fields.phone
       }
     }
 

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -17,7 +17,10 @@ const FALSE = 'False'
 
 interface SubscribeNewsletterArgs {
   email: string
-  name?: string
+  fields?: {
+    name?: string
+    phone?: string
+  }
   isNewsletterOptIn: boolean
 }
 
@@ -45,7 +48,7 @@ export const mutations = {
 
   subscribeNewsletter: async (
     _: any,
-    { email, name, isNewsletterOptIn }: SubscribeNewsletterArgs,
+    { email, fields, isNewsletterOptIn }: SubscribeNewsletterArgs,
     context: Context
   ) => {
     const profile = context.clients.profile
@@ -58,14 +61,20 @@ export const mutations = {
       isNewsletterOptIn: optIn,
     }
 
-    if (name) {
+    if (fields) {
       const userProfile = await profile.getProfileInfo({ email, userId: '' })
 
       const userHasFirstName = Boolean(userProfile.firstName)
+      const userHasPhone = Boolean(userProfile.cellPhone)
 
-      // Prevent overrides of the 'firstName' field.
-      if (!userHasFirstName) {
-        updatedPersonalPreferences.firstName = name
+      // Prevents 'firstName' field from being overridden.
+      if (!userHasFirstName && fields.name) {
+        updatedPersonalPreferences.firstName = fields.name
+      }
+
+      // Prevents 'cellPhone' field from being overridden.
+      if (!userHasPhone && fields.phone) {
+        updatedPersonalPreferences.cellPhone = fields.phone
       }
     }
 

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -65,7 +65,7 @@ export const mutations = {
 
       // Prevent overrides of the 'firstName' field.
       if (!userHasFirstName) {
-        updatedPersonalPreferences['firstName'] = name
+        updatedPersonalPreferences.firstName = name
       }
     }
 

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -17,6 +17,7 @@ const FALSE = 'False'
 
 interface SubscribeNewsletterArgs {
   email: string
+  name?: string
   isNewsletterOptIn: boolean
 }
 
@@ -44,7 +45,7 @@ export const mutations = {
 
   subscribeNewsletter: async (
     _: any,
-    { email, isNewsletterOptIn }: SubscribeNewsletterArgs,
+    { email, name, isNewsletterOptIn }: SubscribeNewsletterArgs,
     context: Context
   ) => {
     const profile = context.clients.profile
@@ -52,11 +53,25 @@ export const mutations = {
       isNewsletterOptIn === undefined || isNewsletterOptIn === true
         ? TRUE
         : FALSE
+
+    const updatedPersonalPreferences: PersonalPreferences = {
+      isNewsletterOptIn: optIn,
+    }
+
+    if (name) {
+      const userProfile = await profile.getProfileInfo({ email, userId: '' })
+
+      const userHasFirstName = Boolean(userProfile.firstName)
+
+      // Prevent overrides of the 'firstName' field.
+      if (!userHasFirstName) {
+        updatedPersonalPreferences['firstName'] = name
+      }
+    }
+
     await profile.updatePersonalPreferences(
       { email, userId: '' },
-      {
-        isNewsletterOptIn: optIn,
-      }
+      updatedPersonalPreferences,
     )
 
     return true

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6480,10 +6480,10 @@ typescript@3.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
   integrity sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.7.3"


### PR DESCRIPTION
#### What problem is this solving?

Enables users to save the name of clients subscribing to a newsletter. 

#### How should this be manually tested?

Go to this [Workspace](https://newsletter--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.133.0/graphiql/v1?operationName=subscribeNewsletter&query=mutation%20subscribeNewsletter(%24email%3A%20String%2C%20%24fields%3A%20NewsletterFieldsInput)%20%7B%0A%20%20subscribeNewsletter(email%3A%20%24email%2C%20fields%3A%20%24fields)%0A%7D%0A&variables=%7B%0A%20%20%22email%22%3A%20%22test%40vtex.com.br%22%2C%0A%09%22fields%22%3A%20%7B%0A%20%20%20%20%22name%22%3A%20%22Person%22%2C%0A%20%20%20%20%22phone%22%3A%20%22%2B11111111%22%0A%20%20%7D%20%20%0A%7D) and perform the following mutation: 

```graphql
mutation subscribeNewsletter($email: String, $fields: NewsletterFieldsInput) {
  subscribeNewsletter(email: $email, fields: $fields)
}
```

The result can be seen in Master Data

![Screen Shot 2020-10-01 at 11 17 37](https://user-images.githubusercontent.com/27777263/94821275-cb624880-03d7-11eb-90f0-dfe5f09718af.png)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
