### PR TITLE
Fix passing undefined to JSON.parse in the profile query getPayments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Parsing `undefined` `availableAccounts` in get Profile `getPayments`.
+- `getPayments` resolver result when `availableAccounts` is not defined.
 
 ## [2.142.2] - 2021-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Parsing `undefined` `availableAccounts` in get Profile `getPayments`.
+
 ## [2.142.2] - 2021-05-06
 
 ### Fixed

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -72,8 +72,6 @@ export async function getPayments(context: Context) {
     return null
   }
 
-  console.log(paymentsRawData, 'payments raw dataaaa')
-  debugger
   const addresses = await getAddresses(context)
   const { availableAccounts } = JSON.parse(paymentsRawData.paymentData)
 

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -68,10 +68,12 @@ export async function getPayments(context: Context) {
 
   const paymentsRawData = await profile.getUserPayments(currentProfile)
 
-  if (!paymentsRawData) {
+  if (!paymentsRawData || paymentsRawData.availableAccounts == null) {
     return null
   }
 
+  console.log(paymentsRawData, 'payments raw dataaaa')
+  debugger
   const addresses = await getAddresses(context)
   const { availableAccounts } = JSON.parse(paymentsRawData.paymentData)
 

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -68,7 +68,7 @@ export async function getPayments(context: Context) {
 
   const paymentsRawData = await profile.getUserPayments(currentProfile)
 
-  if (!paymentsRawData || paymentsRawData.availableAccounts == null) {
+  if (!paymentsRawData?.availableAccounts) {
     return null
   }
 


### PR DESCRIPTION
#### What problem is this solving?

The `vcs-checkout` endpoint in the profile system may return no `availableAccounts`. The value of this variable wasn't null-checked before passing it to `JSON.parse`

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://arthur--adereautoservico.myvtex.com/)

#### Screenshots or example usage:

Before:
![image](https://user-images.githubusercontent.com/11592617/117073971-172bf600-ad09-11eb-816b-0efa2c14b00f.png)
After:
![image](https://user-images.githubusercontent.com/11592617/117073984-1abf7d00-ad09-11eb-85ba-80f342081f23.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://img.wattpad.com/738209a1ed955e07b075826f7bc225d30f0fadbb/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f776174747061642d6d656469612d736572766963652f53746f7279496d6167652f544d76486f59634f67716b786f513d3d2d3531393434353434372e313530376563313330613231623831303635383233333230323637362e676966)
