### PR TITLE
Feature/create doc account param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New `account` param on createDocument mutations
+
 ## [2.134.0] - 2020-09-30
 ### Added
 - Translated `slug` and `href` fields from the Category type

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -855,6 +855,7 @@ type Mutation {
   createDocument(
     acronym: String!
     document: DocumentInput
+    account: String
     schema: String
   ): DocumentResponse
   updateDocument(
@@ -873,6 +874,7 @@ type Mutation {
   createDocumentV2(
     dataEntity: String!
     document: DocumentInputV2
+    account: String
     schema: String
   ): DocumentResponseV2 @cacheControl(scope: PRIVATE)
 

--- a/node/clients/masterdata.ts
+++ b/node/clients/masterdata.ts
@@ -45,11 +45,12 @@ export class MasterData extends ExternalClient {
       },
     })
 
-  public createDocument = (acronym: string, fields: object, schema?: string) =>
+  public createDocument = (acronym: string, fields: object, schema?: string, account?: string) =>
     this.post<DocumentResponse>(this.routes.documents(acronym), fields, {
       metric: 'masterdata-createDocument',
       params: {
         ...(schema ? { _schema: schema } : null),
+        ...(account ? { an: account } : null),
       },
     })
 

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -149,12 +149,14 @@ declare global {
   interface CreateDocumentArgs {
     acronym: string
     document: { fields: KeyValue[] }
+    account?: string
     schema?: string
   }
 
   interface CreateDocumentV2Args {
     dataEntity: string
     document: { document: any }
+    account?: string
     schema?: string
   }
 

--- a/node/package.json
+++ b/node/package.json
@@ -18,7 +18,7 @@
     "querystring": "^0.2.0",
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "unorm": "^1.5.0",
     "url-parse": "^1.2.0"
   },

--- a/node/resolvers/document/index.ts
+++ b/node/resolvers/document/index.ts
@@ -98,6 +98,7 @@ export const mutations = {
     const {
       acronym,
       document: { fields },
+      account,
       schema,
     } = args
     const {
@@ -106,7 +107,8 @@ export const mutations = {
     const response = (await masterdata.createDocument(
       acronym,
       parseFieldsToJson(fields),
-      schema
+      schema,
+      account
     )) as DocumentResponse
 
     const documentId = removeAcronymFromId(acronym, response)
@@ -126,6 +128,7 @@ export const mutations = {
     const {
       dataEntity,
       document: { document },
+      account,
       schema,
     } = args
 
@@ -136,7 +139,8 @@ export const mutations = {
     const response = (await masterdata.createDocument(
       dataEntity,
       document,
-      schema
+      schema,
+      account
     )) as DocumentResponseV2
 
     const documentId = removeAcronymFromId(dataEntity, response)

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6491,10 +6491,10 @@ typescript@3.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
   integrity sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.7.3"


### PR DESCRIPTION
#### What problem is this solving?

The inability to choose which account in a multi-account environment will be used when calling the mutations

#### How should this be manually tested?

[Workspace](https://ecom8257--carrefourbr.myvtex.com/_v/private/vtex.store-graphql@2.134.0/graphiql/v1?operationName=CREATE_DOCUMENT&query=mutation%20CREATE_DOCUMENT(%24document%3A%20DocumentInputV2)%20%7B%0A%20%20createDocumentV2(document%3A%20%24document%2C%20dataEntity%3A%20%22sharedcart%22%2C%20schema%3A%20%22sharedcart%22%2C%20account%3A%20%22carrefourbrfood%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20href%0A%20%20%20%20documentId%0A%20%20%7D%0A%7D%0A&variables=%7B%0A%20%20%22document%22%3A%20%7B%0A%20%20%20%20%22document%22%3A%20%7B%0A%20%20%20%20%20%20%22channel%22%3A%201%2C%0A%20%20%20%20%20%20%22clientEmail%22%3A%20%22qwe%40asd.com%22%2C%0A%20%20%20%20%20%20%22orderFormId%22%3A%20%222312831231%22%2C%0A%20%20%20%20%20%20%22purchased%22%3A%20false%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).
