### PR TITLE
Fix href fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Uses correct fallback for category href
+
 ## [2.135.0] - 2020-10-09
 
 ### Added

--- a/node/resolvers/catalog/category.ts
+++ b/node/resolvers/catalog/category.ts
@@ -63,7 +63,7 @@ export const resolvers = {
       // Won't translate href if current locale is the same as the default locale
       // or account isn't in the tenant system, or binding data isn't present
       return tenant && binding && binding.id && tenant.locale !== binding.locale
-        ? await rewriter.getRoute(id.toString(), getTypeForCategory(path), binding.id) || url
+        ? await rewriter.getRoute(id.toString(), getTypeForCategory(path), binding.id) || path
         : path
     },
 


### PR DESCRIPTION
#### What problem is this solving?

In the multiple binding case, when there isn't a translation for the route the fallback was the incoming url, meaning it had the full `{{account}}.vtexcommercestable.com.bt` host and not only the path.

#### How should this be manually tested?
You can do a category query and check the href property

https://fox--minisocl.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
