### PR TITLE
change itemsWithSimulation scope and add x-vtex-user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `x-vtex-user-agent` to the checkout call.
+
+### Changed
+- `itemsWithSimulation` cache scope.
+
 ## [2.142.7] - 2021-07-20
 ### Added
 - Authorization to subscribeNewsletter resolver

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -561,7 +561,7 @@ type Query {
   checkProfileAllowed: UserCondition @cacheControl(scope: PRIVATE) @withSegment
 
   itemsWithSimulation(items: [ItemInput]): [SKU]
-    @cacheControl(scope: PRIVATE)
+    @cacheControl(scope: SEGMENT, maxAge: SHORT)
     @withSegment
 }
 

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -17,6 +17,7 @@ export class Checkout extends JanusClient {
         ...(ctx.storeUserAuthToken
           ? { VtexIdclientAutCookie: ctx.storeUserAuthToken }
           : null),
+        'x-vtex-user-agent': ctx.userAgent,
       },
     })
   }


### PR DESCRIPTION
#### What problem is this solving?

Currently the `itemsWithSimulation` query has a `private` scope this setting is causing a lot of unnecessary requests to the simulation API. This PR changes from `private` to the `segment` scope.

Also, it adds the `x-vtex-user-agent` header to the checkout calls, which is important to track the call origin.

#### How to test it?

[Workspace](https://hiago--carrefourbr.myvtex.com/)

Go to any PLP. The product prices are being returned by the `itemsWithSimulation` query.