### PR TITLE
change pvtCheckout timeout config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `pvtCheckout` timeout config.
+
 ## [2.146.1] - 2021-09-14
 ### Added
 - `pickupDistance` to ShippingSLA graphql type

--- a/node/index.ts
+++ b/node/index.ts
@@ -31,6 +31,9 @@ export default new Service<Clients, void, CustomContext>({
         concurrency: 10,
         timeout: THIRTY_SECONDS_MS,
       },
+      pvtCheckout: {
+        timeout: THREE_SECONDS_MS,
+      },
       default: {
         retries: 2,
         timeout: THREE_SECONDS_MS,


### PR DESCRIPTION
#### What problem is this solving?

We were facing a lot of simulation timeout errors on `vtex.search-resolver@1.54.0`. This PR  fixes the problem by setting `{timeout: 9000ms, retries: 0}` on [`search-resolver`](https://github.com/vtex-apps/search-resolver/pull/255) and `{timeout: 3000ms, retries 2}` on `store-graphql`.

#### How should this be manually tested?

[Workspace](https://hiago--rihappynovo.myvtex.com/)

#### Related to / Depends on

- https://github.com/vtex-apps/search-resolver/pull/255
