### PR TITLE
Remove orderForm cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove `orderForm` query cache.
 
 ## [2.136.1] - 2020-11-16
 ### Fixed
@@ -37,7 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.132.0] - 2020-09-21
 ### Added
-- New `account` field on `document` query. 
+- New `account` field on `document` query.
 
 ## [2.131.2] - 2020-09-15
 ### Added
@@ -62,7 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.129.0] - 2020-08-27
 ### Added
-- New `account` field on `updateDocuments` query. 
+- New `account` field on `updateDocuments` query.
 
 ## [2.128.0] - 2020-08-27
 ### Added
@@ -82,7 +84,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.126.0] - 2020-07-09
 ### Added
-- New `account` field on `documents` query. 
+- New `account` field on `documents` query.
 
 ## [2.125.0] - 2020-07-09
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -291,7 +291,7 @@ type Query {
   Returns checkout cart details
   """
   orderForm: OrderForm
-    @cacheControl(scope: PRIVATE)
+    @cacheControl(maxAge: ZERO, scope: PRIVATE)
     @withOrderFormId
     @withSegment
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.136.1",
+  "version": "2.136.2-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",


### PR DESCRIPTION
#### What problem is this solving?

We are not setting a `maxAge` for the `orderForm` query, so the platform adds the default value (long). We should explicitly set its value to `ZERO` to avoid caching sensitive information by mistake.

#### How should this be manually tested?

https://bacelar--muji.myvtex.com/?__bindingAddress=www.mujionline.eu/uk

Open Chrome DevTools, filter the requests with `/_v/private`, and check if all the requests with `orderForm` have `maxAge=zero` in the query string.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
