### PR TITLE
Add salesChannel to itemsWithSimulation query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `salesChannel` argument to `itemsWithSimulation`.
+
 ## [2.146.2] - 2021-10-05
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -560,9 +560,11 @@ type Query {
 
   checkProfileAllowed: UserCondition @cacheControl(scope: PRIVATE) @withSegment
 
-  itemsWithSimulation(items: [ItemInput], regionId: String): [SKU]
-    @cacheControl(scope: SEGMENT, maxAge: SHORT)
-    @withSegment
+  itemsWithSimulation(
+    items: [ItemInput]
+    regionId: String
+    salesChannel: String
+  ): [SKU] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 }
 
 type Mutation {

--- a/node/clients/PvtCheckout.ts
+++ b/node/clients/PvtCheckout.ts
@@ -35,17 +35,16 @@ export class PvtCheckout extends JanusClient {
     }
   }
 
-  private getChannelQueryString = () => {
+  private getChannelQueryString = (salesChannel?: string) => {
     const { segment } = this.context as CustomIOContext
-    const channel = segment?.channel
-    const queryString = channel ? `?sc=${channel}` : ''
+    const channel = salesChannel ?? segment?.channel
 
-    return queryString
+    return channel ? `?sc=${channel}` : ''
   }
 
-  public simulation = (simulation: SimulationPayload) =>
+  public simulation = (simulation: SimulationPayload, salesChannel?: string) =>
     this.post<SimulationOrderForm>(
-      this.routes.simulation(this.getChannelQueryString()),
+      this.routes.simulation(this.getChannelQueryString(salesChannel)),
       simulation,
       {
         metric: 'pvt-checkout-simulation',


### PR DESCRIPTION
#### What problem is this solving?
Some stores don't have the `segment` cookie or want to use different info than the cookie, so they use search passing `regionId` and `salesChannel` as parameters. 
However, now that the `search-resolver` uses the `itemsWithSimulation` query to get the simulation info for a product, we weren't passing the `salesChannel` to the simulation like we do with the `regionId`,  so simulation was always getting the salesChannel from segment, instead of using the one the store provides as an argument to `productSearch`.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--jumbo.myvtex.com/admin/graphql-ide)

#### Screenshots or example usage:

If you try to use a different trade policy (AKA sales channel), it should return the price of the sales channel you used, instead of returning the price of the sales channel from the segment (in this case, 1)

[Before](https://thalyta1--jumbo.myvtex.com/admin/graphql-ide): (wrong price, from salesChannel 1)
![image](https://user-images.githubusercontent.com/20840671/137498559-8c0aa792-4d9e-40a7-b9c6-291673ec27e3.png)


After: (price from sales channel 50)
![image](https://user-images.githubusercontent.com/20840671/137497366-5cdf0673-3fef-4197-bd80-2956344ef789.png)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
