### PR TITLE
add spot price to the itemsWithSimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add `spotPrice` to the `itemsWithSimulation` response.
+
 ## [2.146.0] - 2021-09-02
 
 ### Fixed

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -126,6 +126,7 @@ interface CommertialOffer {
   }>
   GetInfoErrorMessage: any | null
   CacheVersionUsedToCallCheckout: string
+  spotPrice: number
 }
 
 interface Seller {

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -61,6 +61,14 @@ export const getSimulationPayloadsByItem = (
   })
 }
 
+export const getSpotPrice = (offer: CommertialOffer) => {
+  const sellingPrice = offer.Price
+  const spotPrice: number | undefined = offer.Installments.find(({NumberOfInstallments, Value}) => {
+    return (NumberOfInstallments === 1 && Value < sellingPrice)
+  })?.Value;
+  return spotPrice || sellingPrice
+}
+
 export const orderFormItemToSeller = (
   orderFormItem: OrderFormItem & {
     paymentData: any
@@ -115,6 +123,8 @@ export const orderFormItemToSeller = (
       } as Installment)
     })
   )
+
+  commertialOffer.spotPrice = getSpotPrice(commertialOffer)
 
   return {
     sellerId: orderFormItem.seller,


### PR DESCRIPTION
#### What problem is this solving?

Add the `sportPrice` field to the `itemsWithSimulation` query.

#### How to test it?

[Workspace](https://hiago--carrefourbr.myvtex.com/)

```
curl --request POST \
  --url 'https://hiago--carrefourbr.myvtex.com/_v/private/graphql/v1?sc=1' \
  --header 'Content-Type: application/json' \
  --data '{"query":"query itemsWithSimulation($items: [ItemInput]) {\n  itemsWithSimulation(items: $items)@context(provider: \"vtex.store-graphql\") {\n    itemId\n    sellers {\n      commertialOffer {\n        spotPrice\n      }\n    }\n  }\n}","variables":{"items":[{"itemId":"4209049","sellers":[{"sellerId":"1"}]}]},"operationName":"itemsWithSimulation"}'
```
