### PR TITLE
Explicitly adding public scope to public queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `scope: public` to `getPublicSchema` query.
 
 ## [2.136.7] - 2020-12-08
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -426,7 +426,7 @@ type Query {
     MasterData schema name.
     """
     schema: String!
-  ): DocumentSchemaV2
+  ): DocumentSchemaV2 @cacheControl(scope: PUBLIC)
 
   """
   Get the benefits associated with a list of products


### PR DESCRIPTION
We've released a hot fix on our framework to always fallback to private queries, what causes workspaces with unannotated queries to fail on SSR.

This query, specifically, seemed to affect the largest number of accounts due `vtex.store-form` app.

https://vtex.slack.com/archives/C9P4RMW6Q/p1607110252253000