### PR TITLE
Add policy to call portal.vtexcommercebeta.com.br

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -112,6 +112,13 @@
       }
     },
     {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "portal.vtexcommercebeta.com.br",
+        "path": "/api/segments/*"
+      }
+    },
+    {
       "name": "POWER_USER_DS"
     },
     {
@@ -150,6 +157,13 @@
       "name": "outbound-access",
       "attrs": {
         "host": "portal.vtexcommercestable.com.br",
+        "path": "/api/profile-system/*"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "portal.vtexcommercebeta.com.br",
         "path": "/api/profile-system/*"
       }
     },


### PR DESCRIPTION
#### What problem is this solving?
This app is calling `portal.vtexcommercebeta.com.br`, but there is no policy that allows this access. It currently depends on another of its policies that is giving out too broad permissions that we are going to fix soon, so I am adding the policy that will replace it.

#### How should this be manually tested?

I am running a script to simulate the permissions the app will have once the bad policy is fixed.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

