### PR TITLE
Add trustedAccounts to settingsSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use `storeUserAuthToken` to call new identity API.
 
 ## [2.148.0] - 2021-11-23
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -703,7 +703,7 @@ type Mutation {
     email: String
     isNewsletterOptIn: Boolean
     fields: NewsletterFieldsInput
-  ): Boolean @cacheControl(scope: PRIVATE)
+  ): Boolean @withCurrentProfile @cacheControl(scope: PRIVATE)
 
   """
   Order Form

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,21 @@
     "vtex.catalog-api-proxy": "0.x",
     "vtex.file-manager": "0.x"
   },
+  "settingsSchema": {
+    "title": "VTEX Store Graphql",
+    "type": "object",
+    "properties": {
+      "trustedAccounts": {
+        "title": "Trusted accounts",
+        "type": "array",
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "description": "Enter trusted account names"
+      }
+    }
+  },
   "policies": [
     {
       "name": "outbound-access",

--- a/node/clients/profile.ts
+++ b/node/clients/profile.ts
@@ -21,7 +21,7 @@ export class ProfileClient extends JanusClient {
       ...options,
       headers: {
         ...(options && options.headers),
-        VtexIdClientAutCookie: context.storeUserAuthToken ?? '',
+        VtexIdClientAutCookie: context.authToken ?? '',
       },
       params: { an: context.account },
       timeout: FIVE_SECONDS_MS,

--- a/node/clients/profile.ts
+++ b/node/clients/profile.ts
@@ -21,7 +21,7 @@ export class ProfileClient extends JanusClient {
       ...options,
       headers: {
         ...(options && options.headers),
-        VtexIdClientAutCookie: context.authToken,
+        VtexIdClientAutCookie: context.storeUserAuthToken ?? '',
       },
       timeout: FIVE_SECONDS_MS,
     })

--- a/node/clients/profile.ts
+++ b/node/clients/profile.ts
@@ -23,6 +23,7 @@ export class ProfileClient extends JanusClient {
         ...(options && options.headers),
         VtexIdClientAutCookie: context.storeUserAuthToken ?? '',
       },
+      params: { an: context.account },
       timeout: FIVE_SECONDS_MS,
     })
   }

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -1,5 +1,5 @@
 import { parse as parseCookie } from 'cookie'
-import { defaultFieldResolver, GraphQLField } from 'graphql'
+import { defaultFieldResolver, GraphQLField, GraphQLResolveInfo } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 import jwtDecode from 'jwt-decode'
 import { AuthenticationError, ResolverError } from '@vtex/api'
@@ -22,43 +22,9 @@ export class WithCurrentProfile extends SchemaDirectiveVisitor {
         return null
       }
 
-      const {
-        vtex: { storeUserAuthToken, adminUserAuthToken, account },
-        dataSources: { identity },
-      } = context
-
-      const tokenUser = await identity.getUserWithToken(
-        storeUserAuthToken ?? adminUserAuthToken ?? ''
-      )
-
-      if (tokenUser.account !== account) {
-        const {
-          fieldName,
-          returnType,
-          operation: { operation, name },
-        } = info
-
-        const {
-          vtex: { logger, host },
-          req: {
-            headers: { 'user-agent': userAgent, referer },
-          },
-        } = context
-
-        const logData = {
-          host,
-          referer,
-          userAgent,
-          message: 'Type: CrossTokenAccount',
-          account,
-          tokenAccount: tokenUser.account ?? '',
-          caller: tokenUser.user ?? '',
-          fieldName,
-          fieldType: (returnType as any).name,
-          operation: name?.value ? `${operation} ${name?.value}` : operation,
-        }
-
-        logger.warn(logData)
+      // If current profile doesn't exist, a new profile will be created. Don't need check it
+      if (currentProfile) {
+        await checkUserAccount(context, currentProfile, info)
       }
 
       context.vtex.currentProfile = await validatedProfile(
@@ -184,4 +150,61 @@ function isValidCallcenterOperator(context: Context, email: string) {
 
 function isLogged(currentProfile: CurrentProfile | null) {
   return currentProfile && currentProfile.email
+}
+
+async function checkUserAccount(
+  context: Context,
+  userProfile: CurrentProfile,
+  resolverInfo: GraphQLResolveInfo
+) {
+  const {
+    dataSources: { identity },
+    vtex: { adminUserAuthToken, storeUserAuthToken, account },
+  } = context
+
+  if (!adminUserAuthToken && !storeUserAuthToken) {
+    throw new AuthenticationError('')
+  }
+
+  const tokenUser = await identity.getUserWithToken(
+    storeUserAuthToken! ?? adminUserAuthToken!
+  )
+
+  if (tokenUser && 'id' in tokenUser && tokenUser.account !== account) {
+    const {
+      fieldName,
+      returnType,
+      operation: { operation, name },
+    } = resolverInfo
+
+    const {
+      vtex: { logger, host },
+      req: {
+        headers: { 'user-agent': userAgent, referer },
+      },
+    } = context
+
+    const logData = {
+      host,
+      referer,
+      userAgent,
+      message: 'Type: CrossTokenAccount',
+      account,
+      tokenAccount: tokenUser.account ?? '',
+      caller: tokenUser.user ?? '',
+      fieldName,
+      fieldType: (returnType as any).name,
+      operation: name?.value ? `${operation} ${name?.value}` : operation,
+    }
+
+    logger.warn(logData)
+  }
+
+  if (
+    tokenUser &&
+    'id' in tokenUser &&
+    (tokenUser.account !== account || tokenUser.user !== userProfile.email)
+  ) {
+    throw new AuthenticationError('')
+  }
 }

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -7,7 +7,6 @@ import { AuthenticationError, ResolverError } from '@vtex/api'
 import { getSession } from '../resolvers/session/service'
 import { SessionFields } from '../resolvers/session/sessionResolver'
 import { allowedAccounts } from '../utils/allowListAccounts'
-import type { AccountName } from '../utils/allowListAccounts'
 
 export class WithCurrentProfile extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
@@ -202,11 +201,16 @@ async function checkUserAccount(
     logger.warn(logData)
   }
 
+  const allowedAccount = await allowedAccounts(
+    context,
+    'account' in tokenUser ? tokenUser.account : ''
+  )
+
   if (
     tokenUser &&
     'id' in tokenUser &&
     // check if account exists in allow list and the user token account exists for that account.
-    !allowedAccounts(account as AccountName, tokenUser.account) &&
+    !allowedAccount &&
     (tokenUser.account !== account || tokenUser.user !== userProfile.email)
   ) {
     throw new AuthenticationError('')

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -210,8 +210,10 @@ async function checkUserAccount(
     tokenUser &&
     'id' in tokenUser &&
     // check if account exists in allow list and the user token account exists for that account.
-    !allowedAccount &&
-    (tokenUser.account !== account || tokenUser.user !== userProfile.email)
+    !(
+      (allowedAccount || tokenUser.account === account) &&
+      tokenUser.user === userProfile.email
+    )
   ) {
     throw new AuthenticationError('')
   }

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -6,6 +6,8 @@ import { AuthenticationError, ResolverError } from '@vtex/api'
 
 import { getSession } from '../resolvers/session/service'
 import { SessionFields } from '../resolvers/session/sessionResolver'
+import { allowedAccounts } from '../utils/allowListAccounts'
+import type { AccountName } from '../utils/allowListAccounts'
 
 export class WithCurrentProfile extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
@@ -203,6 +205,8 @@ async function checkUserAccount(
   if (
     tokenUser &&
     'id' in tokenUser &&
+    // check if account exists in allow list and the user token account exists for that account.
+    !allowedAccounts(account as AccountName, tokenUser.account) &&
     (tokenUser.account !== account || tokenUser.user !== userProfile.email)
   ) {
     throw new AuthenticationError('')

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -23,7 +23,7 @@ export class WithCurrentProfile extends SchemaDirectiveVisitor {
         return null
       }
 
-      // If current profile doesn't exist, a new profile will be created. Don't need check it
+      // If the current profile doesn't exist, a new profile will be created, there is no need to check it
       if (currentProfile) {
         await checkUserAccount(context, currentProfile, info)
       }

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -2,7 +2,7 @@ import { path } from 'ramda'
 import { MutationSaveAddressArgs } from 'vtex.store-graphql'
 
 import type { User } from '../../dataSources/identity'
-import { allowedAccounts } from '../../utils/allowListAccounts'
+import { isTrustedAccount } from '../../utils/trustedAccounts'
 import fieldR from './fieldResolvers'
 import {
   createAddress,
@@ -35,7 +35,7 @@ const checkUserAuthorization = async ({
 
   const tokenUser = await identity.getUserWithToken(storeUserAuthToken ?? '')
 
-  const allowedAccount = await allowedAccounts(
+  const trustedAccount = await isTrustedAccount(
     context,
     'account' in tokenUser ? tokenUser.account : ''
   )
@@ -44,7 +44,7 @@ const checkUserAuthorization = async ({
     validUser &&
     Boolean(tokenUser) &&
     'id' in tokenUser &&
-    (allowedAccount || tokenUser.account === account) &&
+    (trustedAccount || tokenUser.account === account) &&
     tokenUser.user.length === email.length
 
   for (let i = 0; i < email.length; i++) {

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -31,20 +31,20 @@ const checkUserAuthorization = async ({
   account,
 }: CheckUserAuthorizationParams): Promise<boolean> => {
   let validUser = !!storeUserAuthToken
-  let userTokenData: Partial<User> | null = { user: '' }
 
-  if (storeUserAuthToken) {
-    userTokenData = await identity.getUserWithToken(storeUserAuthToken ?? '')
-  }
+  const userTokenData = await identity.getUserWithToken(
+    storeUserAuthToken ?? ''
+  )
 
   validUser =
     validUser &&
-    !!userTokenData &&
+    Boolean(userTokenData) &&
+    'id' in userTokenData &&
     userTokenData?.user?.length === email.length &&
     userTokenData.account === account
 
   for (let i = 0; i < email.length; i++) {
-    if (email[i] !== userTokenData?.user?.[i]) {
+    if (validUser && email[i] !== (userTokenData as User)?.user?.[i]) {
       validUser = false
     }
   }

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -44,7 +44,7 @@ const checkUserAuthorization = async ({
     validUser &&
     Boolean(tokenUser) &&
     'id' in tokenUser &&
-    (!allowedAccount || tokenUser.account === account) &&
+    (allowedAccount || tokenUser.account === account) &&
     tokenUser.user.length === email.length
 
   for (let i = 0; i < email.length; i++) {

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -3,6 +3,7 @@ import { path } from 'ramda'
 import { MutationSaveAddressArgs } from 'vtex.store-graphql'
 
 import type { IdentityDataSource, User } from '../../dataSources/identity'
+import { AccountName, allowedAccounts } from '../../utils/allowListAccounts'
 import fieldR from './fieldResolvers'
 import {
   createAddress,
@@ -40,6 +41,7 @@ const checkUserAuthorization = async ({
     validUser &&
     Boolean(userTokenData) &&
     'id' in userTokenData &&
+    !allowedAccounts(account as AccountName, userTokenData.account) &&
     userTokenData?.user?.length === email.length &&
     userTokenData.account === account
 

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -34,10 +34,7 @@ const checkUserAuthorization = async ({
   let userTokenData: Partial<User> | null = { user: '' }
 
   if (storeUserAuthToken) {
-    userTokenData = await identity.getUserWithToken({
-      token: storeUserAuthToken,
-      account,
-    })
+    userTokenData = await identity.getUserWithToken(storeUserAuthToken ?? '')
   }
 
   validUser =

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -41,7 +41,10 @@ const checkUserAuthorization = async ({
   }
 
   validUser =
-    validUser && !!userTokenData && userTokenData?.user?.length === email.length
+    validUser &&
+    !!userTokenData &&
+    userTokenData?.user?.length === email.length &&
+    userTokenData.account === account
 
   for (let i = 0; i < email.length; i++) {
     if (email[i] !== userTokenData?.user?.[i]) {

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -9,24 +9,12 @@ import paths from '../paths'
 export async function getProfile(context: Context, customFields?: string) {
   const {
     clients: { profile },
-    vtex: { currentProfile, storeUserAuthToken, account },
-    dataSources: { identity },
+    vtex: { currentProfile },
   } = context
 
   const extraFields = customFields
     ? `${customFields},profilePicture,id`
     : `profilePicture,id`
-
-  const identityProfile = await identity.getUserWithToken(
-    storeUserAuthToken ?? ''
-  )
-
-  if (
-    !identityProfile ||
-    ('account' in identityProfile && identityProfile.account !== account)
-  ) {
-    return { email: currentProfile.email }
-  }
 
   return profile
     .getProfileInfo(currentProfile, extraFields)

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -17,12 +17,14 @@ export async function getProfile(context: Context, customFields?: string) {
     ? `${customFields},profilePicture,id`
     : `profilePicture,id`
 
-  const identityProfile = await identity.getUserWithToken({
-    token: storeUserAuthToken ?? '',
-    account,
-  })
+  const identityProfile = await identity.getUserWithToken(
+    storeUserAuthToken ?? ''
+  )
 
-  if (!identityProfile || identityProfile.account !== account) {
+  if (
+    !identityProfile ||
+    ('account' in identityProfile && identityProfile.account !== account)
+  ) {
     return { email: currentProfile.email }
   }
 

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -6,15 +6,25 @@ import { generateRandomName } from '../../utils'
 import { makeRequest } from '../auth'
 import paths from '../paths'
 
-export function getProfile(context: Context, customFields?: string) {
+export async function getProfile(context: Context, customFields?: string) {
   const {
     clients: { profile },
-    vtex: { currentProfile },
+    vtex: { currentProfile, storeUserAuthToken, account },
+    dataSources: { identity },
   } = context
 
   const extraFields = customFields
     ? `${customFields},profilePicture,id`
     : `profilePicture,id`
+
+  const identityProfile = await identity.getUserWithToken({
+    token: storeUserAuthToken ?? '',
+    account,
+  })
+
+  if (!identityProfile || identityProfile.account !== account) {
+    return { email: currentProfile.email }
+  }
 
   return profile
     .getProfileInfo(currentProfile, extraFields)

--- a/node/utils/allowListAccounts.ts
+++ b/node/utils/allowListAccounts.ts
@@ -1,15 +1,21 @@
-export type AccountName = 'drogariasaopaulo' | 'fabula' | 'animale'
+const appName = process.env.VTEX_APP_ID as string
 
-const AccountMapAllowList = new Map<AccountName, Set<string>>()
+interface StoreGraphQLSettings {
+  trustedAccounts?: string[]
+}
 
-AccountMapAllowList.set('drogariasaopaulo', new Set(['drogariasp']))
-AccountMapAllowList.set('fabula', new Set(['lojafabula']))
-AccountMapAllowList.set('animale', new Set(['lojaanimale']))
-
-export const allowedAccounts = (account: AccountName, tokenAccount: string) => {
+export const allowedAccounts = async (
+  context: Context,
+  tokenAccount: string
+) => {
   // check if account exists in allow list and the user token account exists for that account.
-  return (
-    AccountMapAllowList.has(account) &&
-    AccountMapAllowList.get(account)?.has(tokenAccount)
-  )
+  const appSettings = (await context.clients.apps.getAppSettings(
+    appName
+  )) as StoreGraphQLSettings
+
+  if (!appSettings?.trustedAccounts) {
+    return false
+  }
+
+  return appSettings.trustedAccounts.includes(tokenAccount)
 }

--- a/node/utils/allowListAccounts.ts
+++ b/node/utils/allowListAccounts.ts
@@ -1,0 +1,15 @@
+export type AccountName = 'drogariasaopaulo' | 'fabula' | 'animale'
+
+const AccountMapAllowList = new Map<AccountName, Set<string>>()
+
+AccountMapAllowList.set('drogariasaopaulo', new Set(['drogariasp']))
+AccountMapAllowList.set('fabula', new Set(['lojafabula']))
+AccountMapAllowList.set('animale', new Set(['lojaanimale']))
+
+export const allowedAccounts = (account: AccountName, tokenAccount: string) => {
+  // check if account exists in allow list and the user token account exists for that account.
+  return (
+    AccountMapAllowList.has(account) &&
+    AccountMapAllowList.get(account)?.has(tokenAccount)
+  )
+}

--- a/node/utils/allowListAccounts.ts
+++ b/node/utils/allowListAccounts.ts
@@ -9,13 +9,10 @@ export const allowedAccounts = async (
   tokenAccount: string
 ) => {
   // check if account exists in allow list and the user token account exists for that account.
-  const appSettings = (await context.clients.apps.getAppSettings(
-    appName
-  )) as StoreGraphQLSettings
+  const trustedAccounts: string[] =
+    ((await context.clients.apps.getAppSettings(
+      appName
+    )) as StoreGraphQLSettings).trustedAccounts ?? []
 
-  if (!appSettings?.trustedAccounts) {
-    return false
-  }
-
-  return appSettings.trustedAccounts.includes(tokenAccount)
+  return trustedAccounts.includes(tokenAccount)
 }

--- a/node/utils/trustedAccounts.ts
+++ b/node/utils/trustedAccounts.ts
@@ -8,7 +8,6 @@ export const isTrustedAccount = async (
   context: Context,
   tokenAccount: string
 ) => {
-  // check if account exists in allow list and the user token account exists for that account.
   const trustedAccounts: string[] =
     ((await context.clients.apps.getAppSettings(
       appName

--- a/node/utils/trustedAccounts.ts
+++ b/node/utils/trustedAccounts.ts
@@ -4,7 +4,7 @@ interface StoreGraphQLSettings {
   trustedAccounts?: string[]
 }
 
-export const allowedAccounts = async (
+export const isTrustedAccount = async (
   context: Context,
   tokenAccount: string
 ) => {


### PR DESCRIPTION
#### What problem is this solving?
This PR adds a new feature that allows the setup of trusted accounts. To accomplish this feature, this pr adds:
- trustedAccounts app settings
- trustedAccounts on withCurrentProfile and newsletter

#### How to test it?
[Workspace](https://storetheme.vtex.com?workspace=brasileiro)
Try to fetch profile data from different users. 

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
