### PR TITLE
marketingData is undefined when there is no utm info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.142.1] - 2021-05-06
+### Fixed
+- checkout returns 400 when there is no UTM info.
 
-## [2.142.0] - 2021-05-03
+## [2.142.1] - 2021-05-06
 
 ### Added
 - UTM info to the `itemsWithSimulation` query.
+
+## [2.142.0] - 2021-05-03
 
 ### Added
 - `teasers` and `discountHighlights` and payment name to the `itemsWithSimulation`.

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -2,6 +2,17 @@ import { SegmentData } from "@vtex/api"
 
 const ALLOWED_TEASER_TYPES = ["Catalog", "Profiler", "ConditionalPrice"]
 
+const getMarketingData = (segment?: SegmentData) => {
+  if (!segment || !segment.utm_campaign || !segment.utm_source) {
+    return
+  }
+
+  return {
+    utmCampaign: segment!.utm_campaign ,
+    utmSource: segment!.utm_source,
+  }
+}
+
 export const getSimulationPayloadsByItem = (
   item: ItemWithSimulationInput,
   segment?: SegmentData
@@ -19,10 +30,7 @@ export const getSimulationPayloadsByItem = (
       priceTables: segment?.priceTables ? [segment.priceTables] : undefined,
       items: [item],
       shippingData: { logisticsInfo: [{ regionId: segment?.regionId }] },
-      marketingData: segment ? {
-        utmCampaign: segment.utm_campaign,
-        utmSource: segment.utm_source,
-      } : undefined
+      marketingData: getMarketingData(segment)
     }
   })
 }


### PR DESCRIPTION
#### What problem is this solving?

It fixes the `v2.142.1` that was deprecated.

When there is no UTM info, we were calling the simulation API this way:

```
curl --request POST \
  --url 'https://motorolauk.vtexcommercestable.com.br/api/checkout/pub/orderForms/simulation?sc=2' \
  --header 'Content-Type: application/json' \
  --data '{
    "items": [
        {
            "id": "181",
            "quantity": 1,
            "seller": "motorolaeudr"
        }
    ],
    "shippingData": {
        "logisticsInfo": [
            {
                "regionId": null
            }
        ]
    },
    "marketingData": {
        "utmCampaign": null,
        "utmSource": null
    }
}
'
```
but it should be this way

```
curl --request POST \
  --url 'https://motorolauk.vtexcommercestable.com.br/api/checkout/pub/orderForms/simulation?sc=2' \
  --header 'Content-Type: application/json' \
  --data '{
    "items": [
        {
            "id": "181",
            "quantity": 1,
            "seller": "motorolaeudr"
        }
    ],
    "shippingData": {
        "logisticsInfo": [
            {
                "regionId": null
            }
        ]
    }
}
'
```

#### How to test it?

The following `vtex_segment` doesn't have any UTM info, and it stills working fine

```
curl --request POST \
  --url https://hiago2--motorolauk.myvtex.com/_v/private/graphql/v1 \
  --header 'Content-Type: application/json' \
  --header 'Cookie: vtex_segment=eyJjYW1wYWlnbnMiOm51bGwsImNoYW5uZWwiOiIxIiwicHJpY2VUYWJsZXMiOm51bGwsInJlZ2lvbklkIjpudWxsLCJ1dG1fY2FtcGFpZ24iOm51bGwsInV0bV9zb3VyY2UiOm51bGwsInV0bWlfY2FtcGFpZ24iOm51bGwsImN1cnJlbmN5Q29kZSI6IkdCUCIsImN1cnJlbmN5U3ltYm9sIjoiwqMiLCJjb3VudHJ5Q29kZSI6IkdCUiIsImN1bHR1cmVJbmZvIjoiZW4tR0IiLCJhZG1pbl9jdWx0dXJlSW5mbyI6ImVuLVVTIiwiY2hhbm5lbFByaXZhY3kiOiJwdWJsaWMifQ' \
  --data '{"query":"query itemsWithSimulation($items: [ItemInput]) {\n  itemsWithSimulation(items: $items)@context(provider: \"vtex.store-graphql\") {\n    itemId\n    sellers {\n      commertialOffer {\n        AvailableQuantity\n        Price\n        ListPrice\n        PriceValidUntil\n        discountHighlights {\n          name\n        }\n        teasers {\n          name\n        }\n        Installments {\n        \tValue\n          InterestRate\n          TotalValuePlusInterestRate\n          NumberOfInstallments\n          Name\n          PaymentSystemName\n      \t}\n      }\n    }\n  }\n}","variables":{"items":[{"itemId":"181","sellers":[{"sellerId":"motorolaeudr"}]}]},"operationName":"itemsWithSimulation"}'
```

The call stills working even without a segment

```
curl --request POST \
  --url https://hiago2--motorolauk.myvtex.com/_v/private/graphql/v1 \
  --header 'Content-Type: application/json' \
  --data '{"query":"query itemsWithSimulation($items: [ItemInput]) {\n  itemsWithSimulation(items: $items)@context(provider: \"vtex.store-graphql\") {\n    itemId\n    sellers {\n      commertialOffer {\n        AvailableQuantity\n        Price\n        ListPrice\n        PriceValidUntil\n        discountHighlights {\n          name\n        }\n        teasers {\n          name\n        }\n        Installments {\n        \tValue\n          InterestRate\n          TotalValuePlusInterestRate\n          NumberOfInstallments\n          Name\n          PaymentSystemName\n      \t}\n      }\n    }\n  }\n}","variables":{"items":[{"itemId":"181","sellers":[{"sellerId":"motorolaeudr"}]}]},"operationName":"itemsWithSimulation"}'
```
