### PR TITLE
Fix default orderBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `orderBy` default value.
+
 ## [2.147.0] - 2021-10-18
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -49,9 +49,9 @@ type Query {
     """
     salesChannel: String = ""
     """
-    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC
+    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC, OrderByScoreDESC
     """
-    orderBy: String = "OrderByPriceDESC"
+    orderBy: String = "OrderByScoreDESC"
     """
     Pagination item start
     """
@@ -116,9 +116,9 @@ type Query {
     """
     salesChannel: String = ""
     """
-    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC
+    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC, OrderByScoreDESC
     """
-    orderBy: String = "OrderByPriceDESC"
+    orderBy: String = "OrderByScoreDESC"
     """
     Pagination item start
     """


### PR DESCRIPTION
#### What problem is this solving?

Currently the default ordering in our components and in our documentation is by score (relevance) but in the schema, the default ordering was still by price.
this doesn't affect any store because all stores that use it via GraphQL today already define the ordering that should be used


<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--storecomponents.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
