### PR TITLE
Fix seller id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `sellerId` in `itemsWithSimulation` query that was using item ID.
+
 ## [2.143.0] - 2021-07-22
 
 ### Added

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -76,7 +76,7 @@ export const orderFormItemToSeller = (
   )
 
   return {
-    sellerId: orderFormItem.id,
+    sellerId: orderFormItem.seller,
     commertialOffer,
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

In the `itemsWithSimulation` query, the `sellerId` was being set with the value of the item ID:

![image](https://user-images.githubusercontent.com/20840671/128391443-ee9fc945-330d-4fff-8a1f-bfb1e85d3791.png)

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://regionalization--carrefourbr.myvtex.com/busca/galaxy%20tab%20a%20t290?&map=ft)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
