### PR TITLE
Feature/marketing data mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `updateOrderFormMarketingData` on checkout mutations
+
 ## [2.136.6] - 2020-12-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `updateOrderFormMarketingData` on checkout mutations
+- `updateOrderFormMarketingData` in checkout mutations
 
 ## [2.136.6] - 2020-12-03
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,7 @@ TODO
 - `updateOrderFormShipping`
 - `updateOrderFormPayment`
 - `updateOrderFormIgnoreProfile`
+- `updateOrderFormMarketingData`
 - `addOrderFormPaymentToken`
 - `setOrderFormCustomData`
 - `createPaymentSession`

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -698,6 +698,9 @@ type Mutation {
     orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     ignoreProfileData: Boolean
   ): OrderForm @withOrderFormId
+  updateOrderFormMarketingData(
+    marketingData: OrderFormMarketingDataInput
+  ): OrderForm @withOrderFormId
   addOrderFormPaymentToken(
     orderFormId: String @deprecated(reason: "Field is no longer needed. Checkout cookie is automatically taken into account now")
     paymentToken: OrderFormPaymentTokenInput

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -18,6 +18,7 @@ type OrderForm {
   ignoreProfileData: Boolean
   totalizers: [Totalizer]
   clientProfileData: ClientProfile
+  marketingData: MarketingData
   sellers: [OrderFormSeller]
   shippingData: OrderFormShippingData
   storePreferencesData: StorePreferencesData
@@ -165,6 +166,17 @@ type ClientProfile {
   tradeName: String
 }
 
+type MarketingData {
+  coupon: String
+  utmCampaign: String
+  utmMedium: String
+  utmSource: String
+  utmiCampaign: String
+  utmiPage: String
+  utmiPart: String
+  marketingTags: [String]
+}
+
 type OrderFormShippingData {
   address: Address
   availableAddresses: [Address]!
@@ -225,6 +237,17 @@ input OrderFormPaymentTokenInput {
   bin: String
   paymentSystem: String
   paymentSystemName: String
+}
+
+input OrderFormMarketingDataInput {
+  coupon: String
+  utmCampaign: String
+  utmMedium: String
+  utmSource: String
+  utmiCampaign: String
+  utmiPage: String
+  utmiPart: String
+  marketingTags: [String]
 }
 
 input OrderFormCheckinInput {

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -611,6 +611,16 @@ export const mutations: Record<string, Resolver> = {
     })
   },
 
+  updateOrderFormMarketingData: async (_, { marketingData }, ctx) => {
+    const { clients: { checkout }, vtex: { orderFormId } } = ctx
+
+    if (orderFormId == null) {
+      throw new Error('No orderformid in cookies')
+    }
+
+    return checkout.updateOrderFormMarketingData(orderFormId, marketingData)
+  },
+
   addAssemblyOptions: (
     _,
     { itemId, assemblyOptionsId, options },


### PR DESCRIPTION
#### What problem is this solving?

Make able to change marketingData on orderForm in VTEX IO environment.

#### How should this be manually tested?

Go to graphql-ide on admin and execute mutation like image below.

Print - https://prnt.sc/vxib8x

[Workspace](https://ireslanfelipe--dzarm.myvtex.com/_v/private/dzarm.dzarm-theme@0.59.16/graphiql/v1)

#### Checklist/Reminders

- [ x ] Updated `README.md`.
- [ x ] Updated `CHANGELOG.md`.
- [ x ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
