### PR TITLE
Add authorization to subscribeNewsletter resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Authorization to subscribeNewsletter resolver
 
 ## [2.142.6] - 2021-07-05
 ### Fixed

--- a/node/dataSources/identity.ts
+++ b/node/dataSources/identity.ts
@@ -3,7 +3,7 @@ import { forEachObjIndexed } from 'ramda'
 
 import { RESTDataSource } from './RESTDataSource'
 
-interface User {
+export interface User {
   userId: string
   user: string
   userType: string

--- a/node/dataSources/identity.ts
+++ b/node/dataSources/identity.ts
@@ -3,9 +3,15 @@ import { forEachObjIndexed } from 'ramda'
 
 import { RESTDataSource } from './RESTDataSource'
 
+interface User {
+  userId: string
+  user: string
+  userType: string
+}
+
 export class IdentityDataSource extends RESTDataSource {
   public getUserWithToken = (token: string) => {
-    return this.get(
+    return this.get<User | null>(
       `authenticated/user?authToken=${encodeURIComponent(token)}`,
       undefined,
       { metric: 'vtexid-getUserWithToken' }

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -76,7 +76,7 @@ async function getCurrentProfileFromCookies(
   if (userToken) {
     return identity
       .getUserWithToken(userToken)
-      .then((data) => ({ userId: data.userId, email: data.user }))
+      .then((data) => (data ? { userId: data.userId, email: data.user } : null))
   }
 
   if (!userToken && !!adminToken) {

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -83,8 +83,6 @@ const paths = {
     sessionId: string
   }) =>
     `${paths.vtexId}/sessions/${sessionId}/revoke?scope=${scope}&an=${account}`,
-  checkUserAuthorization: ({ account }: { account: string }) =>
-    `${paths.vtexIdPub}/authenticated/user?an=${account}`,
   vtexId: `http://vtexid.vtex.com.br/api/vtexid`,
   vtexIdPub: `http://vtexid.vtex.com.br/api/vtexid/pub`,
   vtexIdPvt: `http://vtexid.vtex.com.br/api/vtexid/pvt`,

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -83,6 +83,8 @@ const paths = {
     sessionId: string
   }) =>
     `${paths.vtexId}/sessions/${sessionId}/revoke?scope=${scope}&an=${account}`,
+  checkUserAuthorization: ({ account }: { account: string }) =>
+    `${paths.vtexIdPub}/authenticated/user?an=${account}`,
   vtexId: `http://vtexid.vtex.com.br/api/vtexid`,
   vtexIdPub: `http://vtexid.vtex.com.br/api/vtexid/pub`,
   vtexIdPvt: `http://vtexid.vtex.com.br/api/vtexid/pvt`,

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -23,7 +23,7 @@ interface CheckUserAuthenticationParams {
   email: string
 }
 
-export const checkUserAuthentication = async ({
+const checkUserAuthentication = async ({
   identity,
   storeUserAuthToken,
   email,

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -30,8 +30,6 @@ const checkUserAuthorization = async ({
 }: CheckUserAuthorizationParams) => {
   const userTokenData = await identity.getUserWithToken(storeUserAuthToken)
 
-  console.log(userTokenData, userTokenData?.user.length === email.length)
-
   let validUser = !!userTokenData && userTokenData.user.length === email.length
 
   for (let i = 0; i < email.length; i++) {

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -17,17 +17,17 @@ import {
 const TRUE = 'True'
 const FALSE = 'False'
 
-interface CheckUserAuthenticationParams {
+interface CheckUserAuthorizationParams {
   identity: IdentityDataSource
   storeUserAuthToken: IOContext['storeUserAuthToken']
   email: string
 }
 
-const checkUserAuthentication = async ({
+const checkUserAuthorization = async ({
   identity,
   storeUserAuthToken,
   email,
-}: CheckUserAuthenticationParams): Promise<boolean> => {
+}: CheckUserAuthorizationParams): Promise<boolean> => {
   let validUser = !!storeUserAuthToken
   let userTokenData: Partial<User> | null = { user: '' }
 
@@ -131,7 +131,7 @@ export const mutations = {
     if (userProfile.createdIn) {
       const { storeUserAuthToken } = context.vtex
 
-      updateData = await checkUserAuthentication({
+      updateData = await checkUserAuthorization({
         identity: context.dataSources.identity,
         storeUserAuthToken,
         email,

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -1,4 +1,4 @@
-import { AuthenticationError, ForbiddenError } from '@vtex/api'
+import { AuthenticationError, ForbiddenError, IOContext } from '@vtex/api'
 import { path } from 'ramda'
 import { MutationSaveAddressArgs } from 'vtex.store-graphql'
 
@@ -19,9 +19,7 @@ const TRUE = 'True'
 const FALSE = 'False'
 
 interface CheckUserAuthorizationParams {
-  account: string
-  storeUserAuthToken: string
-  ctx: any
+  ctx: IOContext
   email: string
 }
 
@@ -33,10 +31,9 @@ interface UserTokenData {
 
 const checkUserAuthorization = async ({
   ctx,
-  account,
-  storeUserAuthToken: authCookieStore,
   email,
 }: CheckUserAuthorizationParams) => {
+  const { account, storeUserAuthToken: authCookieStore } = ctx
   const url = paths.checkUserAuthorization({ account })
   const { data: userTokenData } = await makeRequest<UserTokenData | null>({
     ctx,
@@ -95,7 +92,7 @@ export const mutations = {
     { email, fields, isNewsletterOptIn }: SubscribeNewsletterArgs,
     context: Context
   ) => {
-    const { account, storeUserAuthToken } = context.vtex
+    const { storeUserAuthToken } = context.vtex
 
     if (!storeUserAuthToken) {
       throw new AuthenticationError('Unauthorized')
@@ -103,8 +100,6 @@ export const mutations = {
 
     checkUserAuthorization({
       ctx: context.vtex,
-      account,
-      storeUserAuthToken,
       email,
     })
 

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -52,7 +52,9 @@ const checkUserAuthorization = async ({
     }
   }
 
-  return validUser
+  if (!validUser) {
+    throw new ForbiddenError('Forbidden')
+  }
 }
 
 interface SubscribeNewsletterArgs {
@@ -99,16 +101,12 @@ export const mutations = {
       throw new AuthenticationError('Unauthorized')
     }
 
-    const validUser = await checkUserAuthorization({
+    checkUserAuthorization({
       ctx: context.vtex,
       account,
       storeUserAuthToken,
       email,
     })
-
-    if (!validUser) {
-      throw new ForbiddenError('Forbidden')
-    }
 
     const { profile } = context.clients
     const optIn =


### PR DESCRIPTION
#### What problem is this solving?
Add authorization to subscribeNewsletter resolver.

#### How to test it?
Fulfill the `<YOUR COOKIE HERE>` with your browser cookie and <BASE64 VARIABLES> with encoded base64 object with this pattern `"{\"isNewsletterOptIn\":true,\"email\":\"user-email-here\"}"`

```
curl --location --request POST 'https://brasileiro--storecomponents.myvtex.com/_v/private/graphql/v1?workspace=brasileiro&maxAge=long&appsEtag=remove&domain=store&locale=en-US&__bindingId=aacb06b3-a8fa-4bab-b5bd-2d654d20dcd8' \
--header 'pragma: no-cache' \
--header 'cache-control: no-cache' \
--header 'accept: */*' \
--header 'content-type: application/json' \
--header 'accept-language: pt,en-US;q=0.9,en;q=0.8,pt-PT;q=0.7' \
--header 'cookie: <YOUR COOKIE HERE>' \
--data-raw '{"operationName":"subscribeNewsletter","variables":{},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"83c5f3edc9d843eea51a375ddf3d7e98a524e7dbbcba78b1366faf00d8591a52","sender":"vtex.my-account@1.x","provider":"vtex.store-graphql@2.x"},"variables":"<BASE64 VARIABLES>"}}'
```

variables has this pattern: `"{\"isNewsletterOptIn\":true,\"email\":\"user-email-here\"}"`

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/l2QEkfoeSobA2YbOU/giphy.gif)
