### PR TITLE
fix: brand slugify same as catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Brand slugify on `resolvers/catalog/brand` same as catalog
+
 ## [2.139.0] - 2021-03-11
 ### Added
 - `AvailableQuantity` to the `itemsWithSimulation` query.

--- a/node/resolvers/catalog/brand.ts
+++ b/node/resolvers/catalog/brand.ts
@@ -1,6 +1,6 @@
 import { prop } from 'ramda'
 
-import { Slugify } from './slug'
+import { catalogSlugify } from './slug'
 
 export const resolvers = {
   Brand: {
@@ -10,8 +10,8 @@ export const resolvers = {
 
     active: prop('isActive'),
 
-    cacheId: (brand: any) => Slugify(brand.name),
+    cacheId: (brand: any) => catalogSlugify(brand.name),
 
-    slug: (brand: any) => Slugify(brand.name),
+    slug: (brand: any) => catalogSlugify(brand.name),
   },
 }


### PR DESCRIPTION
#### What problem is this solving?

We are slugifying different than catalog on store-graphql, when the right behavior should be using same as catalog, causing unexpected behaviors when calling this query with the wrong slug:

https://github.com/vtex-apps/store-graphql/blob/e4a1bec686dc04c42c60c8e51da9f5f04bef07f7/node/resolvers/catalog/slug.ts#L26-L27

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
Go to the workspace
Select store-graphql app
Try the following query:

```
query{
  brand(id:2000105){
    id
    name
    slug
    cacheId
  }
}
```

[Workspace](https://iespinoza--equishopper.myvtex.com/admin/graphql-ide)

#### Screenshots or example usage:

What we were doing
![image](https://user-images.githubusercontent.com/13649073/112886482-6054ae80-90a8-11eb-9eb4-c105bf77702c.png)

What we should do
![image](https://user-images.githubusercontent.com/13649073/112886494-6480cc00-90a8-11eb-9a74-aadc5a3ab361.png)
 
The fix with this PR
![image](https://user-images.githubusercontent.com/13649073/112886573-7ebaaa00-90a8-11eb-901f-3682330d94a7.png)

<!--- Optional -->

#### Related to / Depends on

Zendesk: #340592

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/oy3KWBNjxG6YST6pak/giphy.gif)
