### PR TITLE
fix: Remove withCurrentProfile directive from subscribeNewsletter mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- `withCurrentProfile` directive from `subscribeNewsletter` mutation.
 
 ## [2.149.2] - 2022-01-12
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -703,7 +703,7 @@ type Mutation {
     email: String
     isNewsletterOptIn: Boolean
     fields: NewsletterFieldsInput
-  ): Boolean @withCurrentProfile @cacheControl(scope: PRIVATE)
+  ): Boolean @cacheControl(scope: PRIVATE)
 
   """
   Order Form

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -1,7 +1,7 @@
 import { path } from 'ramda'
 import { MutationSaveAddressArgs } from 'vtex.store-graphql'
 
-import type { User } from '../../dataSources/identity'
+import type { DefaultUser, User } from '../../dataSources/identity'
 import fieldR from './fieldResolvers'
 import {
   createAddress,
@@ -32,7 +32,11 @@ const checkUserAuthorization = async ({
 
   let validUser = !!storeUserAuthToken
 
-  const tokenUser = await identity.getUserWithToken(storeUserAuthToken ?? '')
+  const tokenUser = await identity
+    .getUserWithToken(storeUserAuthToken ?? '')
+    .catch(() => {
+      return { authStatus: '' } as DefaultUser
+    })
 
   validUser =
     validUser &&


### PR DESCRIPTION
#### What problem is this solving?
Allow new users subscribe to the newsletter without being authenticated.

#### How to test it?

[Workspace](https://storetheme.vtex.com/?workspace=brasileiro)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
