### PR TITLE
Feature/idcs 67/log out from session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.140.0] - 2021-04-14
 ### Added
+- `logOutFromSession` mutation
+
+### Added
 - `loginSessionsInfo` query
 
 ## [2.139.1] - 2021-03-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.140.0] - 2021-04-14
 ### Added
 - `logOutFromSession` mutation
+
+## [2.140.0] - 2021-04-14
 
 ### Added
 - `loginSessionsInfo` query

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,10 @@ TODO
 - `updateAddress`
 - `deleteAddress`
 
+### VTEXID
+
+- `logOutFromSession` - Logs out from a specific login session (this can't be the current one - it doesn't delete the cookie)
+
 ## Contributing
 
 TODO

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -380,7 +380,6 @@ type Query {
     account: String
   ): [Document] @cacheControl(scope: PUBLIC, maxAge: SHORT)
 
-
   """
   Get document
   """
@@ -873,6 +872,11 @@ type Mutation {
     @deprecated(
       reason: "See https://github.com/vtex-apps/store-graphql/issues/182"
     )
+
+  """
+  Logs out from a specific login session
+  """
+  logOutFromSession(sessionId: ID): ID @cacheControl(scope: PRIVATE)
 
   """
   Impersonate a customer

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -257,6 +257,41 @@ export const mutations = {
     return true
   },
 
+  /**
+   * Log out from specified login sessions of user (identified by the cookie)
+   * @return login session ID
+   */
+  logOutFromSession: async (
+    _: any,
+    {
+      sessionId,
+    }: {
+      sessionId: string
+    },
+    {
+      request: {
+        headers: { 'vtex-ui-id-version': uiVersion },
+      },
+      vtex: ioContext,
+    }: any
+  ) => {
+    const { storeUserAuthToken, account } = ioContext
+
+    if (!storeUserAuthToken) {
+      return null
+    }
+
+    makeRequest({
+      url: paths.logOutFromSession({ account, scope: account, sessionId }),
+      ctx: ioContext,
+      vtexIdVersion: uiVersion,
+      method: 'POST',
+      authCookieStore: storeUserAuthToken,
+    })
+
+    return sessionId
+  },
+
   oAuth: async (_: any, args: any, { vtex: ioContext }: any) => {
     const { provider, redirectUrl } = args
     const VtexSessionToken = await getSessionToken(ioContext, redirectUrl)

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -281,7 +281,7 @@ export const mutations = {
       return null
     }
 
-    makeRequest({
+    await makeRequest({
       url: paths.logOutFromSession({ account, scope: account, sessionId }),
       ctx: ioContext,
       vtexIdVersion: uiVersion,

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -78,9 +78,9 @@ const paths = {
     account,
     sessionId,
   }: {
-    scope: any
-    account: any
-    sessionId: any
+    scope: string
+    account: string
+    sessionId: string
   }) =>
     `${paths.vtexId}/sessions/${sessionId}/revoke?scope=${scope}&an=${account}`,
   vtexId: `http://vtexid.vtex.com.br/api/vtexid`,

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -71,7 +71,7 @@ const paths = {
     }/authentication/start?appStart=true&scope=${scope}&accountName=${account}${
       redirect && `&callbackUrl=${redirect}`
     }${returnUrl && `&returnUrl=${returnUrl}`}`,
-  loginSessions: (scope: any, account: any) =>
+  loginSessions: (scope: string, account: string) =>
     `${paths.vtexId}/sessions?scope=${scope}&an=${account}`,
   logOutFromSession: ({
     scope,

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -73,6 +73,16 @@ const paths = {
     }${returnUrl && `&returnUrl=${returnUrl}`}`,
   loginSessions: (scope: any, account: any) =>
     `${paths.vtexId}/sessions?scope=${scope}&an=${account}`,
+  logOutFromSession: ({
+    scope,
+    account,
+    sessionId,
+  }: {
+    scope: any
+    account: any
+    sessionId: any
+  }) =>
+    `${paths.vtexId}/sessions/${sessionId}/revoke?scope=${scope}&an=${account}`,
   vtexId: `http://vtexid.vtex.com.br/api/vtexid`,
   vtexIdPub: `http://vtexid.vtex.com.br/api/vtexid/pub`,
   vtexIdPvt: `http://vtexid.vtex.com.br/api/vtexid/pvt`,


### PR DESCRIPTION
#### What problem is this solving?

This adds the mutation `logOutFromSession`. It allows a user to log out from another device remotely.

#### How to test it?

First, log in to the admin and store [here](http://rafaprtest7--storecomponents.myvtex.com/login).

Do that again in a different device/browser (example: your phone)!

Then, look at the results of [this query](https://rafaprtest7--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.140.0/graphiql/v1?query=query%20%7B%0A%20%20loginSessionsInfo%20%7B%0A%20%20%20%20currentLoginSessionId%0A%20%20%20%20loginSessions%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20cacheId%0A%20%20%20%20%20%20deviceType%0A%20%20%20%20%20%20city%0A%20%20%20%20%20%20lastAccess%0A%20%20%20%20%20%20browser%0A%20%20%20%20%20%20os%0A%20%20%20%20%20%20ip%0A%20%20%20%20%20%20fullAddress%0A%20%20%20%20%20%20firstAccess%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D). These are your current valid store login sessions. They include sessions from other workspaces. Pay special attention to the `browser`, `os` and `lastAccess` fields of each object in the `loginSessions` array. Your current login session is the one whose `id` is equal to the `currentLoginSessionId` field.

Then, you should copy the `id` of any login session that is not the current one (example: the session you started on your phone).

Now comes the actual new feature: [this mutation](https://rafaprtest7--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.140.0/graphiql/v1?query=mutation(%24sessionId%3A%20ID)%20%7B%0A%20%20logOutFromSession(sessionId%3A%20%24sessionId)%0A%7D&variables=%7B%0A%20%20%22sessionId%22%3A%20%22%22%0A%7D). In the `Query Variables` section (at the bottom of the screen), paste the `id` you copied previously. It should look like this:

```json
{
  "sessionId": "{{YOUR SESSION ID HERE}}"
}
```

Run the mutation. If it works, you should get something like this:

```json
{
  "data": {
    "logOutFromSession": "{{YOUR SESSION ID HERE}}"
  }
}
```

To check it out, make [this query](https://rafaprtest7--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.140.0/graphiql/v1?query=query%20%7B%0A%20%20loginSessionsInfo%20%7B%0A%20%20%20%20currentLoginSessionId%0A%20%20%20%20loginSessions%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20cacheId%0A%20%20%20%20%20%20deviceType%0A%20%20%20%20%20%20city%0A%20%20%20%20%20%20lastAccess%0A%20%20%20%20%20%20browser%0A%20%20%20%20%20%20os%0A%20%20%20%20%20%20ip%0A%20%20%20%20%20%20fullAddress%0A%20%20%20%20%20%20firstAccess%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D) again! Your login session should be removed from the list. You may refresh your browser in that session's device - and you will see you've been logged out of the store! (for now, this may take about 10min because of cache)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/BzyTuYCmvSORqs1ABM/giphy.gif)
