### PR TITLE
handle error on itemsWithSimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `itemsWithSimulation` stuck when there is a simulation error.
+- Catch `itemsWithSimulation` errors by seller.
+
 ## [2.146.1] - 2021-09-14
 ### Added
 - `pickupDistance` to ShippingSLA graphql type


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes two problems:

1. When the simulation API returns an error the `store-graphql` request get stuck until it hits the timeout. This is happening because the error is throw inside a promise.
2. When there is more than one seller and one of them returns an error, the `itemsWithSimulation` query is not returning any of them.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--rihappynovo.myvtex.com/)

