### PR TITLE
feat: add totals field in simulation order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- added totals values in graphql schema for simulate order
 
 ## [2.146.0] - 2021-09-02
 

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -86,14 +86,14 @@ type LogisticsItem {
   availability: String
 }
 
-type Totals {
-  id: String
-  name: String
-  value: Int
-}
-
 input ShippingItem {
   id: String
   quantity: String
   seller: String
+}
+
+type Totals {
+  id: String
+  name: String
+  value: Int
 }

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -2,6 +2,7 @@ type ShippingData {
   items: [LogisticsItem]
   logisticsInfo: [LogisticsInfo]
   messages: [MessageInfo]
+  totals: [Totals]
 }
 
 type MessageInfo {
@@ -83,6 +84,12 @@ type LogisticsItem {
   measurementUnit: String
   unitMultiplier: Int
   availability: String
+}
+
+type Totals {
+  id: String
+  name: String
+  value: Int
 }
 
 input ShippingItem {


### PR DESCRIPTION
#### What problem is this solving?

The query `shipping()` doesn't have the **totals**  field that comes in the native simulation service of VTEX

#### Motivation of PR 

in case of used a list of products to simulate, you can use total instead of calculate with each selling prices in FrontEnd. 

![image](https://user-images.githubusercontent.com/33559104/132565265-ca300e9c-0dc7-42b4-ab25-934e2b8af2eb.png)
