### PR TITLE
fix pricewithoutdiscount and price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fills the `PriceWithoutDiscount` field in the `itemsWithSimulation` query.
+- Use `sellingPrice` instead of `price` in the `itemsWithSimulation` query.
 
 ## [2.136.0] - 2020-10-29
 ### Added

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -18,9 +18,10 @@ export const getSimulationPayloadsByItem = (item: ItemWithSimulationInput, price
 
 export const orderFormItemToSeller = (orderFormItem: OrderFormItem & { paymentData: any }) => {
   const commertialOffer = {
-    Price: orderFormItem.price / 100,
+    Price: orderFormItem.sellingPrice / 100,
     PriceValidUntil: orderFormItem.priceValidUntil,
-    ListPrice: orderFormItem.listPrice / 100
+    ListPrice: orderFormItem.listPrice / 100,
+    PriceWithoutDiscount: orderFormItem.price / 100
   } as CommertialOffer
 
   const installmentOptions = orderFormItem?.paymentData?.installmentOptions || []


### PR DESCRIPTION
#### What problem is this solving?

Fills the `PriceWithoutDiscount` field in the `itemsWithSimulation` query.
Use `sellingPrice` instead of `price` in the `itemsWithSimulation` query.

#### How should this be manually tested?

```
curl --request POST \
  --url 'https://pricewithoutdiscount--storecomponents.myvtex.com/_v/segment/graphql/v1?workspace=pricewithoutdiscount' \
  --header 'Content-Type: application/json' \
  --data '{"query":"{\n  itemsWithSimulation(items: [{itemId: \"20\", sellers: [{sellerId: \"1\"}]}]) {\n    sellers {\n      commertialOffer {\n        Price\n        PriceWithoutDiscount\n      }\n    }\n  }\n}\n"}'
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
