### PR TITLE
Bring back 'pickupStoreInfo' type to app's schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bring back `pickupStoreInfo` type to avoid breaking app builds.
 
 ## [2.138.1] - 2021-03-01
 ### Added

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -33,10 +33,10 @@ type ShippingSLA {
   deliveryChannel: String
   friendlyName: String
   pickupPointId: String
-  pickupStoreInfo: PickupStoreInfoSLA
+  pickupStoreInfo: pickupStoreInfo
 }
 
-type PickupStoreInfoSLA {
+type pickupStoreInfo {
   friendlyName: String
   address: PickupAddress
   additionalInfo: String


### PR DESCRIPTION
#### What problem is this solving?

Changes introduced by https://github.com/vtex-apps/store-graphql/pull/524 could cause build fails on apps that import GraphQL types from `vtex.store-graphql`. This PR aims to revert those changes.

#### How to test it?

[Workspace](https://victormiranda--storecomponents.myvtex.com/_v/private/vtex.store-graphql@2.138.1/graphiql/v1)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/OiwOPq0fFqqyainyMu/giphy.gif)
