### PR TITLE
Client Profile Data into the Order type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- OrderItemClientProfileData to Order type.
+
 ## [2.136.8] - 2020-12-08
 ### Added
 - `scope: public` to `getPublicSchema` query.

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -17,9 +17,28 @@ type Order {
   items: [OrderItem]
   sellers: [OrderItemSeller]
   totals: [OrderItemTotal]
+  clientProfileData: OrderItemClientProfileData
   paymentData: OrderItemPaymentData
   shippingData: OrderItemShippingData
   storePreferencesData: StorePreferencesData
+}
+
+type OrderItemClientProfileData {
+  id: String
+  email: String
+  firstName: String
+  lastName: String
+  documentType: String
+  document: String
+  phone: String
+  corporateName: String
+  tradeName: String
+  corporateDocument: String
+  stateInscription: String
+  corporatePhone: String
+  isCorporate: Boolean
+  userProfileId: String
+  customerClass: String
 }
 
 type OrderItem {


### PR DESCRIPTION
#### What problem is this solving?

We need to show the user informations on a block.

#### How should this be manually tested?

[Workspace](https://gus--acctglobal.myvtex.com/_v/private/vtex.store-graphql@2.136.8/graphiql/v1?operationName=GET_ORDER&variables=%7B%0A%20%20%22id%22%3A%20%221082531117130-01%22%0A%7D)

```
query GET_ORDER($id: String = "1082531117130-01") {
  order(id: $id) {
    clientProfileData {
      id
      email
      firstName
      lastName
      documentType
      document
      phone
      corporateName
      tradeName
      corporateDocument
      stateInscription
      corporatePhone
      isCorporate
      userProfileId
      customerClass
    }
  }
}
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
