### PR TITLE
Feature/idcs 40/login sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `loginSessionsInfo` query
 
 ## [2.139.1] - 2021-03-29
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,10 @@ TODO
 
 - `profile` - Returns user profile details
 
+### VTEXID
+
+- `loginSessionsInfo` - Returns an object with currently active user login sessions and the ID of the current session
+
 ## Mutations
 
 ### Checkout

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -298,8 +298,7 @@ type Query {
   """
   returns a certain checkout cart details
   """
-  searchOrderForm(orderFormId: String!): OrderForm
-    @cacheControl(scope: PRIVATE)
+  searchOrderForm(orderFormId: String!): OrderForm @cacheControl(scope: PRIVATE)
 
   """
   Returns user orders details
@@ -445,6 +444,11 @@ type Query {
   loginOptions: LoginOptions @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 
   """
+  Get an object containing the list of the user's loginSessions
+  """
+  loginSessionsInfo: LoginSessionsInfo @cacheControl(scope: PRIVATE)
+
+  """
   Get the IDs for the provided search context slugs
   """
   searchContextFromParams(
@@ -553,7 +557,9 @@ type Query {
 
   checkProfileAllowed: UserCondition @cacheControl(scope: PRIVATE) @withSegment
 
-  itemsWithSimulation(items: [ItemInput]): [SKU] @cacheControl(scope: PRIVATE) @withSegment
+  itemsWithSimulation(items: [ItemInput]): [SKU]
+    @cacheControl(scope: PRIVATE)
+    @withSegment
 }
 
 type Mutation {
@@ -564,7 +570,10 @@ type Mutation {
     """
     Id of orderForm you want to mutate
     """
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     """
     List of items you want to add and their properties
     """
@@ -579,11 +588,17 @@ type Mutation {
     utmiParams: OrderFormInputUTMIParams
   ): OrderForm @withSegment @withOrderFormId
   cancelOrder(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     reason: String
   ): Boolean @withOrderFormId
   updateItems(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     items: [OrderFormItemInput]
   ): OrderForm @withSegment @withOrderFormId @cacheControl(scope: PRIVATE)
 
@@ -677,46 +692,73 @@ type Mutation {
   """
   Subscribe to newsletter
   """
-  subscribeNewsletter(email: String, isNewsletterOptIn: Boolean, fields: NewsletterFieldsInput): Boolean
-    @cacheControl(scope: PRIVATE)
+  subscribeNewsletter(
+    email: String
+    isNewsletterOptIn: Boolean
+    fields: NewsletterFieldsInput
+  ): Boolean @cacheControl(scope: PRIVATE)
 
   """
   Order Form
   """
   updateOrderFormProfile(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     fields: OrderFormProfileInput
   ): OrderForm @withOrderFormId
   updateOrderFormShipping(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     address: OrderFormAddressInput
   ): OrderForm @withOrderFormId
   updateOrderFormPayment(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     payments: [OrderFormPaymentInput]
   ): OrderForm @withOrderFormId
   updateOrderFormIgnoreProfile(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     ignoreProfileData: Boolean
   ): OrderForm @withOrderFormId
   addOrderFormPaymentToken(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     paymentToken: OrderFormPaymentTokenInput
   ): OrderForm @withOrderFormId
   setOrderFormCustomData(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     appId: String
     field: String
     value: String
   ): OrderForm @withOrderFormId
   addAssemblyOptions(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     itemId: String
     assemblyOptionsId: String
     options: [AssemblyOptionInput]
   ): OrderForm @withOrderFormId
   updateOrderFormCheckin(
-    orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
+    orderFormId: String
+      @deprecated(
+        reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
+      )
     checkin: OrderFormCheckinInput
   ): OrderForm @withOrderFormId @cacheControl(scope: PRIVATE)
 
@@ -898,6 +940,7 @@ type Mutation {
   """
   Set new orderForm.
   """
-
-  newOrderForm(orderFormId: String): OrderForm @cacheControl(scope: PRIVATE) @withOrderFormId
+  newOrderForm(orderFormId: String): OrderForm
+    @cacheControl(scope: PRIVATE)
+    @withOrderFormId
 }

--- a/graphql/types/LoginSessionsInfo.graphql
+++ b/graphql/types/LoginSessionsInfo.graphql
@@ -1,0 +1,23 @@
+enum DeviceType {
+  MOBILE
+  TABLET
+  DESKTOP
+}
+
+type LoginSession {
+  id: ID!
+  cacheId: ID!
+  deviceType: DeviceType!
+  city: String
+  lastAccess: String!
+  browser: String
+  os: String
+  ip: String
+  fullAddress: String
+  firstAccess: String!
+}
+
+type LoginSessionsInfo {
+  currentLoginSessionId: ID
+  loginSessions: [LoginSession!]
+}

--- a/node/package.json
+++ b/node/package.json
@@ -19,6 +19,7 @@
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
     "typescript": "3.9.7",
+    "ua-parser-js": "^0.7.22",
     "unorm": "^1.5.0",
     "url-parse": "^1.2.0"
   },
@@ -33,6 +34,7 @@
     "@types/node": "10.x",
     "@types/qs": "^6.5.1",
     "@types/ramda": "0.26.39",
+    "@types/ua-parser-js": "^0.7.33",
     "@types/unorm": "^1.3.27",
     "@types/url-parse": "^1.4.3",
     "@vtex/api": "^3.0.0",

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -28,6 +28,7 @@ export async function makeRequest({
   cookie = null,
 }: ParamsMakeRequest) {
   const composedHeaders = {
+    'X-Vtex-Use-Https': 'true',
     Cookie: `VtexIdClientAutCookie=${cookie}`,
     'vtex-ui-id-version': vtexIdVersion,
     accept: 'application/vnd.vtex.ds.v10+json',

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -44,7 +44,6 @@ export async function makeRequest<T = any>({
   const composedHeaders = {
     'X-Vtex-Use-Https': 'true',
     'vtex-ui-id-version': vtexIdVersion,
-    accept: 'application/vnd.vtex.ds.v10+json',
     ...(cookieHeader && { Cookie: cookieHeader }),
     ...(body && { 'content-type': 'application/x-www-form-urlencoded' }),
   }

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -22,7 +22,7 @@ interface ParamsMakeRequest {
 export async function makeRequest<T = any>({
   ctx,
   url,
-  method = 'POST',
+  method = 'GET',
   body,
   vtexIdVersion = 'store-graphql',
   authCookie = null,
@@ -48,7 +48,6 @@ const getSessionToken = async (ioContext: any, redirectUrl?: any) => {
   const { data, status } = await makeRequest({
     ctx: ioContext,
     url: paths.sessionToken(ioContext.account, ioContext.account, redirectUrl),
-    method: 'GET',
   })
 
   if (!data.authenticationToken) {
@@ -116,7 +115,6 @@ export const queries = {
     } = await makeRequest({
       ctx: ioContext,
       url: paths.sessionToken(ioContext.account, ioContext.account),
-      method: 'GET',
     })
 
     return {
@@ -154,6 +152,7 @@ export const mutations = {
       data: { authStatus },
     } = await makeRequest({
       ctx: ioContext,
+      method: 'POST',
       url: paths.accessKeySignIn(),
       body: {
         accesskey: args.code,
@@ -184,6 +183,7 @@ export const mutations = {
       data: { authStatus },
     } = await makeRequest({
       ctx: ioContext,
+      method: 'POST',
       url: paths.classicSignIn(),
       body: {
         authenticationToken: VtexSessionToken,
@@ -246,6 +246,7 @@ export const mutations = {
       data: { authStatus },
     } = await makeRequest({
       ctx: ioContext,
+      method: 'POST',
       url: paths.recoveryPassword(
         VtexSessionToken,
         args.email,
@@ -288,8 +289,8 @@ export const mutations = {
       data: { authStatus },
     } = await makeRequest({
       ctx: ioContext,
-      url: passPath,
       method: 'POST',
+      url: passPath,
       vtexIdVersion: args.vtexIdVersion,
     })
 
@@ -317,6 +318,7 @@ export const mutations = {
 
     await makeRequest({
       ctx: ioContext,
+      method: 'POST',
       url: paths.sendEmailVerification(args.email, VtexSessionToken),
     })
     response.set(

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -16,7 +16,7 @@ interface ParamsMakeRequest {
   method?: Method
   body?: any
   vtexIdVersion?: string
-  cookie?: string | null
+  authCookie?: string | null
 }
 
 export async function makeRequest({
@@ -25,13 +25,14 @@ export async function makeRequest({
   method = 'POST',
   body,
   vtexIdVersion = 'store-graphql',
-  cookie = null,
+  authCookie = null,
 }: ParamsMakeRequest) {
+  const cookieHeader = authCookie ? `VtexIdClientAutCookie=${authCookie}` : ''
   const composedHeaders = {
     'X-Vtex-Use-Https': 'true',
-    Cookie: `VtexIdClientAutCookie=${cookie}`,
     'vtex-ui-id-version': vtexIdVersion,
     accept: 'application/vnd.vtex.ds.v10+json',
+    ...(cookieHeader && { Cookie: cookieHeader }),
     ...(body && { 'content-type': 'application/x-www-form-urlencoded' }),
   }
 

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -4,7 +4,7 @@ import { ResolverError, UserInputError } from '@vtex/api'
 import http, { Method } from 'axios'
 import { parse, serialize } from 'cookie'
 
-import { headers as authHeaders, withAuthToken } from '../headers'
+import { withAuthToken } from '../headers'
 import paths from '../paths'
 
 const E_PASS = 'Password does not follow specified format'
@@ -28,9 +28,10 @@ export async function makeRequest({
   cookie = null,
 }: ParamsMakeRequest) {
   const composedHeaders = {
-    ...authHeaders.profile,
     Cookie: `VtexIdClientAutCookie=${cookie}`,
     'vtex-ui-id-version': vtexIdVersion,
+    accept: 'application/vnd.vtex.ds.v10+json',
+    ...(body && { 'content-type': 'application/x-www-form-urlencoded' }),
   }
 
   return http.request({

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -19,7 +19,7 @@ interface ParamsMakeRequest {
   authCookie?: string | null
 }
 
-export async function makeRequest({
+export async function makeRequest<T = any>({
   ctx,
   url,
   method = 'POST',
@@ -36,7 +36,7 @@ export async function makeRequest({
     ...(body && { 'content-type': 'application/x-www-form-urlencoded' }),
   }
 
-  return http.request({
+  return http.request<T>({
     ...(body && { data: stringify(body) }),
     headers: withAuthToken(composedHeaders)(ctx),
     method,

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -14,6 +14,7 @@ interface ParamsMakeRequest {
   ctx: any
   url: any
   method?: Method
+  body?: any
   vtexIdVersion?: string
   cookie?: string | null
 }
@@ -22,6 +23,7 @@ export async function makeRequest({
   ctx,
   url,
   method = 'POST',
+  body,
   vtexIdVersion = 'store-graphql',
   cookie = null,
 }: ParamsMakeRequest) {
@@ -32,6 +34,7 @@ export async function makeRequest({
   }
 
   return http.request({
+    ...(body && { data: stringify(body) }),
     headers: withAuthToken(composedHeaders)(ctx),
     method,
     url,

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -44,25 +44,6 @@ export async function makeRequest({
   })
 }
 
-const makeSecureRequest = async (
-  ctx: any,
-  url: any,
-  body: any,
-  method: Method = 'POST',
-  vtexIdVersion = 'store-graphql'
-) =>
-  http.request({
-    data: stringify(body),
-    headers: withAuthToken({
-      'X-Vtex-Use-Https': 'true',
-      accept: 'application/vnd.vtex.ds.v10+json',
-      'content-type': 'application/x-www-form-urlencoded',
-      'vtex-ui-id-version': vtexIdVersion,
-    })(ctx),
-    method,
-    url,
-  })
-
 const getSessionToken = async (ioContext: any, redirectUrl?: any) => {
   const { data, status } = await makeRequest({
     ctx: ioContext,
@@ -171,10 +152,14 @@ export const mutations = {
     const {
       headers,
       data: { authStatus },
-    } = await makeSecureRequest(ioContext, paths.accessKeySignIn(), {
-      accesskey: args.code,
-      authenticationToken: VtexSessionToken,
-      email: args.email,
+    } = await makeRequest({
+      ctx: ioContext,
+      url: paths.accessKeySignIn(),
+      body: {
+        accesskey: args.code,
+        authenticationToken: VtexSessionToken,
+        email: args.email,
+      },
     })
 
     return setVtexIdAuthCookie(ioContext, response, headers, authStatus)
@@ -197,10 +182,14 @@ export const mutations = {
     const {
       headers,
       data: { authStatus },
-    } = await makeSecureRequest(ioContext, paths.classicSignIn(), {
-      authenticationToken: VtexSessionToken,
-      login: args.email,
-      password: args.password,
+    } = await makeRequest({
+      ctx: ioContext,
+      url: paths.classicSignIn(),
+      body: {
+        authenticationToken: VtexSessionToken,
+        login: args.email,
+        password: args.password,
+      },
     })
 
     return setVtexIdAuthCookie(ioContext, response, headers, authStatus)

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -17,6 +17,7 @@ interface ParamsMakeRequest {
   body?: any
   vtexIdVersion?: string
   authCookieAdmin?: string | null
+  authCookieStore?: string | null
 }
 
 export async function makeRequest<T = any>({
@@ -26,12 +27,17 @@ export async function makeRequest<T = any>({
   body,
   vtexIdVersion = 'store-graphql',
   authCookieAdmin = null,
+  authCookieStore = null,
 }: ParamsMakeRequest) {
   const adminAuthHeader = authCookieAdmin
     ? `VtexIdClientAutCookie=${authCookieAdmin};`
     : ''
 
-  const cookieHeader = `${adminAuthHeader}`
+  const storeAuthHeader = authCookieStore
+    ? `VtexIdClientAutCookie_${ctx.account}=${authCookieStore};`
+    : ''
+
+  const cookieHeader = `${adminAuthHeader}${storeAuthHeader}`
 
   const composedHeaders = {
     'X-Vtex-Use-Https': 'true',

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -16,7 +16,7 @@ interface ParamsMakeRequest {
   method?: Method
   body?: any
   vtexIdVersion?: string
-  authCookie?: string | null
+  authCookieAdmin?: string | null
 }
 
 export async function makeRequest<T = any>({
@@ -25,9 +25,14 @@ export async function makeRequest<T = any>({
   method = 'GET',
   body,
   vtexIdVersion = 'store-graphql',
-  authCookie = null,
+  authCookieAdmin = null,
 }: ParamsMakeRequest) {
-  const cookieHeader = authCookie ? `VtexIdClientAutCookie=${authCookie}` : ''
+  const adminAuthHeader = authCookieAdmin
+    ? `VtexIdClientAutCookie=${authCookieAdmin};`
+    : ''
+
+  const cookieHeader = `${adminAuthHeader}`
+
   const composedHeaders = {
     'X-Vtex-Use-Https': 'true',
     'vtex-ui-id-version': vtexIdVersion,

--- a/node/resolvers/auth/mapLoginSessionsFromAPI.ts
+++ b/node/resolvers/auth/mapLoginSessionsFromAPI.ts
@@ -1,0 +1,61 @@
+import { UAParser } from 'ua-parser-js'
+
+import { LoginSession, LoginAccess, DeviceType } from './types'
+
+const getLastAccessDateFromHistory = (history: LoginAccess[]) => {
+  if (history && history.length > 0) {
+    const epochSeconds = history[history.length - 1].date
+
+    return new Date(epochSeconds * 1000).toISOString()
+  }
+
+  return null
+}
+
+const deviceTypeByParserType: {
+  [K in string]: DeviceType
+} = {
+  console: 'DESKTOP',
+  mobile: 'MOBILE',
+  tablet: 'TABLET',
+  smarttv: 'DESKTOP',
+  wearable: 'MOBILE',
+  embedded: 'DESKTOP',
+}
+
+const parseUserAgent = (userAgent: string) => {
+  const parser = new UAParser(userAgent)
+  const { name: browser = null } = parser.getBrowser()
+  const { name: os = null } = parser.getOS()
+  const { type: parserType } = parser.getDevice()
+
+  const deviceType: DeviceType = parserType
+    ? deviceTypeByParserType[parserType]
+    : 'DESKTOP'
+
+  return {
+    browser,
+    os,
+    deviceType,
+  }
+}
+
+const mapLoginSessionsFromAPI = (loginSessions: LoginSession[]) =>
+  loginSessions.map((session) => {
+    const { browser, os, deviceType } = parseUserAgent(session.userAgent)
+
+    return {
+      id: session.id,
+      cacheId: session.id,
+      deviceType,
+      city: null,
+      lastAccess: getLastAccessDateFromHistory(session.accessHistory),
+      browser,
+      os,
+      ip: session.ipAddress,
+      fullAddress: null,
+      firstAccess: session.creationDate,
+    }
+  })
+
+export default mapLoginSessionsFromAPI

--- a/node/resolvers/auth/mapLoginSessionsFromAPI.ts
+++ b/node/resolvers/auth/mapLoginSessionsFromAPI.ts
@@ -12,9 +12,7 @@ const getLastAccessDateFromHistory = (history: LoginAccess[]) => {
   return null
 }
 
-const deviceTypeByParserType: {
-  [K in string]: DeviceType
-} = {
+const deviceTypeByParserType: Record<string, DeviceType> = {
   console: 'DESKTOP',
   mobile: 'MOBILE',
   tablet: 'TABLET',

--- a/node/resolvers/auth/types.ts
+++ b/node/resolvers/auth/types.ts
@@ -1,0 +1,21 @@
+export interface LoginAccess {
+  date: number
+  ip: string
+}
+
+export interface LoginSession {
+  id: string
+  creationDate: string
+  expirationDate: string
+  originHostname: string
+  ipAddress: string
+  userAgent: string
+  accessHistory: LoginAccess[]
+}
+
+export interface GetLoginSessionsResponse {
+  currentSessionId: string | null
+  sessions: LoginSession[]
+}
+
+export type DeviceType = 'MOBILE' | 'TABLET' | 'DESKTOP'

--- a/node/resolvers/headers.ts
+++ b/node/resolvers/headers.ts
@@ -8,10 +8,6 @@ export const headers = {
     accept: 'application/json',
     'content-type': 'application/json',
   },
-  profile: {
-    accept: 'application/vnd.vtex.ds.v10+json',
-    'content-type': 'application/json',
-  },
 }
 
 export const withAuthToken = (currentHeaders = {}) => (

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -71,6 +71,9 @@ const paths = {
     }/authentication/start?appStart=true&scope=${scope}&accountName=${account}${
       redirect && `&callbackUrl=${redirect}`
     }${returnUrl && `&returnUrl=${returnUrl}`}`,
+  loginSessions: (scope: any, account: any) =>
+    `${paths.vtexId}/sessions?scope=${scope}&an=${account}`,
+  vtexId: `http://vtexid.vtex.com.br/api/vtexid`,
   vtexIdPub: `http://vtexid.vtex.com.br/api/vtexid/pub`,
   vtexIdPvt: `http://vtexid.vtex.com.br/api/vtexid/pvt`,
 

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -48,30 +48,30 @@ const paths = {
     `${paths.gateway(account)}/pub/sessions/${sessionId}/tokens`,
 
   /** VTEX ID API */
-  accessKeySignIn: () => `${paths.vtexId}/authentication/accesskey/validate`,
-  classicSignIn: () => `${paths.vtexId}/authentication/classic/validate`,
+  accessKeySignIn: () => `${paths.vtexIdPub}/authentication/accesskey/validate`,
+  classicSignIn: () => `${paths.vtexIdPub}/authentication/classic/validate`,
   getUser: (accountName: any) =>
     `${paths.vtexIdPvt}/user/detailedinfo?scope=${accountName}`,
   oAuth: (authenticationToken: any, providerName: any) =>
-    `${paths.vtexId}/authentication/oauth/redirect?authenticationToken=${authenticationToken}&providerName=${providerName}`,
+    `${paths.vtexIdPub}/authentication/oauth/redirect?authenticationToken=${authenticationToken}&providerName=${providerName}`,
   recoveryPassword: (token: any, email: any, password: any, code: any) =>
-    `${paths.vtexId}/authentication/classic/setpassword?authenticationToken=${token}&login=${email}&newPassword=${password}&accessKey=${code}`,
+    `${paths.vtexIdPub}/authentication/classic/setpassword?authenticationToken=${token}&login=${email}&newPassword=${password}&accessKey=${code}`,
   redefinePassword: (
     token: any,
     email: any,
     currentPassword: any,
     newPassword: any
   ) =>
-    `${paths.vtexId}/authentication/classic/setpassword?authenticationToken=${token}&login=${email}&newPassword=${newPassword}&currentPassword=${currentPassword}`,
+    `${paths.vtexIdPub}/authentication/classic/setpassword?authenticationToken=${token}&login=${email}&newPassword=${newPassword}&currentPassword=${currentPassword}`,
   sendEmailVerification: (email: any, token: any) =>
-    `${paths.vtexId}/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
+    `${paths.vtexIdPub}/authentication/accesskey/send?authenticationToken=${token}&email=${email}`,
   sessionToken: (scope: any, account: any, redirect = '/', returnUrl = '/') =>
     `${
-      paths.vtexId
+      paths.vtexIdPub
     }/authentication/start?appStart=true&scope=${scope}&accountName=${account}${
       redirect && `&callbackUrl=${redirect}`
     }${returnUrl && `&returnUrl=${returnUrl}`}`,
-  vtexId: `http://vtexid.vtex.com.br/api/vtexid/pub`,
+  vtexIdPub: `http://vtexid.vtex.com.br/api/vtexid/pub`,
   vtexIdPvt: `http://vtexid.vtex.com.br/api/vtexid/pvt`,
 
   /** Sessions API */

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -47,7 +47,7 @@ export function getPasswordLastUpdate(context: Context) {
   return makeRequest({
     ctx: context.vtex,
     url,
-    authCookie: userCookie,
+    authCookieAdmin: userCookie,
   }).then((response: any) => {
     return response.data.passwordLastUpdate
   })

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -44,11 +44,14 @@ export function getPasswordLastUpdate(context: Context) {
 
   if (!userCookie) return null
 
-  return makeRequest(context.vtex, url, 'GET', undefined, userCookie).then(
-    (response: any) => {
-      return response.data.passwordLastUpdate
-    }
-  )
+  return makeRequest({
+    ctx: context.vtex,
+    url,
+    method: 'GET',
+    cookie: userCookie,
+  }).then((response: any) => {
+    return response.data.passwordLastUpdate
+  })
 }
 
 export function getAddresses(context: Context) {

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -48,9 +48,7 @@ export function getPasswordLastUpdate(context: Context) {
     ctx: context.vtex,
     url,
     authCookieAdmin: userCookie,
-  }).then((response: any) => {
-    return response.data.passwordLastUpdate
-  })
+  }).then((response: any) => response.data.passwordLastUpdate)
 }
 
 export function getAddresses(context: Context) {

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -47,7 +47,6 @@ export function getPasswordLastUpdate(context: Context) {
   return makeRequest({
     ctx: context.vtex,
     url,
-    method: 'GET',
     authCookie: userCookie,
   }).then((response: any) => {
     return response.data.passwordLastUpdate

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -48,7 +48,7 @@ export function getPasswordLastUpdate(context: Context) {
     ctx: context.vtex,
     url,
     method: 'GET',
-    cookie: userCookie,
+    authCookie: userCookie,
   }).then((response: any) => {
     return response.data.passwordLastUpdate
   })

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1581,6 +1581,11 @@
     "@types/react-dom" "*"
     "@types/testing-library__dom" "*"
 
+"@types/ua-parser-js@^0.7.33":
+  version "0.7.33"
+  resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz#4a92089511574e12928a7cb6b99a01831acd1dd7"
+  integrity sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==
+
 "@types/unorm@^1.3.27":
   version "1.3.27"
   resolved "https://registry.yarnpkg.com/@types/unorm/-/unorm-1.3.27.tgz#60bdb3bb2e5c9ebe6d082df3a13ca992302cca7a"
@@ -6018,6 +6023,11 @@ typescript@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+
+ua-parser-js@^0.7.22:
+  version "0.7.22"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.22.tgz#960df60a5f911ea8f1c818f3747b99c6e177eae3"
+  integrity sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
#### What problem is this solving?

Add `loginSessionsInfo` query to graphql

This also refactors a piece of `node/resolvers/auth/index.ts` to improve code quality and consistency.

The fields returned by `loginSessionsInfo` satisfy [this design](https://www.figma.com/file/6rplh1huI6IpzRfaCnv0SD/Sessions-Manager---MyAccount?node-id=1%3A15).

#### How should this be manually tested?

Check out [this query](https://rafaprtest7--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.136.6/graphiql/v1?operationName=loginSessions&query=query%20loginSessions%20%7B%0A%20%20loginSessionsInfo%20%7B%0A%09%09currentLoginSessionId%0A%20%20%20%20loginSessions%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20cacheId%0A%20%20%20%20%20%20deviceType%0A%20%20%20%20%20%20city%0A%20%20%20%20%20%20lastAccess%0A%20%20%20%20%20%20browser%0A%20%20%20%20%20%20os%0A%20%20%20%20%20%20ip%0A%20%20%20%20%20%20fullAddress%0A%20%20%20%20%20%20firstAccess%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D). It returns `null`, right?!
Now log into the [store](https://rafaprtest7--storecomponents.myvtex.com/) and try that query again!
Pretty cool, huh?

![image](https://user-images.githubusercontent.com/22064061/101064830-2b5da280-3573-11eb-9b97-75a0af227329.png)

#### Checklist/Reminders

- [X] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [X] Linked this PR to a Jira story (if applicable).
- [X] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
