### PR TITLE
[USAAPPTEAM-32] Show distance on pickup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `pickupDistance` to ShippingSLA graphql type
+
+## [2.146.0] - 2021-09-02
+
+### Fixed
+- Use `unitMultiplier` to calculate the price.
+
+### Added
+- Add utmi campaign to the simulation request.
+- `regionId` to `itemsWithSimulation` query.
+
 ## [2.145.2] - 2021-09-01
 ### Changed
 - Attempt to clear profile data on orderForms with app ID in email.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 ## [2.146.0] - 2021-09-02
 
@@ -24,6 +25,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.145.2] - 2021-09-01
 ### Changed
 - Attempt to clear profile data on orderForms with app ID in email.
+=======
+### Added
+- `pickupDistance` to ShippingSLA graphql type
+>>>>>>> [USAAPPTEAM-32] Show distance on pickup
 ## [2.145.1] - 2021-09-01
 ### Fixed
 - Broken orderForms with app ID in `clientProfileData.email`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+<<<<<<< HEAD
 
 ## [2.146.0] - 2021-09-02
 
@@ -16,10 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add utmi campaign to the simulation request.
 - `regionId` to `itemsWithSimulation` query.
 
+=======
+### Added
+- `pickupDistance` to ShippingSLA graphql type
+>>>>>>> [USAAPPTEAM-32] Show distance on pickup
 ## [2.145.2] - 2021-09-01
 ### Changed
 - Attempt to clear profile data on orderForms with app ID in email.
-
 ## [2.145.1] - 2021-09-01
 ### Fixed
 - Broken orderForms with app ID in `clientProfileData.email`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.145.2] - 2021-09-01
 ### Changed
 - Attempt to clear profile data on orderForms with app ID in email.
+
 ## [2.145.1] - 2021-09-01
 ### Fixed
 - Broken orderForms with app ID in `clientProfileData.email`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-## [2.146.0] - 2021-09-02
-
-### Fixed
-- Use `unitMultiplier` to calculate the price.
-
-### Added
-- Add utmi campaign to the simulation request.
-- `regionId` to `itemsWithSimulation` query.
-
-=======
 ### Added
 - `pickupDistance` to ShippingSLA graphql type
->>>>>>> [USAAPPTEAM-32] Show distance on pickup
 ## [2.145.2] - 2021-09-01
 ### Changed
 - Attempt to clear profile data on orderForms with app ID in email.
-=======
-### Added
-- `pickupDistance` to ShippingSLA graphql type
->>>>>>> [USAAPPTEAM-32] Show distance on pickup
 ## [2.145.1] - 2021-09-01
 ### Fixed
 - Broken orderForms with app ID in `clientProfileData.email`.

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -34,6 +34,7 @@ type ShippingSLA {
   friendlyName: String
   pickupPointId: String
   pickupStoreInfo: pickupStoreInfo
+  pickupDistance: Float
 }
 
 type pickupStoreInfo {


### PR DESCRIPTION
#### What problem is this solving?
A T1 customer wants to show the distance from the customer to the Store, this PR adds this field to a type we're using on the App, the information is already available by the API and resolver, no need to do extra development

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://wender--eriksbikeshop.myvtex.com/_v/private/vtex.store-graphql@2.145.1/graphiql/v1?variables=%7B%0A%20%20%22items%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22quantity%22%3A%20%221%22%2C%0A%20%20%20%20%20%20%22id%22%3A%20%228055383%22%2C%0A%20%20%20%20%20%20%22seller%22%3A%20%221%22%0A%20%20%20%20%7D%0A%20%20%5D%2C%0A%20%20%22postalCode%22%3A%20%2255408%22%2C%0A%20%20%22country%22%3A%20%22USA%22%0A%7D&operationName=getShippingEstimates&query=query%20getShippingEstimates(%24items%3A%20%5BShippingItem%5D%2C%20%24postalCode%3A%20String%2C%20%24country%3A%20String)%20%7B%0A%20%20shipping(items%3A%20%24items%2C%20postalCode%3A%20%24postalCode%2C%20country%3A%20%24country)%20%7B%0A%20%20%20%20logisticsInfo%20%7B%0A%20%20%20%20%20%20itemIndex%0A%20%20%20%20%20%20slas%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20friendlyName%0A%20%20%20%20%20%20%20%20price%0A%20%20%20%20%20%20%20%20shippingEstimate%0A%20%20%20%20%20%20%20%20shippingEstimateDate%0A%20%20%20%20%20%20%20%20pickupDistance%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A)

#### Screenshots or example usage:
![image](https://user-images.githubusercontent.com/24723/131740659-d4ef58f2-7cc4-4d04-a3ca-3a2e68ddb210.png)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

[Jira Task](https://vtex-dev.atlassian.net/browse/AVAILABLE-2)
<!--- Optional -->
