### PR TITLE
add avalable quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `AvailableQuantity` to the `itemsWithSimulation` query.
 
 ## [2.138.2] - 2021-03-09
 ### Fixed

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -28,6 +28,7 @@ export const orderFormItemToSeller = (
     PriceValidUntil: orderFormItem.priceValidUntil,
     ListPrice: orderFormItem.listPrice / 100,
     PriceWithoutDiscount: orderFormItem.price / 100,
+    AvailableQuantity: orderFormItem?.availability === 'available' ? 10000 : 0
   } as CommertialOffer
 
   const installmentOptions =


### PR DESCRIPTION
#### What problem is this solving?

When we use the async price, we need to have the `AvailableQuantity` information. For while, the IS doesn't have the exact quantity value, that's why we use the hardcoded values `? 0 : 10000`. We are doing the same [here](https://github.com/vtex-apps/search-resolver/blob/v1.x/node/commons/compatibility-layer.ts#L228)

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--carrefourbrfood.myvtex.com/)

1. Scroll the page until you are able to see a product price
2. Open the Apollo the dev tools and check the `itemsWithSimulation` query

![image](https://user-images.githubusercontent.com/40380674/110795935-26854a80-8256-11eb-9c9f-2ce4b30e1625.png)

#### Related to / Depends on

https://github.com/vtex-apps/store-resources/pull/149

