### PR TITLE
Update cookie extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Extract session cookie in a safe manner
 
 ## [2.143.1] - 2021-08-09
 

--- a/node/clients/session.ts
+++ b/node/clients/session.ts
@@ -1,6 +1,5 @@
 import { JanusClient } from '@vtex/api'
 import parseCookie from 'cookie'
-import { prop } from 'ramda'
 
 interface VtexIdCookies {
   account: string | null
@@ -18,12 +17,7 @@ export class Session extends JanusClient {
    * Get the session data using the given token
    */
   public getSession = async (token: string, items: string[]) => {
-    const {
-      data: sessionData,
-      headers: {
-        'set-cookie': [setCookies],
-      },
-    } = await this.http.getRaw(routes.base, {
+    const { data: sessionData, headers } = await this.http.getRaw(routes.base, {
       headers: {
         'Content-Type': 'application/json',
         Cookie: `vtex_session=${token};`,
@@ -34,12 +28,9 @@ export class Session extends JanusClient {
       },
     })
 
-    const parsedCookie = parseCookie.parse(setCookies)
-    const sessionToken = prop(SESSION_COOKIE, parsedCookie)
-
     return {
       sessionData,
-      sessionToken,
+      sessionToken: extractSessionCookie(headers) ?? token,
     }
   }
 
@@ -77,4 +68,17 @@ export class Session extends JanusClient {
 
     return this.http.post(routes.base, data, config)
   }
+}
+
+function extractSessionCookie(headers: Record<string, string>) {
+  for (const setCookie of headers['set-cookie'] ?? []) {
+    const parsedCookie = parseCookie.parse(setCookie)
+    const sessionCookie = parsedCookie[SESSION_COOKIE]
+
+    if (sessionCookie != null) {
+      return sessionCookie
+    }
+  }
+
+  return null
 }


### PR DESCRIPTION
#### What problem is this solving?

Session cookie being extracted in a safe manner.

The session cookie extraction relied on the fact that the responses always came with the Set-Cookie header.
When Janus stopped setting its janus-sid cookie, there was no Set-Cookie present in the response.

This caused IO to be down for almost an hour.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

- [Als](https://victormiranda--alssports.myvtex.com/clothing/hoodies---sweatshirts/Womens?map=c,c,specificationFilter_7721)
- [Umbro](https://victormiranda--umbro.myvtex.com/)
- [Store Components](https://victormiranda--storecomponents.myvtex.com/apparel---accessories/)
- [Red Oxx](https://victormiranda--redoxx.myvtex.com/)
- [New Balance](https://victormiranda--newbalance.myvtex.com/tenis-new-balance-574-casual-masculino-ml574bi2/p?skuId=387084)
- [Motorola US](https://victormiranda--motorolaus.myvtex.com/)
- [Motorola ES](https://victormiranda--motorolaes.myvtex.com/)
- [Garmin](https://victormiranda--garmin.myvtex.com/relogio-garmin-venu-2-cinza-chumbo-pulseira-preta-ww-monitor-cardiaco-de-pulso-com-gps/p)
- [Boticário PT](https://victormiranda--btpt.myvtex.com/historia)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
