### PR TITLE
Security/prevent urls being passed via query args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Security vulnerability concerning the `masterdata` client.
 
 ## [2.142.4] - 2021-06-01
 

--- a/node/package.json
+++ b/node/package.json
@@ -21,7 +21,8 @@
     "typescript": "3.9.7",
     "ua-parser-js": "^0.7.22",
     "unorm": "^1.5.0",
-    "url-parse": "^1.2.0"
+    "url-parse": "^1.2.0",
+    "validator": "^13.6.0"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",
@@ -37,6 +38,7 @@
     "@types/ua-parser-js": "^0.7.33",
     "@types/unorm": "^1.3.27",
     "@types/url-parse": "^1.4.3",
+    "@types/validator": "^13.1.4",
     "@vtex/api": "^3.0.0",
     "@vtex/test-tools": "2.1.1",
     "@vtex/tsconfig": "^0.2.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1596,6 +1596,11 @@
   resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.3.tgz#fba49d90f834951cb000a674efee3d6f20968329"
   integrity sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==
 
+"@types/validator@^13.1.4":
+  version "13.1.4"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.1.4.tgz#d2e3c27523ce1b5d9dc13d16cbce65dc4db2adbe"
+  integrity sha512-19C02B8mr53HufY7S+HO/EHBD7a/R22IwEwyqiHaR19iwL37dN3o0M8RianVInfSSqP7InVSg/o0mUATM4JWsQ==
+
 "@types/ws@^6.0.0":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.2.tgz#f3340f7e3d7a07104a5dbcaa8ada4e8d2d45eecb"
@@ -6153,6 +6158,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^13.6.0:
+  version "13.6.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.6.0.tgz#1e71899c14cdc7b2068463cb24c1cc16f6ec7059"
+  integrity sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
#### What problem is this solving?

This should make our `masterdata` client a bit safer. We currently receive some user input as strings and perform HTTP requests to URLs based on these strings. The security team reported this to the Store Framework team as a vulnerability, since it exposes us to possible [SSRF attacks](https://portswigger.net/web-security/ssrf).

#### How to test it?

This is a bit tricky to test, but a simple way to see that we're now returning an error as soon as we detect an URL being passed to the `masterdata` client is going to this [Workspace](https://victormirandavtex--carrefourbr.myvtex.com/admin/graphql-ide) and performing the following query:

```graphql
query GET_MDFIELDS($acronym: String, $fields: [String], $where: String, $account: String, $sort: String) {
  documents(acronym: $acronym, fields: $fields, where: $where, account: $account, sort: $sort) {
    fields {
      key
      value
    }
  }
}
```

with the following variables:

```json
{
  "account": "carrefourbr",
  "acronym": "https://google.com",
  "fields": ["isWhatsAppOptIn", "isSmsOptIn", "isNewsletterOptIn", "id&v=0.003833165341867062"]
}
```

You should get back an error with a `"Invalid arguments"` message.

The main difference between the new behavior and the previous one is the fact that now we'll throw this error as soon as we detect an URL being passed via user input, whereas previously we would just go ahead and perform an HTTP request anyway before throwing an error.

#### Related to / Depends on

Related to this Jira issue: https://vtex-dev.atlassian.net/browse/IOSF-389.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3ohzAml66eYPpVjPj2/giphy.gif)
