### PR TITLE
Added priceDefinition structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
-- Added `priceDefinition` structure on OrderForm.graphql an `priceDefinition` typings
+- `priceDefinition` property to `OrderFormItem` type  on OrderForm.graphql.
+- `priceDefinition` typings to `Checkout.ts`.
+
 ## [2.143.1] - 2021-08-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added `priceDefinition` structure on OrderForm.graphql an `priceDefinition` typings
 ## [2.143.1] - 2021-08-09
 
 ### Fixed

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -115,6 +115,18 @@ type OrderFormItem {
   """
   unitMultiplier: Float
   canHaveAttachment: Boolean
+  priceDefinition: PriceDefinition
+}
+
+type PriceDefinition {
+  calculatedSellingPrice: Float
+  sellingPrices: [SellingPrice]
+  total: Float
+}
+
+type SellingPrice {
+  quantity: Float
+  value: Float
 }
 
 type ItemAdditionalInfo {

--- a/node/typings/Checkout.ts
+++ b/node/typings/Checkout.ts
@@ -73,6 +73,16 @@ interface OrderFormItem {
   unitMultiplier: number
   assemblies: CheckoutAssemblyItem[]
   attachmentOfferings: CheckoutAttachmentOffering[]
+  priceDefinition: {
+    calculatedSellingPrice: number
+    sellingPrices: SellingPrice[]
+    total: number
+  }
+}
+
+interface SellingPrice {
+  quantity: number
+  value: number
 }
 
 interface InstallmentOption {


### PR DESCRIPTION
#### What problem is this solving?

Add checkout API priceDefinition structure

#### How to test it?

[Workspace](https://pricedefinition--vtexproject.myvtex.com/_v/private/vtex.store-graphql@2.143.1/graphiql/v1?query=query%20%7B%0A%20%20searchOrderForm%20(%0A%20%20%20%20orderFormId%3A%2278f1aa981882432993c6877bbaa7fdd2%22%0A%20%20)%20%7B%0A%20%20%20%20items%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20sellingPrice%0A%20%20%20%20%20%20priceDefinition%20%7B%0A%20%20%20%20%20%20%20%20calculatedSellingPrice%0A%20%20%20%20%20%20%20%20sellingPrices%20%7B%0A%20%20%20%20%20%20%20%20%20%20quantity%0A%20%20%20%20%20%20%20%20%20%20value%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20total%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/3091668/130143418-a12047f4-7f38-4359-bf46-273c5ac982f0.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/xT5LMHxhOfscxPfIfm/giphy.gif?cid=ecf05e47xx4bj7eo7sie3a4yvo4x62qbjzl9588pmltwwwjz&rid=giphy.gif&ct=g)
