### PR TITLE
Adding scope: public to Master Data queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `scope: public` to `document` and `documents`'s Master Data queries.
 
 ## [2.136.8] - 2020-12-08
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -379,7 +379,8 @@ type Query {
     Defines which account will be required
     """
     account: String
-  ): [Document]
+  ): [Document] @cacheControl(scope: PUBLIC, maxAge: SHORT)
+
 
   """
   Get document
@@ -401,7 +402,7 @@ type Query {
     Defines in which account the request will be made
     """
     account: String
-  ): Document
+  ): Document @cacheControl(scope: PUBLIC, maxAge: SHORT)
 
   """
   Get a document schema

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.136.8",
+  "version": "2.136.9-beta.cache.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",


### PR DESCRIPTION
Motivation: [this PR](https://github.com/vtex-apps/render-runtime/pull/589) changed how we _fetch_ our GraphQL queries when they're not annotated. As an end result, unannotated queries (like these ones) that before were going via `GET` requests are now using `POST`.

That is not ideal for two reasons:
- It's _non-SSRable_.
- It's not cacheable on CDN

Here, we explicitly annotate such queries.