### PR TITLE
Feature/add teasers and discount highlights to the itemswithsimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `teasers` and `discountHighlights` to the `itemsWithSimulation`.
+
 ## [2.141.0] - 2021-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `teasers` and `discountHighlights` to the `itemsWithSimulation`.
+- `teasers` and `discountHighlights` and payment name to the `itemsWithSimulation`.
 
 ## [2.141.0] - 2021-04-26
 

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -375,6 +375,7 @@ export const queries: Record<string, Resolver> = {
               return orderFormItemToSeller({
                 ...simulationItem,
                 paymentData: simulation.paymentData,
+                ratesAndBenefitsData: simulation.ratesAndBenefitsData
               })
             }
           )

--- a/node/typings/Checkout.ts
+++ b/node/typings/Checkout.ts
@@ -324,3 +324,31 @@ interface ItemWithSimulationInput {
     sellerId: string
   }>
 }
+
+interface RatesAndBenefitsData {
+  rateAndBenefitsIdentifiers: {
+    id: string
+    name: string
+    featured: boolean
+    description: string
+  }[]
+  teaser: {
+    featured: boolean
+    id: string
+    name: string
+    conditions: {
+      parameters: {
+        name: string
+        value: string
+      }[]
+      minimumQuantity: number
+    }
+    effects: {
+      parameters: {
+        name: string
+        value: string
+      }[]
+    }
+    teaserType: string
+  }[]
+}

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -1,3 +1,5 @@
+const ALLOWED_TEASER_TYPES = ["Catalog", "Profiler", "ConditionalPrice"]
+
 export const getSimulationPayloadsByItem = (
   item: ItemWithSimulationInput,
   priceTable?: string,
@@ -21,14 +23,16 @@ export const getSimulationPayloadsByItem = (
 }
 
 export const orderFormItemToSeller = (
-  orderFormItem: OrderFormItem & { paymentData: any }
+  orderFormItem: OrderFormItem & { paymentData: any, ratesAndBenefitsData: any }
 ) => {
   const commertialOffer = {
     Price: orderFormItem.sellingPrice / 100,
     PriceValidUntil: orderFormItem.priceValidUntil,
     ListPrice: orderFormItem.listPrice / 100,
     PriceWithoutDiscount: orderFormItem.price / 100,
-    AvailableQuantity: orderFormItem?.availability === 'available' ? 10000 : 0
+    AvailableQuantity: orderFormItem?.availability === 'available' ? 10000 : 0,
+    Teasers: getTeasersFromRatesAndBenefitsData(orderFormItem.ratesAndBenefitsData),
+    DiscountHighLight: getDiscountHighLightsFromRatesAndBenefitsData(orderFormItem.ratesAndBenefitsData)
   } as CommertialOffer
 
   const installmentOptions =
@@ -52,4 +56,25 @@ export const orderFormItemToSeller = (
     sellerId: orderFormItem.id,
     commertialOffer,
   }
+}
+
+const getTeasersFromRatesAndBenefitsData = (ratesAndBenefitsData: any) => {
+  if (!ratesAndBenefitsData) {
+    return []
+  }
+
+  return ratesAndBenefitsData.teaser
+    .filter((teaser: any) => ALLOWED_TEASER_TYPES.includes(teaser.teaserType))
+    .map((teaser: any) => ({"<Name>k__BackingField": teaser.name}))
+}
+
+
+const getDiscountHighLightsFromRatesAndBenefitsData = (ratesAndBenefitsData: any) => {
+  if (!ratesAndBenefitsData) {
+    return []
+  }
+
+  return ratesAndBenefitsData.rateAndBenefitsIdentifiers
+    .filter((rateAndBenefitsIdentifier: any) => rateAndBenefitsIdentifier.featured)
+    .map((rateAndBenefitsIdentifier: any) => ({"<Name>k__BackingField": rateAndBenefitsIdentifier.name}))
 }


### PR DESCRIPTION
#### What problem is this solving?

Currently, we are not using the teasers and discount highlights from the simulation call.

#### How to test it?

```
curl --request POST \
  --url https://hiago--carrefourbrfood.myvtex.com/_v/private/graphql/v1 \
  --header 'Content-Type: application/json' \
  --header 'Cookie: vtex_segment=eyJjYW1wYWlnbnMiOm51bGwsImNoYW5uZWwiOiIyIiwicHJpY2VUYWJsZXMiOm51bGwsInJlZ2lvbklkIjoiVTFjalkyRnljbVZtYjNWeVluSTVOekE9IiwidXRtX2NhbXBhaWduIjpudWxsLCJ1dG1fc291cmNlIjpudWxsLCJ1dG1pX2NhbXBhaWduIjpudWxsLCJjdXJyZW5jeUNvZGUiOiJCUkwiLCJjdXJyZW5jeVN5bWJvbCI6IlIkIiwiY291bnRyeUNvZGUiOiJCUkEiLCJjdWx0dXJlSW5mbyI6InB0LUJSIiwiYWRtaW5fY3VsdHVyZUluZm8iOiJwdC1CUiIsImNoYW5uZWxQcml2YWN5IjoicHVibGljIn0' \
  --data '{"query":"query itemsWithSimulation($items: [ItemInput]) {\n  itemsWithSimulation(items: $items)@context(provider: \"vtex.store-graphql\") {\n    itemId\n    sellers {\n      commertialOffer {\n        AvailableQuantity\n        Price\n        ListPrice\n        PriceValidUntil\n        discountHighlights {\n          name\n        }\n        teasers {\n          name\n        }\n        Installments {\n        \tValue\n          InterestRate\n          TotalValuePlusInterestRate\n          NumberOfInstallments\n          Name\n          PaymentSystemName\n      \t}\n      }\n    }\n  }\n}","variables":{"items":[{"itemId":"4865","sellers":[{"sellerId":"1"}]}]},"operationName":"itemsWithSimulation"}'
```

