### PR TITLE
Adding dataentites as a prefix on all endpoints of Master Data client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use `dataentities` as a prefix on Master Data client.
 
 ## [2.136.2] - 2020-11-20
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.136.2",
+  "version": "2.136.3-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/clients/masterdata.ts
+++ b/node/clients/masterdata.ts
@@ -9,9 +9,11 @@ import FormData from 'form-data'
 
 import { statusToError } from '../utils'
 
+const DATAENTITIES_PREFIX = '/dataentities'
+
 export class MasterData extends ExternalClient {
   public constructor(ctx: IOContext, options?: InstanceOptions) {
-    super(`http://api.vtex.com/${ctx.account}/dataentities`, ctx, {
+    super(`http://api.vtex.com/${ctx.account}`, ctx, {
       ...options,
       headers: {
         ...(options && options.headers),
@@ -123,17 +125,18 @@ export class MasterData extends ExternalClient {
     return this.http.patch<T>(url, data, config).catch(statusToError)
   }
 
+  
   private get routes() {
     return {
       attachments: (acronym: string, id: string, fields: string) =>
-        `${acronym}/documents/${id}/${fields}/attachments`,
-      document: (acronym: string, id: string) => `${acronym}/documents/${id}`,
-      documents: (acronym: string) => `${acronym}/documents`,
+        `${DATAENTITIES_PREFIX}/${acronym}/documents/${id}/${fields}/attachments`,
+      document: (acronym: string, id: string) => `${DATAENTITIES_PREFIX}/${acronym}/documents/${id}`,
+      documents: (acronym: string) => `${DATAENTITIES_PREFIX}/${acronym}/documents`,
       schema: (acronym: string, schema: string) =>
-        `${acronym}/schemas/${schema}`,
+        `${DATAENTITIES_PREFIX}/${acronym}/schemas/${schema}`,
       publicSchema: (acronym: string, schema: string) =>
-        `${acronym}/schemas/${schema}/public`,
-      search: (acronym: string) => `${acronym}/search`,
+        `${DATAENTITIES_PREFIX}/${acronym}/schemas/${schema}/public`,
+      search: (acronym: string) => `${DATAENTITIES_PREFIX}/${acronym}/search`,
     }
   }
 }


### PR DESCRIPTION
Test [here](https://lucis--vtexufcg.myvtex.com/_v/private/vtex.store-graphql@2.136.2/graphiql/v1?query=mutation%20a%20%7B%0A%20%20updateDocument(acronym%3A%20%22CL%22%2C%20document%3A%7B%20fields%3A%20%5B%7Bkey%3A%20%22id%22%2C%20value%3A%20%22b%22%7D%5D%7D%2C%20schema%3A%22v1%22)%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D&operationName=a)