### PR TITLE
Adding new PII Profile System Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added support for the new Profile System that has to be used if an account is PII enabled
+
 ## [2.149.3] - 2022-03-03
 ### Removed
 - `withCurrentProfile` directive from `subscribeNewsletter` mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Added support for the new Profile System that has to be used if an account is PII enabled
+- support for the new Profile System that has to be used if an account is PII enabled
 
 ## [2.149.4] - 2022-03-24
 

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -91,6 +91,10 @@ type Profile {
   User's last password update time
   """
   passwordLastUpdate: String
+  """
+  Shows if PII is being audited
+  """
+  pii: Boolean
 }
 
 """

--- a/manifest.json
+++ b/manifest.json
@@ -169,6 +169,13 @@
     {
       "name": "outbound-access",
       "attrs": {
+        "host": "profile-system-beta.vtex.systems",
+        "path": "/api/profile-system/profiles/*"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
         "host": "profile-system-eu-west-1.vtex.systems",
         "path": "/api/profile-system/profiles/*"
       }

--- a/manifest.json
+++ b/manifest.json
@@ -158,6 +158,22 @@
       "name": "vtex.file-manager:file-manager-read-write"
     },
     {
+      "name": "GetItemResource"
+    },
+    {
+      "name": "PutItemResource"
+    },
+    {
+      "name": "DeleteItemResource"
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "profile-system-beta.vtex.systems",
+        "path": "/api/profile-system/profiles/*"
+      }
+    },
+    {
       "name": "outbound-access",
       "attrs": {
         "host": "portal.vtexcommercestable.com.br",

--- a/manifest.json
+++ b/manifest.json
@@ -169,7 +169,14 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "profile-system-beta.vtex.systems",
+        "host": "profile-system-eu-west-1.vtex.systems",
+        "path": "/api/profile-system/profiles/*"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "profile-system-us-east-1.vtex.systems",
         "path": "/api/profile-system/profiles/*"
       }
     },

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -6,6 +6,9 @@ import { Checkout } from './checkout'
 import { PvtCheckout } from './PvtCheckout'
 import { MasterData } from './masterdata'
 import { ProfileClient } from './profile'
+import { ProfileClientV1 } from './profile/profileV1'
+import { ProfileClientV2 } from './profile/profileV2'
+import { LicenseManagerExtendedClient } from './licenseManagerExtended'
 import { OMS } from './oms'
 import { Portal } from './portal'
 import { LogisticsClient } from './logistics'
@@ -35,6 +38,18 @@ export class Clients extends IOClients {
 
   public get profile() {
     return this.getOrSet('profile', ProfileClient)
+  }
+
+  public get profileV1() {
+    return this.getOrSet('profileV1', ProfileClientV1)
+  }
+
+  public get profileV2() {
+    return this.getOrSet('profileV2', ProfileClientV2)
+  }
+
+  public get licenseManagerExtended() {
+    return this.getOrSet('licenseManagerExtended', LicenseManagerExtendedClient)
   }
 
   public get oms() {

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -46,11 +46,11 @@ export class Clients extends IOClients {
   }
 
   public get profileV2EU() {
-    return this.getOrSet('profileV2EU', ProfileClientV2US)
+    return this.getOrSet('profileV2EU', ProfileClientV2EU)
   }
 
   public get profileV2US() {
-    return this.getOrSet('profileV2US', ProfileClientV2EU)
+    return this.getOrSet('profileV2US', ProfileClientV2US)
   }
 
   public get licenseManagerExtended() {

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -7,7 +7,8 @@ import { PvtCheckout } from './PvtCheckout'
 import { MasterData } from './masterdata'
 import { ProfileClient } from './profile'
 import { ProfileClientV1 } from './profile/profileV1'
-import { ProfileClientV2 } from './profile/profileV2'
+import { ProfileClientV2US } from './profile/profileV2US'
+import { ProfileClientV2EU } from './profile/profileV2EU'
 import { LicenseManagerExtendedClient } from './licenseManagerExtended'
 import { OMS } from './oms'
 import { Portal } from './portal'
@@ -44,8 +45,12 @@ export class Clients extends IOClients {
     return this.getOrSet('profileV1', ProfileClientV1)
   }
 
-  public get profileV2() {
-    return this.getOrSet('profileV2', ProfileClientV2)
+  public get profileV2EU() {
+    return this.getOrSet('profileV2EU', ProfileClientV2US)
+  }
+
+  public get profileV2US() {
+    return this.getOrSet('profileV2US', ProfileClientV2EU)
   }
 
   public get licenseManagerExtended() {

--- a/node/clients/licenseManagerExtended.ts
+++ b/node/clients/licenseManagerExtended.ts
@@ -1,0 +1,51 @@
+import {
+  InstanceOptions,
+  IOContext,
+  LicenseManager,
+  RequestConfig,
+} from '@vtex/api'
+
+import { statusToError } from '../utils'
+
+const FIVE_SECONDS_MS = 5 * 1000
+
+export class LicenseManagerExtendedClient extends LicenseManager {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(context, {
+      ...options,
+      headers: {
+        ...(options && options.headers),
+        VtexIdClientAutCookie: context.authToken ?? '',
+      },
+      timeout: FIVE_SECONDS_MS,
+    })
+  }
+
+  public getCurrentAccount = (customFields?: string) =>
+    this.get<Account>(
+      `${this.baseUrl}/${this.context.account}`,
+      {
+        metric: 'account-getAccount',
+        params: {
+          extraFields: customFields,
+        },
+      }
+    ).then((account: Account) => {
+      account.PIIEnabled = Boolean(account.Privacy)
+      return account
+    })
+
+  protected get = <T>(url: string, config?: RequestConfig) =>
+    this.http.get<T>(url, config).catch<any>(statusToError)
+
+  protected post = <T>(url: string, data?: any, config?: RequestConfig) =>
+    this.http.post<T>(url, data, config).catch<any>(statusToError)
+
+  protected delete = <T>(url: string, config?: RequestConfig) =>
+    this.http.delete<T>(url, config).catch<any>(statusToError)
+
+  protected patch = <T>(url: string, data?: any, config?: RequestConfig) =>
+    this.http.patch<T>(url, data, config).catch<any>(statusToError)
+
+  private baseUrl = '/api/pvt/accounts'
+}

--- a/node/clients/licenseManagerExtended.ts
+++ b/node/clients/licenseManagerExtended.ts
@@ -22,10 +22,8 @@ export class LicenseManagerExtendedClient extends LicenseManager {
   }
 
   public getCurrentAccount = (customFields?: string) =>
-    this.get<Account>(
-      `${this.baseUrl}/${this.context.account}`,
-      {
-        metric: 'account-getAccount',
+    this.get<Account>(`${this.baseUrl}/${this.context.account}`, {
+      metric: 'account-getAccount',
       params: {
         extraFields: customFields,
       },

--- a/node/clients/licenseManagerExtended.ts
+++ b/node/clients/licenseManagerExtended.ts
@@ -23,14 +23,13 @@ export class LicenseManagerExtendedClient extends LicenseManager {
 
   public getCurrentAccount = (customFields?: string) =>
     this.get<Account>(
-     `${this.baseUrl}/${this.context.account}`,
+      `${this.baseUrl}/${this.context.account}`,
       {
         metric: 'account-getAccount',
-        params: {
-          extraFields: customFields,
-        },
-      }
-    ).then((account: Account) => {
+      params: {
+        extraFields: customFields,
+      },
+    }).then((account: Account) => {
       account.PIIEnabled = Boolean(account.Privacy)
       return account
     })

--- a/node/clients/licenseManagerExtended.ts
+++ b/node/clients/licenseManagerExtended.ts
@@ -38,14 +38,5 @@ export class LicenseManagerExtendedClient extends LicenseManager {
   protected get = <T>(url: string, config?: RequestConfig) =>
     this.http.get<T>(url, config).catch<any>(statusToError)
 
-  protected post = <T>(url: string, data?: any, config?: RequestConfig) =>
-    this.http.post<T>(url, data, config).catch<any>(statusToError)
-
-  protected delete = <T>(url: string, config?: RequestConfig) =>
-    this.http.delete<T>(url, config).catch<any>(statusToError)
-
-  protected patch = <T>(url: string, data?: any, config?: RequestConfig) =>
-    this.http.patch<T>(url, data, config).catch<any>(statusToError)
-
   private baseUrl = '/api/pvt/accounts'
 }

--- a/node/clients/licenseManagerExtended.ts
+++ b/node/clients/licenseManagerExtended.ts
@@ -23,7 +23,7 @@ export class LicenseManagerExtendedClient extends LicenseManager {
 
   public getCurrentAccount = (customFields?: string) =>
     this.get<Account>(
-      `${this.baseUrl}/${this.context.account}`,
+     `${this.baseUrl}/${this.context.account}`,
       {
         metric: 'account-getAccount',
         params: {

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -77,7 +77,7 @@ export class ProfileClient extends JanusClient {
           return context.clients.profileV2US
         }
         if (account.Privacy?.PII.toLowerCase() == "eu") {
-          return context.clients.profileV2US
+          return context.clients.profileV2EU
         }
       }
       return context.clients.profileV1

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -1,0 +1,72 @@
+import {
+  InstanceOptions,
+  IOContext,
+  JanusClient,
+} from '@vtex/api'
+
+const FIVE_SECONDS_MS = 5 * 1000
+
+export class ProfileClient extends JanusClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(context, {
+      ...options,
+      headers: {
+        ...(options && options.headers),
+        VtexIdClientAutCookie: context.authToken ?? '',
+      },
+      timeout: FIVE_SECONDS_MS,
+    })
+  }
+
+  public getProfileInfo = (user: CurrentProfile, context: Context, customFields?: string) =>
+    this.getProfileClient(context).
+      then(profileClient => profileClient.getProfileInfo(user, customFields))
+
+  public getUserAddresses = (user: CurrentProfile, context: Context) =>
+    this.getProfileClient(context).
+      then(profileClient => profileClient.getUserAddresses(user))
+
+  public getUserPayments = (user: CurrentProfile, context: Context) =>
+    this.getProfileClient(context).
+      then(profileClient => profileClient.getUserPayments(user))
+
+  public updateProfileInfo = (
+    user: CurrentProfile,
+    profile: Profile | { profilePicture: string },
+    context: Context,
+    customFields?: string
+  ) =>
+    this.getProfileClient(context).
+      then(profileClient => profileClient.updateProfileInfo(user, profile, customFields))
+
+  public updateAddress = (user: CurrentProfile, addressesData: any, context: Context) =>
+    this.getProfileClient(context).
+      then(profileClient => profileClient.updateAddress(user, addressesData))
+
+  public deleteAddress = (user: CurrentProfile, addressName: string, context: Context) =>
+    this.getProfileClient(context).
+      then(profileClient => profileClient.deleteAddress(user, addressName))
+
+  public updatePersonalPreferences = (
+    user: CurrentProfile,
+    personalPreferences: PersonalPreferences,
+    context: Context
+  ) =>
+    this.getProfileClient(context).
+      then(profileClient => profileClient.updatePersonalPreferences(user, personalPreferences))
+
+  public createProfile = (profile: Profile, context: Context) =>
+    this.getProfileClient(context).
+      then(profileClient => profileClient.createProfile(profile))
+
+  private getProfileClient = (context: Context) => {
+    let licenseManager = context.clients.licenseManagerExtended
+
+    return licenseManager.getCurrentAccount().then(account => {
+      if (account.PIIEnabled) {
+        return context.clients.profileV2
+      }
+      return context.clients.profileV1
+    })
+  }
+}

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -73,11 +73,11 @@ export class ProfileClient extends JanusClient {
 
     return licenseManager.getCurrentAccount().then(account => {
       if (account.PIIEnabled) {
-        if (account.Infra?.Region.toLowerCase() === "us") {
-            return context.clients.profileV2US
+        if (account.Privacy?.PII.toLowerCase() == "us") {
+          return context.clients.profileV2US
         }
-        if (account.Infra?.Region.toLowerCase() === "eu") {
-            return context.clients.profileV2EU
+        if (account.Privacy?.PII.toLowerCase() == "eu") {
+          return context.clients.profileV2US
         }
       }
       return context.clients.profileV1

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -73,7 +73,12 @@ export class ProfileClient extends JanusClient {
 
     return licenseManager.getCurrentAccount().then(account => {
       if (account.PIIEnabled) {
-        return context.clients.profileV2
+        if (account.Infra?.Region.toLowerCase() == "us") {
+            return context.clients.profileV2US
+        }
+        if (account.Infra?.Region.toLowerCase() == "eu") {
+            return context.clients.profileV2EU
+        }
       }
       return context.clients.profileV1
     })

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -90,10 +90,11 @@ export class ProfileClient extends JanusClient {
 
     return licenseManager.getCurrentAccount().then((account) => {
       if (account.PIIEnabled) {
-        if (account.Privacy?.PII.toLowerCase() == 'us') {
+        if (account.Privacy?.PII.toLowerCase() === 'us') {
           return context.clients.profileV2US
         }
-        if (account.Privacy?.PII.toLowerCase() == 'eu') {
+        if (account.Privacy?.PII.toLowerCase() === 'eu') {
+          // THIS IS ON PURPOSE. Waiting for the Storage team fix the EU Profile System
           return context.clients.profileV2US
         }
       }

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -22,9 +22,22 @@ export class ProfileClient extends JanusClient {
     this.getProfileClient(context).
       then(profileClient => profileClient.getProfileInfo(user, customFields))
 
-  public getUserAddresses = (user: CurrentProfile, context: Context) =>
+  public createProfile = (profile: Profile, context: Context) =>
     this.getProfileClient(context).
-      then(profileClient => profileClient.getUserAddresses(user))
+      then(profileClient => profileClient.createProfile(profile))
+
+  public getUserAddresses = (user: CurrentProfile, context: Context, currentUserProfile?: Profile) =>
+    this.getProfileClient(context).
+      then(profileClient => {
+        if (!currentUserProfile) {
+          return profileClient.getProfileInfo(user)
+            .then(userProfile => {
+              return profileClient.getUserAddresses(user, userProfile, undefined)
+            })
+        }
+
+        return profileClient.getUserAddresses(user, currentUserProfile, undefined)
+      })
 
   public getUserPayments = (user: CurrentProfile, context: Context) =>
     this.getProfileClient(context).
@@ -54,10 +67,6 @@ export class ProfileClient extends JanusClient {
   ) =>
     this.getProfileClient(context).
       then(profileClient => profileClient.updatePersonalPreferences(user, personalPreferences))
-
-  public createProfile = (profile: Profile, context: Context) =>
-    this.getProfileClient(context).
-      then(profileClient => profileClient.createProfile(profile))
 
   private getProfileClient = (context: Context) => {
     let licenseManager = context.clients.licenseManagerExtended

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -73,7 +73,7 @@ export class ProfileClient extends JanusClient {
 
     return licenseManager.getCurrentAccount().then(account => {
       if (account.PIIEnabled) {
-        if (account.Infra?.Region.toLowerCase() == "us") {
+        if (account.Infra?.Region.toLowerCase() === "us") {
             return context.clients.profileV2US
         }
         if (account.Infra?.Region.toLowerCase() == "eu") {

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -76,7 +76,7 @@ export class ProfileClient extends JanusClient {
         if (account.Infra?.Region.toLowerCase() === "us") {
             return context.clients.profileV2US
         }
-        if (account.Infra?.Region.toLowerCase() == "eu") {
+        if (account.Infra?.Region.toLowerCase() === "eu") {
             return context.clients.profileV2EU
         }
       }

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -69,7 +69,7 @@ export class ProfileClient extends JanusClient {
       then(profileClient => profileClient.updatePersonalPreferences(user, personalPreferences))
 
   private getProfileClient = (context: Context) => {
-    let licenseManager = context.clients.licenseManagerExtended
+    const licenseManager = context.clients.licenseManagerExtended
 
     return licenseManager.getCurrentAccount().then(account => {
       if (account.PIIEnabled) {

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -1,8 +1,4 @@
-import {
-  InstanceOptions,
-  IOContext,
-  JanusClient,
-} from '@vtex/api'
+import { InstanceOptions, IOContext, JanusClient } from '@vtex/api'
 
 const FIVE_SECONDS_MS = 5 * 1000
 
@@ -18,30 +14,39 @@ export class ProfileClient extends JanusClient {
     })
   }
 
-  public getProfileInfo = (user: CurrentProfile, context: Context, customFields?: string) =>
-    this.getProfileClient(context).
-      then(profileClient => profileClient.getProfileInfo(user, customFields))
+  public getProfileInfo = (
+    user: CurrentProfile,
+    context: Context,
+    customFields?: string
+  ) =>
+    this.getProfileClient(context).then((profileClient) =>
+      profileClient.getProfileInfo(user, customFields)
+    )
 
   public createProfile = (profile: Profile, context: Context) =>
-    this.getProfileClient(context).
-      then(profileClient => profileClient.createProfile(profile))
+    this.getProfileClient(context).then((profileClient) =>
+      profileClient.createProfile(profile)
+    )
 
-  public getUserAddresses = (user: CurrentProfile, context: Context, currentUserProfile?: Profile) =>
-    this.getProfileClient(context).
-      then(profileClient => {
-        if (!currentUserProfile) {
-          return profileClient.getProfileInfo(user)
-            .then(userProfile => {
-              return profileClient.getUserAddresses(user, userProfile, undefined)
-            })
-        }
+  public getUserAddresses = (
+    user: CurrentProfile,
+    context: Context,
+    currentUserProfile?: Profile
+  ) =>
+    this.getProfileClient(context).then((profileClient) => {
+      if (!currentUserProfile) {
+        return profileClient.getProfileInfo(user).then((userProfile) => {
+          return profileClient.getUserAddresses(user, userProfile, undefined)
+        })
+      }
 
-        return profileClient.getUserAddresses(user, currentUserProfile, undefined)
-      })
+      return profileClient.getUserAddresses(user, currentUserProfile, undefined)
+    })
 
   public getUserPayments = (user: CurrentProfile, context: Context) =>
-    this.getProfileClient(context).
-      then(profileClient => profileClient.getUserPayments(user))
+    this.getProfileClient(context).then((profileClient) =>
+      profileClient.getUserPayments(user)
+    )
 
   public updateProfileInfo = (
     user: CurrentProfile,
@@ -49,35 +54,47 @@ export class ProfileClient extends JanusClient {
     context: Context,
     customFields?: string
   ) =>
-    this.getProfileClient(context).
-      then(profileClient => profileClient.updateProfileInfo(user, profile, customFields))
+    this.getProfileClient(context).then((profileClient) =>
+      profileClient.updateProfileInfo(user, profile, customFields)
+    )
 
-  public updateAddress = (user: CurrentProfile, addressesData: any, context: Context) =>
-    this.getProfileClient(context).
-      then(profileClient => profileClient.updateAddress(user, addressesData))
+  public updateAddress = (
+    user: CurrentProfile,
+    addressesData: any,
+    context: Context
+  ) =>
+    this.getProfileClient(context).then((profileClient) =>
+      profileClient.updateAddress(user, addressesData)
+    )
 
-  public deleteAddress = (user: CurrentProfile, addressName: string, context: Context) =>
-    this.getProfileClient(context).
-      then(profileClient => profileClient.deleteAddress(user, addressName))
+  public deleteAddress = (
+    user: CurrentProfile,
+    addressName: string,
+    context: Context
+  ) =>
+    this.getProfileClient(context).then((profileClient) =>
+      profileClient.deleteAddress(user, addressName)
+    )
 
   public updatePersonalPreferences = (
     user: CurrentProfile,
     personalPreferences: PersonalPreferences,
     context: Context
   ) =>
-    this.getProfileClient(context).
-      then(profileClient => profileClient.updatePersonalPreferences(user, personalPreferences))
+    this.getProfileClient(context).then((profileClient) =>
+      profileClient.updatePersonalPreferences(user, personalPreferences)
+    )
 
   private getProfileClient = (context: Context) => {
     const licenseManager = context.clients.licenseManagerExtended
 
-    return licenseManager.getCurrentAccount().then(account => {
+    return licenseManager.getCurrentAccount().then((account) => {
       if (account.PIIEnabled) {
-        if (account.Privacy?.PII.toLowerCase() == "us") {
+        if (account.Privacy?.PII.toLowerCase() == 'us') {
           return context.clients.profileV2US
         }
-        if (account.Privacy?.PII.toLowerCase() == "eu") {
-          return context.clients.profileV2EU
+        if (account.Privacy?.PII.toLowerCase() == 'eu') {
+          return context.clients.profileV2US
         }
       }
       return context.clients.profileV1

--- a/node/clients/profile/profileV1.ts
+++ b/node/clients/profile/profileV1.ts
@@ -27,8 +27,8 @@ export class ProfileClientV1 extends JanusClient {
     })
   }
 
-  public getProfileInfo = (user: CurrentProfile, customFields?: string) => {
-    return this.get<Profile>(
+  public getProfileInfo = (user: CurrentProfile, customFields?: string) =>
+    this.get<Profile>(
       `${this.baseUrl}/${getUserIdentification(user)}/personalData`,
       {
         metric: 'profile-system-getProfileInfo',
@@ -41,7 +41,6 @@ export class ProfileClientV1 extends JanusClient {
 
       return profile
     })
-  }
 
   public getUserAddresses = (user: CurrentProfile, _: Profile) =>
     this.get(`${this.baseUrl}/${getUserIdentification(user)}/addresses`, {

--- a/node/clients/profile/profileV1.ts
+++ b/node/clients/profile/profileV1.ts
@@ -28,7 +28,6 @@ export class ProfileClientV1 extends JanusClient {
   }
 
   public getProfileInfo = (user: CurrentProfile, customFields?: string) => {
-    console.log("Will use V1")
     return this.get<Profile>(
       `${this.baseUrl}/${getUserIdentification(user)}/personalData`,
       {
@@ -37,10 +36,14 @@ export class ProfileClientV1 extends JanusClient {
           extraFields: customFields,
         },
       }
-    )
+    ).then(profile => {
+      profile.pii = false
+
+      return profile
+    })
   }
 
-  public getUserAddresses = (user: CurrentProfile) =>
+  public getUserAddresses = (user: CurrentProfile, _: Profile) =>
     this.get(`${this.baseUrl}/${getUserIdentification(user)}/addresses`, {
       metric: 'profile-system-getUserAddresses',
     }).then(mapAddressesObjToList)

--- a/node/clients/profile/profileV1.ts
+++ b/node/clients/profile/profileV1.ts
@@ -5,7 +5,7 @@ import {
   RequestConfig,
 } from '@vtex/api'
 
-import { statusToError } from '../utils'
+import { statusToError } from '../../utils'
 
 const FIVE_SECONDS_MS = 5 * 1000
 
@@ -15,7 +15,7 @@ function mapAddressesObjToList(addressesObj: any): Address[] {
   )
 }
 
-export class ProfileClient extends JanusClient {
+export class ProfileClientV1 extends JanusClient {
   constructor(context: IOContext, options?: InstanceOptions) {
     super(context, {
       ...options,
@@ -27,8 +27,9 @@ export class ProfileClient extends JanusClient {
     })
   }
 
-  public getProfileInfo = (user: CurrentProfile, customFields?: string) =>
-    this.get<Profile>(
+  public getProfileInfo = (user: CurrentProfile, customFields?: string) => {
+    console.log("Will use V1")
+    return this.get<Profile>(
       `${this.baseUrl}/${getUserIdentification(user)}/personalData`,
       {
         metric: 'profile-system-getProfileInfo',
@@ -37,6 +38,7 @@ export class ProfileClient extends JanusClient {
         },
       }
     )
+  }
 
   public getUserAddresses = (user: CurrentProfile) =>
     this.get(`${this.baseUrl}/${getUserIdentification(user)}/addresses`, {

--- a/node/clients/profile/profileV1.ts
+++ b/node/clients/profile/profileV1.ts
@@ -36,7 +36,7 @@ export class ProfileClientV1 extends JanusClient {
           extraFields: customFields,
         },
       }
-    ).then(profile => {
+    ).then((profile) => {
       profile.pii = false
 
       return profile

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -10,8 +10,8 @@ import { statusToError } from '../../utils'
 const FIVE_SECONDS_MS = 5 * 1000
 
 export class ProfileClientV2 extends ExternalClient {
-  account: string
-  defaultPIIRequest: PIIRequest
+  protected account: string
+  private defaultPIIRequest: PIIRequest
 
   constructor(baseUrl: string, context: IOContext, options?: InstanceOptions) {
     super(baseUrl, context, {
@@ -101,7 +101,7 @@ export class ProfileClientV2 extends ExternalClient {
     profile: Profile | { profilePicture: string },
     customFields?: string
   ) => {
-    let { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
+    const { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
 
     if (!(profile as Profile)) {
       const profileCast = profile as Profile
@@ -126,7 +126,7 @@ export class ProfileClientV2 extends ExternalClient {
     currentUserProfile: Profile,
     piiRequest?: PIIRequest
   ) => {
-    let url = this.getPIIUrl(
+    const url = this.getPIIUrl(
       `${this.baseUrl}/${currentUserProfile.id}/addresses`,
       undefined,
       piiRequest
@@ -214,7 +214,7 @@ export class ProfileClientV2 extends ExternalClient {
 
     const addressesV2 = this.translateToV2Address(addressesV1)
     const toChange = addressesV2.filter(
-      (addr) => addr.document.name == addressesV1[0].addressName
+      (addr) => addr.document.name === addressesV1[0].addressName
     )[0]
 
     return this.getProfileInfo(user).then((profile) => {

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -262,8 +262,8 @@ export class ProfileClientV2 extends ExternalClient {
   }
 
   public getUserPayments = (user: CurrentProfile, piiRequest?: PIIRequest) => {
-    let { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
-    let url = this.getPIIUrl(
+    const { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
+    const url = this.getPIIUrl(
       `${this.baseUrl}/${userKey}/purchase-info/unmask`,
       alternativeKey,
       piiRequest

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -76,10 +76,9 @@ export class ProfileClientV2 extends ExternalClient {
     personalPreferences: PersonalPreferences
   ) => {
     const { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
-    let parsedPersonalPreferences = Object.keys(personalPreferences).reduce((preferences: any, key) => {
-      preferences[key] = personalPreferences[key] === 'True'
-      return preferences
-    }, {})
+    const parsedPersonalPreferences = Object.fromEntries(Object.entries(personalPreferences).map(([key, value]) => {
+      return [key, value === 'True']
+    }))
 
     return this.patch(
       `${this.baseUrl}/${userKey}?alternativeKey=${alternativeKey}`,

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -50,6 +50,7 @@ export class ProfileClientV2 extends ExternalClient {
         let profileV2 = profile[0].document
         profileV2.pii = true
         profileV2.id = profile[0].id
+        profileV2.isNewsletterOptIn = profileV2.isNewsletterOptIn || false
 
         return profileV2
       }
@@ -92,9 +93,10 @@ export class ProfileClientV2 extends ExternalClient {
   ) => {
     let { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
 
-    if (!(profile as Profile)?.gender) {
+    if (!(profile as Profile)) {
       const profileCast = profile as Profile
-      profileCast.gender = ""
+      profileCast.gender = profileCast.gender || ""
+      profileCast.document = profileCast.document || ""
     }
 
     return this.patch(
@@ -110,7 +112,7 @@ export class ProfileClientV2 extends ExternalClient {
   }
 
   public getUserAddresses = (_: CurrentProfile, currentUserProfile: Profile, piiRequest?: PIIRequest) => {
-    let url = this.getPIIUrl(`${this.baseUrl}/${currentUserProfile.userId}/addresses`, undefined, piiRequest)
+    let url = this.getPIIUrl(`${this.baseUrl}/${currentUserProfile.id}/addresses`, undefined, piiRequest)
 
     return this.get<Address[]>(url, { metric: 'profile-system-v2-getUserAddresses', })
       .then((addresses: AddressV2[]) => this.translateToV1Address(addresses))

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -130,7 +130,7 @@ export class ProfileClientV2 extends ExternalClient {
 
   private translateToV1Address = (addresses: AddressV2[]) =>
     addresses.map((address: AddressV2) => {
-      let addressV2 = address.document
+      const addressV2 = address.document
 
       return {
         addressName: addressV2.name,
@@ -177,9 +177,13 @@ export class ProfileClientV2 extends ExternalClient {
   private mapAddressesObjToList(addressesObj: any): Address[] {
     return Object.entries<string>(addressesObj).map(
       ([key, stringifiedObj]) => {
-        let address = JSON.parse(stringifiedObj) as Address
-        address.addressName = key
-        return address
+        try {
+          const address = JSON.parse(stringifiedObj) as Address
+          address.addressName = key
+          return address
+        } catch (e) {
+          return {} as Address
+        }
       }
     )
   }

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -39,10 +39,11 @@ export class ProfileClientV2 extends ExternalClient {
       if (profile.length > 0) {
         const profileV2 = {
           ...profile[0].document,
-          pii = true,
-          id = profile[0].id,
-          isNewsletterOptIn = profileV2.isNewsletterOptIn || false,
+          pii: true,
+          id: profile[0].id,
         }
+
+        profileV2.isNewsletterOptIn = profileV2.isNewsletterOptIn || false
 
         return profileV2
       }
@@ -54,11 +55,10 @@ export class ProfileClientV2 extends ExternalClient {
   public createProfile = (profile: Profile) =>
     this.post<ProfileV2>(`${this.baseUrl}?an=${this.account}`, profile)
       .then((profileV2: ProfileV2) => {
-        const newProfile = {
-          ...profileV2.document as Profile
-          id = profileV2.id
+        return {
+          ...profileV2.document as Profile,
+          id: profileV2.id
         }
-        return newProfile
       })
 
   public updatePersonalPreferences = (
@@ -88,11 +88,9 @@ export class ProfileClientV2 extends ExternalClient {
     let { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
 
     if (!(profile as Profile)) {
-      const profileCast = {
-        ...profile as Profile,
-        gender: profile.gender ?? ''
-        document: profile.document ?? ''
-      }
+      const profileCast = profile as Profile
+      profileCast.gender = profileCast.gender || ""
+      profileCast.document = profileCast.document || ""
     }
 
     return this.patch(

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -14,8 +14,8 @@ export class ProfileClientV2 extends ExternalClient {
   account: string
   defaultPIIRequest: PIIRequest
 
-  constructor(context: IOContext, options?: InstanceOptions) {
-    super("https://profile-system-beta.vtex.systems", context, {
+  constructor(baseUrl: string, context: IOContext, options?: InstanceOptions) {
+    super(baseUrl, context, {
       ...options,
       headers: {
         ...(options && options.headers),

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -4,7 +4,6 @@ import {
   ExternalClient,
   RequestConfig,
 } from '@vtex/api'
-import { AxiosError } from 'axios'
 
 import { statusToError } from '../../utils'
 
@@ -186,15 +185,13 @@ export class ProfileClientV2 extends ExternalClient {
   }
 
   public updateAddress = (user: CurrentProfile, addressesData: any) => {
-    let addressesV1 = this.mapAddressesObjToList(addressesData)
-
-    addressesV1 = addressesV1.map((addr:  any) => {
+    const addressesV1 = this.mapAddressesObjToList(addressesData).map((addr:  any) => {
       addr.geoCoordinates = addr.geoCoordinate
       return addr
     })
 
-    let addressesV2 = this.translateToV2Address(addressesV1)
-    let toChange = addressesV2.filter(addr => addr.document.name == addressesV1[0].addressName)[0]
+    const addressesV2 = this.translateToV2Address(addressesV1)
+    const toChange = addressesV2.filter(addr => addr.document.name == addressesV1[0].addressName)[0]
 
     return this.getProfileInfo(user)
       .then(profile => {
@@ -247,9 +244,8 @@ export class ProfileClientV2 extends ExternalClient {
     return this.get(url, {
       metric: 'profile-system-v2-getUserPayments',
     }).catch<any>(e => {
-      const { response } = e as AxiosError
-      const { status } = response!
-      if (status == 404) {
+      const { status } = e.response ?? {}
+      if (status === 404) {
         return [] as PaymentProfile[]
       }
 
@@ -289,15 +285,13 @@ export class ProfileClientV2 extends ExternalClient {
   }
 
   private getPIIUrl(url: string, alternativeKey?: string, piiRequest?: PIIRequest){
-    let params = [
-      ["an", this.account],
-    ]
+    const params = []
 
     if (alternativeKey) {
       params.push(["alternativeKey", alternativeKey])
     }
 
-    let currentPIIRequest = piiRequest || this.defaultPIIRequest
+    const currentPIIRequest = piiRequest || this.defaultPIIRequest
 
     if (currentPIIRequest) {
       params.push(
@@ -308,7 +302,7 @@ export class ProfileClientV2 extends ExternalClient {
       url += "/unmask"
     }
 
-    let queryString = params.map(el => el.join("=")).join("&")
+    const queryString = params.map(el => el.join("=")).join("&")
 
     return `${url}?${queryString}`
   }

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -121,7 +121,7 @@ export class ProfileClientV2 extends ExternalClient {
       .then((addresses: AddressV2[]) => this.translateToV1Address(addresses))
       .catch<any>(e => {
         const { status } = e.response ?? {}
-        if (status == 404) {
+        if (status === 404) {
           return [] as AddressV2[]
         }
 

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -54,8 +54,10 @@ export class ProfileClientV2 extends ExternalClient {
   public createProfile = (profile: Profile) =>
     this.post<ProfileV2>(`${this.baseUrl}?an=${this.account}`, profile)
       .then((profileV2: ProfileV2) => {
-        let newProfile = profileV2.document as Profile
-        newProfile.id = profileV2.id
+        const newProfile = {
+          ...profileV2.document as Profile
+          id = profileV2.id
+        }
         return newProfile
       })
 

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -8,22 +8,12 @@ import { AxiosError } from 'axios'
 
 import { statusToError } from '../../utils'
 
-const FIVE_SECONDS_MS = 5 * 1000
-
 export class ProfileClientV2 extends ExternalClient {
   account: string
   defaultPIIRequest: PIIRequest
 
   constructor(baseUrl: string, context: IOContext, options?: InstanceOptions) {
-    super(baseUrl, context, {
-      ...options,
-      headers: {
-        ...(options && options.headers),
-        userAgent: context.userAgent,
-        VtexIdClientAutCookie: context.authToken,
-      },
-      timeout: FIVE_SECONDS_MS,
-    })
+    super(baseUrl, context, options)
 
     this.account = context.account
 

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -24,8 +24,8 @@ export class ProfileClientV2 extends ExternalClient {
   }
 
   public getProfileInfo = (user: CurrentProfile, customFields?: string, piiRequest?: PIIRequest) => {
-    let { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
-    let url = this.getPIIUrl(`${this.baseUrl}/${userKey}`, alternativeKey, piiRequest)
+    const { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
+    const url = this.getPIIUrl(`${this.baseUrl}/${userKey}`, alternativeKey, piiRequest)
 
     return this.get<ProfileV2>(
       url,

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -37,10 +37,12 @@ export class ProfileClientV2 extends ExternalClient {
       }
     ).then((profile: ProfileV2[]) => {
       if (profile.length > 0) {
-        let profileV2 = profile[0].document
-        profileV2.pii = true
-        profileV2.id = profile[0].id
-        profileV2.isNewsletterOptIn = profileV2.isNewsletterOptIn || false
+        const profileV2 = {
+          ...profile[0].document,
+          pii = true,
+          id = profile[0].id,
+          isNewsletterOptIn = profileV2.isNewsletterOptIn || false,
+        }
 
         return profileV2
       }

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -88,9 +88,11 @@ export class ProfileClientV2 extends ExternalClient {
     let { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
 
     if (!(profile as Profile)) {
-      const profileCast = profile as Profile
-      profileCast.gender = profileCast.gender || ""
-      profileCast.document = profileCast.document || ""
+      const profileCast = {
+        ...profile as Profile,
+        gender: profile.gender ?? ''
+        document: profile.document ?? ''
+      }
     }
 
     return this.patch(

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -1,0 +1,118 @@
+import {
+  InstanceOptions,
+  IOContext,
+  JanusClient,
+  RequestConfig,
+} from '@vtex/api'
+
+import { statusToError } from '../../utils'
+
+const FIVE_SECONDS_MS = 5 * 1000
+
+function mapAddressesObjToList(addressesObj: any): Address[] {
+  return Object.values<string>(addressesObj).map(
+    (stringifiedObj) => JSON.parse(stringifiedObj) as Address
+  )
+}
+
+export class ProfileClientV2 extends JanusClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(context, {
+      ...options,
+      headers: {
+        ...(options && options.headers),
+        VtexIdClientAutCookie: context.authToken ?? '',
+      },
+      timeout: FIVE_SECONDS_MS,
+    })
+  }
+
+  public getProfileInfo = (user: CurrentProfile, customFields?: string) => {
+    console.log("Will use V2")
+    return this.get<Profile>(
+      `${this.baseUrl}/${getUserIdentification(user)}/personalData`,
+      {
+        metric: 'profile-system-getProfileInfo',
+        params: {
+          extraFields: customFields,
+        },
+      }
+    )
+  }
+
+  public getUserAddresses = (user: CurrentProfile) =>
+    this.get(`${this.baseUrl}/${getUserIdentification(user)}/addresses`, {
+      metric: 'profile-system-getUserAddresses',
+    }).then(mapAddressesObjToList)
+
+  public getUserPayments = (user: CurrentProfile) =>
+    this.get(`${this.baseUrl}/${getUserIdentification(user)}/vcs-checkout`, {
+      metric: 'profile-system-getUserPayments',
+    })
+
+  public updateProfileInfo = (
+    user: CurrentProfile,
+    profile: Profile | { profilePicture: string },
+    customFields?: string
+  ) =>
+    this.post<Profile>(
+      `${this.baseUrl}/${getUserIdentification(user)}/personalData`,
+      profile,
+      {
+        metric: 'profile-system-updateProfileInfo',
+        params: {
+          extraFields: customFields,
+        },
+      }
+    )
+
+  public updateAddress = (user: CurrentProfile, addressesData: any) =>
+    this.post(
+      `${this.baseUrl}/${getUserIdentification(user)}/addresses`,
+      addressesData,
+      {
+        metric: 'profile-system-updateAddress',
+      }
+    )
+
+  public deleteAddress = (user: CurrentProfile, addressName: string) =>
+    this.delete(
+      `${this.baseUrl}/${getUserIdentification(user)}/addresses/${addressName}`,
+      {
+        metric: 'profile-system-deleteAddress',
+      }
+    )
+
+  public updatePersonalPreferences = (
+    user: CurrentProfile,
+    personalPreferences: PersonalPreferences
+  ) =>
+    this.post(
+      `${this.baseUrl}/${getUserIdentification(user)}/personalPreferences/`,
+      personalPreferences,
+      {
+        metric: 'profile-system-subscribeNewsletter',
+      }
+    )
+
+  public createProfile = (profile: Profile) =>
+    this.post(this.baseUrl, { personalData: profile })
+
+  protected get = <T>(url: string, config?: RequestConfig) =>
+    this.http.get<T>(url, config).catch<any>(statusToError)
+
+  protected post = <T>(url: string, data?: any, config?: RequestConfig) =>
+    this.http.post<T>(url, data, config).catch<any>(statusToError)
+
+  protected delete = <T>(url: string, config?: RequestConfig) =>
+    this.http.delete<T>(url, config).catch<any>(statusToError)
+
+  protected patch = <T>(url: string, data?: any, config?: RequestConfig) =>
+    this.http.patch<T>(url, data, config).catch<any>(statusToError)
+
+  private baseUrl = '/api/profile-system/pvt/profiles'
+}
+
+function getUserIdentification(user: CurrentProfile) {
+  return user.userId || encodeURIComponent(user.email)
+}

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -63,7 +63,7 @@ export class ProfileClientV2 extends ExternalClient {
     user: CurrentProfile,
     personalPreferences: PersonalPreferences
   ) => {
-    let { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
+    const { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
     let parsedPersonalPreferences = Object.keys(personalPreferences).reduce((preferences: any, key) => {
       preferences[key] = personalPreferences[key] === 'True'
       return preferences

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -27,24 +27,29 @@ export class ProfileClientV2 extends ExternalClient {
     this.account = context.account
 
     this.defaultPIIRequest = {
-      useCase: "MyAcocunts",
-      onBehalfOf: "user"
+      useCase: 'MyAcocunts',
+      onBehalfOf: 'user',
     } as PIIRequest
   }
 
-  public getProfileInfo = (user: CurrentProfile, customFields?: string, piiRequest?: PIIRequest) => {
+  public getProfileInfo = (
+    user: CurrentProfile,
+    customFields?: string,
+    piiRequest?: PIIRequest
+  ) => {
     const { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
-    const url = this.getPIIUrl(`${this.baseUrl}/${userKey}`, alternativeKey, piiRequest)
+    const url = this.getPIIUrl(
+      `${this.baseUrl}/${userKey}`,
+      alternativeKey,
+      piiRequest
+    )
 
-    return this.get<ProfileV2>(
-      url,
-      {
-        metric: 'profile-system-v2-getProfileInfo',
-        params: {
-          extraFields: customFields,
-        },
-      }
-    ).then((profile: ProfileV2[]) => {
+    return this.get<ProfileV2>(url, {
+      metric: 'profile-system-v2-getProfileInfo',
+      params: {
+        extraFields: customFields,
+      },
+    }).then((profile: ProfileV2[]) => {
       if (profile.length > 0) {
         const profileV2 = {
           ...profile[0].document,
@@ -62,22 +67,25 @@ export class ProfileClientV2 extends ExternalClient {
   }
 
   public createProfile = (profile: Profile) =>
-    this.post<ProfileV2>(`${this.baseUrl}`, profile)
-      .then((profileV2: ProfileV2) => {
+    this.post<ProfileV2>(`${this.baseUrl}`, profile).then(
+      (profileV2: ProfileV2) => {
         return {
-          ...profileV2.document as Profile,
-          id: profileV2.id
+          ...(profileV2.document as Profile),
+          id: profileV2.id,
         }
-      })
+      }
+    )
 
   public updatePersonalPreferences = (
     user: CurrentProfile,
     personalPreferences: PersonalPreferences
   ) => {
     const { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
-    const parsedPersonalPreferences = Object.fromEntries(Object.entries(personalPreferences).map(([key, value]) => {
-      return [key, value === 'True']
-    }))
+    const parsedPersonalPreferences = Object.fromEntries(
+      Object.entries(personalPreferences).map(([key, value]) => {
+        return [key, value === 'True']
+      })
+    )
 
     return this.patch(
       `${this.baseUrl}/${userKey}?alternativeKey=${alternativeKey}`,
@@ -97,8 +105,8 @@ export class ProfileClientV2 extends ExternalClient {
 
     if (!(profile as Profile)) {
       const profileCast = profile as Profile
-      profileCast.gender = profileCast.gender || ""
-      profileCast.document = profileCast.document || ""
+      profileCast.gender = profileCast.gender || ''
+      profileCast.document = profileCast.document || ''
     }
 
     return this.patch(
@@ -113,12 +121,22 @@ export class ProfileClientV2 extends ExternalClient {
     )
   }
 
-  public getUserAddresses = (_: CurrentProfile, currentUserProfile: Profile, piiRequest?: PIIRequest) => {
-    let url = this.getPIIUrl(`${this.baseUrl}/${currentUserProfile.id}/addresses`, undefined, piiRequest)
+  public getUserAddresses = (
+    _: CurrentProfile,
+    currentUserProfile: Profile,
+    piiRequest?: PIIRequest
+  ) => {
+    let url = this.getPIIUrl(
+      `${this.baseUrl}/${currentUserProfile.id}/addresses`,
+      undefined,
+      piiRequest
+    )
 
-    return this.get<Address[]>(url, { metric: 'profile-system-v2-getUserAddresses', })
+    return this.get<Address[]>(url, {
+      metric: 'profile-system-v2-getUserAddresses',
+    })
       .then((addresses: AddressV2[]) => this.translateToV1Address(addresses))
-      .catch<any>(e => {
+      .catch<any>((e) => {
         const { status } = e.response ?? {}
         if (status === 404) {
           return [] as AddressV2[]
@@ -146,7 +164,7 @@ export class ProfileClientV2 extends ExternalClient {
         state: addressV2.administrativeAreaLevel1,
         street: addressV2.route,
         userId: addressV2.profileId,
-        addressType: addressV2.addressType || "residential",
+        addressType: addressV2.addressType || 'residential',
         neighborhood: addressV2.neighborhood,
       } as Address
     })
@@ -157,97 +175,103 @@ export class ProfileClientV2 extends ExternalClient {
         id: address.id,
         document: {
           administrativeAreaLevel1: address.state,
-          addressType: address.addressType || "residential",
+          addressType: address.addressType || 'residential',
           countryCode: address.country,
-          extend: address.complement || "",
+          extend: address.complement || '',
           geoCoordinates: address.geoCoordinates,
           localityAreaLevel1: address.city,
           name: address.addressName,
-          nearly: address.reference || "",
+          nearly: address.reference || '',
           postalCode: address.postalCode,
           profileId: address.userId,
           route: address.street,
           streetNumber: address.number,
           receiverName: address.receiverName,
           neighborhood: address.neighborhood,
-        }
+        },
       } as AddressV2
-  })
+    })
 
   private mapAddressesObjToList(addressesObj: any): Address[] {
-    return Object.entries<string>(addressesObj).map(
-      ([key, stringifiedObj]) => {
-        try {
-          const address = JSON.parse(stringifiedObj) as Address
-          address.addressName = key
-          return address
-        } catch (e) {
-          return {} as Address
-        }
+    return Object.entries<string>(addressesObj).map(([key, stringifiedObj]) => {
+      try {
+        const address = JSON.parse(stringifiedObj) as Address
+        address.addressName = key
+        return address
+      } catch (e) {
+        return {} as Address
       }
-    )
+    })
   }
 
   public updateAddress = (user: CurrentProfile, addressesData: any) => {
-    const addressesV1 = this.mapAddressesObjToList(addressesData).map((addr:  any) => {
-      addr.geoCoordinates = addr.geoCoordinate
-      return addr
-    })
+    const addressesV1 = this.mapAddressesObjToList(addressesData).map(
+      (addr: any) => {
+        addr.geoCoordinates = addr.geoCoordinate
+        return addr
+      }
+    )
 
     const addressesV2 = this.translateToV2Address(addressesV1)
-    const toChange = addressesV2.filter(addr => addr.document.name == addressesV1[0].addressName)[0]
+    const toChange = addressesV2.filter(
+      (addr) => addr.document.name == addressesV1[0].addressName
+    )[0]
 
-    return this.getProfileInfo(user)
-      .then(profile => {
-          return this.getUserAddresses(user, profile)
-          .then((addresses: Address[]) => {
-            const address = addresses.filter(addr => addr.addressName === addressesV1[0].addressName)[0]
-            if (address) {
-              return this.patch(
-                `${this.baseUrl}/${profile.id}/addresses/${address.id}`,
-                toChange.document,
-                {
-                  metric: 'profile-system-v2-updateAddress',
-                }
-              )
-            }
-
-            return this.post(
-              `${this.baseUrl}/${profile.id}/addresses`,
+    return this.getProfileInfo(user).then((profile) => {
+      return this.getUserAddresses(user, profile).then(
+        (addresses: Address[]) => {
+          const address = addresses.filter(
+            (addr) => addr.addressName === addressesV1[0].addressName
+          )[0]
+          if (address) {
+            return this.patch(
+              `${this.baseUrl}/${profile.id}/addresses/${address.id}`,
               toChange.document,
               {
-                metric: 'profile-system-v2-createAddress'
-              }
-            )
-          })
-      })
-  }
-
-  public deleteAddress = (user: CurrentProfile, addressName: string) => {
-    return this.getProfileInfo(user)
-      .then(profile => {
-          this.getUserAddresses(user, profile)
-          .then((addresses: Address[]) => {
-            const address = addresses.filter(addr => addr.addressName === addressName)[0]
-            return this.delete(
-              `${this.baseUrl}/${profile.id}/addresses/${address.id}`,
-              {
-                metric: 'profile-system-v2-deleteAddress',
+                metric: 'profile-system-v2-updateAddress',
               }
             )
           }
+
+          return this.post(
+            `${this.baseUrl}/${profile.id}/addresses`,
+            toChange.document,
+            {
+              metric: 'profile-system-v2-createAddress',
+            }
+          )
+        }
+      )
+    })
+  }
+
+  public deleteAddress = (user: CurrentProfile, addressName: string) => {
+    return this.getProfileInfo(user).then((profile) => {
+      this.getUserAddresses(user, profile).then((addresses: Address[]) => {
+        const address = addresses.filter(
+          (addr) => addr.addressName === addressName
+        )[0]
+        return this.delete(
+          `${this.baseUrl}/${profile.id}/addresses/${address.id}`,
+          {
+            metric: 'profile-system-v2-deleteAddress',
+          }
         )
-      }
-    )
+      })
+    })
   }
 
   public getUserPayments = (user: CurrentProfile, piiRequest?: PIIRequest) => {
     let { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
-    let url = this.getPIIUrl(`${this.baseUrl}/${userKey}/purchase-info/unmask`, alternativeKey, piiRequest)
+    let url = this.getPIIUrl(
+      `${this.baseUrl}/${userKey}/purchase-info/unmask`,
+      alternativeKey,
+      piiRequest
+    )
 
     return this.get(url, {
       metric: 'profile-system-v2-getUserPayments',
-    }).catch<any>(e => {
+    }).catch<any>((e) => {
       const { status } = e.response ?? {}
       if (status === 404) {
         return [] as PaymentProfile[]
@@ -272,41 +296,45 @@ export class ProfileClientV2 extends ExternalClient {
   private baseUrl = 'api/profile-system/profiles'
 
   private getUserKeyAndAlternateKey(user: CurrentProfile) {
-      let alternativeKey
-      let userKey
+    let alternativeKey
+    let userKey
 
-      if (user.email) {
-        alternativeKey = "email"
-        userKey = user.email
-      } else {
-        userKey = user.userId
-      }
+    if (user.email) {
+      alternativeKey = 'email'
+      userKey = user.email
+    } else {
+      userKey = user.userId
+    }
 
     return {
       userKey,
-      alternativeKey
+      alternativeKey,
     }
   }
 
-  private getPIIUrl(url: string, alternativeKey?: string, piiRequest?: PIIRequest){
+  private getPIIUrl(
+    url: string,
+    alternativeKey?: string,
+    piiRequest?: PIIRequest
+  ) {
     const params = []
 
     if (alternativeKey) {
-      params.push(["alternativeKey", alternativeKey])
+      params.push(['alternativeKey', alternativeKey])
     }
 
     const currentPIIRequest = piiRequest || this.defaultPIIRequest
 
     if (currentPIIRequest) {
       params.push(
-        ["useCase", currentPIIRequest.useCase],
-        ["onBehalfOf", currentPIIRequest.onBehalfOf]
+        ['useCase', currentPIIRequest.useCase],
+        ['onBehalfOf', currentPIIRequest.onBehalfOf]
       )
 
-      url += "/unmask"
+      url += '/unmask'
     }
 
-    const queryString = params.map(el => el.join("=")).join("&")
+    const queryString = params.map((el) => el.join('=')).join('&')
 
     return `${url}?${queryString}`
   }

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -113,8 +113,7 @@ export class ProfileClientV2 extends ExternalClient {
     return this.get<Address[]>(url, { metric: 'profile-system-v2-getUserAddresses', })
       .then((addresses: AddressV2[]) => this.translateToV1Address(addresses))
       .catch<any>(e => {
-        const { response } = e as AxiosError
-        const { status } = response!
+        const { status } = e.response ?? {}
         if (status == 404) {
           return [] as AddressV2[]
         }

--- a/node/clients/profile/profileV2EU.ts
+++ b/node/clients/profile/profileV2EU.ts
@@ -1,12 +1,9 @@
-import {
-  InstanceOptions,
-  IOContext,
-} from '@vtex/api'
+import { InstanceOptions, IOContext } from '@vtex/api'
 
 import { ProfileClientV2 } from './profileV2'
 
 export class ProfileClientV2EU extends ProfileClientV2 {
   constructor(context: IOContext, options?: InstanceOptions) {
-    super("https://profile-system-eu-west-1.vtex.systems", context, options)
+    super('https://profile-system-eu-west-1.vtex.systems', context, options)
   }
 }

--- a/node/clients/profile/profileV2EU.ts
+++ b/node/clients/profile/profileV2EU.ts
@@ -5,28 +5,8 @@ import {
 
 import { ProfileClientV2 } from './profileV2'
 
-const FIVE_SECONDS_MS = 5 * 1000
-
 export class ProfileClientV2EU extends ProfileClientV2 {
-  account: string
-  defaultPIIRequest: PIIRequest
-
   constructor(context: IOContext, options?: InstanceOptions) {
-    super("https://profile-system-eu-west-1.vtex.systems", context, {
-      ...options,
-      headers: {
-        ...(options && options.headers),
-        userAgent: context.userAgent,
-        VtexIdClientAutCookie: context.authToken,
-      },
-      timeout: FIVE_SECONDS_MS,
-    })
-
-    this.account = context.account
-
-    this.defaultPIIRequest = {
-      useCase: "MyAcocunts",
-      onBehalfOf: "user"
-    } as PIIRequest
+    super("https://profile-system-eu-west-1.vtex.systems", context, options)
   }
 }

--- a/node/clients/profile/profileV2EU.ts
+++ b/node/clients/profile/profileV2EU.ts
@@ -1,0 +1,32 @@
+import {
+  InstanceOptions,
+  IOContext,
+} from '@vtex/api'
+
+import { ProfileClientV2 } from './profileV2'
+
+const FIVE_SECONDS_MS = 5 * 1000
+
+export class ProfileClientV2EU extends ProfileClientV2 {
+  account: string
+  defaultPIIRequest: PIIRequest
+
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super("https://profile-system-eu-west-1.vtex.systems", context, {
+      ...options,
+      headers: {
+        ...(options && options.headers),
+        userAgent: context.userAgent,
+        VtexIdClientAutCookie: context.authToken,
+      },
+      timeout: FIVE_SECONDS_MS,
+    })
+
+    this.account = context.account
+
+    this.defaultPIIRequest = {
+      useCase: "MyAcocunts",
+      onBehalfOf: "user"
+    } as PIIRequest
+  }
+}

--- a/node/clients/profile/profileV2US.ts
+++ b/node/clients/profile/profileV2US.ts
@@ -1,12 +1,9 @@
-import {
-  InstanceOptions,
-  IOContext,
-} from '@vtex/api'
+import { InstanceOptions, IOContext } from '@vtex/api'
 
 import { ProfileClientV2 } from './profileV2'
 
 export class ProfileClientV2US extends ProfileClientV2 {
   constructor(context: IOContext, options?: InstanceOptions) {
-    super("https://profile-system-us-east-1.vtex.systems", context, options)
+    super('https://profile-system-us-east-1.vtex.systems', context, options)
   }
 }

--- a/node/clients/profile/profileV2US.ts
+++ b/node/clients/profile/profileV2US.ts
@@ -5,28 +5,8 @@ import {
 
 import { ProfileClientV2 } from './profileV2'
 
-const FIVE_SECONDS_MS = 5 * 1000
-
 export class ProfileClientV2US extends ProfileClientV2 {
-  account: string
-  defaultPIIRequest: PIIRequest
-
   constructor(context: IOContext, options?: InstanceOptions) {
-    super("https://profile-system-us-east-1.vtex.systems", context, {
-      ...options,
-      headers: {
-        ...(options && options.headers),
-        userAgent: context.userAgent,
-        VtexIdClientAutCookie: context.authToken,
-      },
-      timeout: FIVE_SECONDS_MS,
-    })
-
-    this.account = context.account
-
-    this.defaultPIIRequest = {
-      useCase: "MyAcocunts",
-      onBehalfOf: "user"
-    } as PIIRequest
+    super("https://profile-system-us-east-1.vtex.systems", context, options)
   }
 }

--- a/node/clients/profile/profileV2US.ts
+++ b/node/clients/profile/profileV2US.ts
@@ -1,0 +1,32 @@
+import {
+  InstanceOptions,
+  IOContext,
+} from '@vtex/api'
+
+import { ProfileClientV2 } from './profileV2'
+
+const FIVE_SECONDS_MS = 5 * 1000
+
+export class ProfileClientV2US extends ProfileClientV2 {
+  account: string
+  defaultPIIRequest: PIIRequest
+
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super("https://profile-system-us-east-1.vtex.systems", context, {
+      ...options,
+      headers: {
+        ...(options && options.headers),
+        userAgent: context.userAgent,
+        VtexIdClientAutCookie: context.authToken,
+      },
+      timeout: FIVE_SECONDS_MS,
+    })
+
+    this.account = context.account
+
+    this.defaultPIIRequest = {
+      useCase: "MyAcocunts",
+      onBehalfOf: "user"
+    } as PIIRequest
+  }
+}

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -135,7 +135,7 @@ async function getCurrentProfileFromCookies(
     const customerEmail = parsedCookies['vtex-impersonated-customer-email']
 
     return profile
-      .getProfileInfo({ email: customerEmail, userId: '' })
+      .getProfileInfo({ email: customerEmail, userId: '' }, context, undefined)
       .then(({ email, userId }) => ({
         currentProfile: { email, userId },
         userType: 'CallCenterOperator',
@@ -154,7 +154,7 @@ async function validatedProfile(
   } = context
 
   const { id, userId } = (await profile
-    .getProfileInfo(currentProfile, 'id')
+    .getProfileInfo(currentProfile, context, 'id')
     .catch(() => {})) || { id: '', userId: '' } // 404 case.
 
   if (!id) {
@@ -163,9 +163,9 @@ async function validatedProfile(
       .createProfile({
         email: currentProfile.email,
         userId,
-      })
+      }, context)
       .then(({ profileId }: any) =>
-        profile.getProfileInfo({ userId: profileId, email: '' })
+        profile.getProfileInfo({ userId: profileId, email: '' }, context, undefined)
       )
   }
 

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -157,19 +157,24 @@ async function validatedProfile(
     .getProfileInfo(currentProfile, context, 'id')
     .catch(() => {})) || { id: '', userId: '' } // 404 case.
 
-
   if (id) {
     return { userId, email: currentProfile.email }
   }
 
   return profile
-    .createProfile({
-      email: currentProfile.email,
-      userId,
-    } as Profile, context)
-    .then(
-      (newProfile: Profile) =>
-        profile.getProfileInfo({ userId: newProfile.userId, email: '' }, context, undefined)
+    .createProfile(
+      {
+        email: currentProfile.email,
+        userId,
+      } as Profile,
+      context
+    )
+    .then((newProfile: Profile) =>
+      profile.getProfileInfo(
+        { userId: newProfile.userId, email: '' },
+        context,
+        undefined
+      )
     )
 }
 

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -157,19 +157,20 @@ async function validatedProfile(
     .getProfileInfo(currentProfile, context, 'id')
     .catch(() => {})) || { id: '', userId: '' } // 404 case.
 
-  if (!id) {
-    // doesn't have a profile, create one
-    return profile
-      .createProfile({
-        email: currentProfile.email,
-        userId,
-      }, context)
-      .then(({ profileId }: any) =>
-        profile.getProfileInfo({ userId: profileId, email: '' }, context, undefined)
-      )
+
+  if (id) {
+    return { userId, email: currentProfile.email }
   }
 
-  return { userId, email: currentProfile.email }
+  return profile
+    .createProfile({
+      email: currentProfile.email,
+      userId,
+    } as Profile, context)
+    .then(
+      (newProfile: Profile) =>
+        profile.getProfileInfo({ userId: newProfile.userId, email: '' }, context, undefined)
+    )
 }
 
 async function isValidCallcenterOperator(context: Context, email: string) {

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -56,21 +56,59 @@ declare global {
   }
 
   interface Address {
-    id: string
-    userId: string
-    receiverName?: string
-    complement?: string
-    neighborhood?: string
-    country?: string
-    state?: string
-    number?: string
-    street?: string
-    postalCode?: string
-    city?: string
-    reference?: string
     addressName?: string
     addressType?: string
-    geoCoordinates?: string
+    city?: string
+    complement?: string
+    country?: string
+    geoCoordinates?: string[]
+    id: string
+    neighborhood?: string
+    number?: string
+    postalCode?: string
+    receiverName?: string
+    reference?: string
+    state?: string
+    street?: string
+    userId: string
+  }
+
+  interface AddressV2 {
+    id: string
+    document: {
+      administrativeAreaLevel1?: string
+      addressType?: string
+      countryCode?: string
+      extend?: string
+      geoCoordinates?: string[]
+      locality?: string
+      localityAreaLevel1?: string
+      name?: string
+      nearly?: string
+      postalCode?: string
+      profileId?: string
+      route?: string
+      streetNumber?: string
+      receiverName?: string
+      neighborhood?: string
+    }
+    meta?: {
+      version: string
+      author: string
+      creationDate: string
+      lastUpdateDate: string
+    }
+  }
+
+  interface ProfileV2 {
+    id: string
+    document: Profile
+    meta: {
+      version: string
+      author: string
+      creationDate: string
+      lastUpdateDate: string
+    }
   }
 
   interface Profile {
@@ -92,6 +130,9 @@ declare global {
     tradeName?: string
     payments?: PaymentProfile[]
     customFields?: ProfileCustomField[]
+    id: string
+    pii: boolean
+    isNewsletterOptIn?: boolean
   }
 
   interface Account {
@@ -264,5 +305,10 @@ declare global {
   interface Reference {
     Key: string
     Value: string
+  }
+
+  interface PIIRequest {
+    useCase: string,
+    onBehalfOf: string
   }
 }

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -136,48 +136,48 @@ declare global {
   }
 
   interface Account {
-    HostName: string,
-    MainAccountName: string,
-    IsPersisted: boolean,
-    IsRemoved: boolean,
-    Id: string,
-    Cnpj: string,
-    CompanyName: string,
-    TradingName: string,
-    AccountName: string,
-    DefaultUrl: string,
-    Address: string,
-    Number: string,
-    Complement: string,
-    District: string,
-    City: string,
-    State: string,
-    PostalCode: string,
-    Country: string,
-    Telephone: string,
-    IsActive: boolean,
-    Sponsor: string,
-    Logo: string,
-    AppId: string,
-    IsOperating: boolean,
-    LV: string,
-    Sigla: string,
-    AppKeys: string,
-    CreationDate: string,
-    OperationDate: string,
-    InactivationDate: string,
-    ParentAccountId: string,
-    ParentAccountName: string,
-    ChildAccounts: string[],
-    Platform: string,
-    Licenses: number[],
-    Workspace: string,
-    Stores: string[],
+    HostName: string
+    MainAccountName: string
+    IsPersisted: boolean
+    IsRemoved: boolean
+    Id: string
+    Cnpj: string
+    CompanyName: string
+    TradingName: string
+    AccountName: string
+    DefaultUrl: string
+    Address: string
+    Number: string
+    Complement: string
+    District: string
+    City: string
+    State: string
+    PostalCode: string
+    Country: string
+    Telephone: string
+    IsActive: boolean
+    Sponsor: string
+    Logo: string
+    AppId: string
+    IsOperating: boolean
+    LV: string
+    Sigla: string
+    AppKeys: string
+    CreationDate: string
+    OperationDate: string
+    InactivationDate: string
+    ParentAccountId: string
+    ParentAccountName: string
+    ChildAccounts: string[]
+    Platform: string
+    Licenses: number[]
+    Workspace: string
+    Stores: string[]
     Privacy: {
-      PII: string,
+      PII: string
     } | null
     Infra: {
-      Provider: string,
+      Provider: string
       Region: string
     } | null
     PIIEnabled: boolean
@@ -308,7 +308,7 @@ declare global {
   }
 
   interface PIIRequest {
-    useCase: string,
+    useCase: string
     onBehalfOf: string
   }
 }

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -94,6 +94,54 @@ declare global {
     customFields?: ProfileCustomField[]
   }
 
+  interface Account {
+    HostName: string,
+    MainAccountName: string,
+    IsPersisted: boolean,
+    IsRemoved: boolean,
+    Id: string,
+    Cnpj: string,
+    CompanyName: string,
+    TradingName: string,
+    AccountName: string,
+    DefaultUrl: string,
+    Address: string,
+    Number: string,
+    Complement: string,
+    District: string,
+    City: string,
+    State: string,
+    PostalCode: string,
+    Country: string,
+    Telephone: string,
+    IsActive: boolean,
+    Sponsor: string,
+    Logo: string,
+    AppId: string,
+    IsOperating: boolean,
+    LV: string,
+    Sigla: string,
+    AppKeys: string,
+    CreationDate: string,
+    OperationDate: string,
+    InactivationDate: string,
+    ParentAccountId: string,
+    ParentAccountName: string,
+    ChildAccounts: string[],
+    Platform: string,
+    Licenses: number[],
+    Workspace: string,
+    Stores: string[],
+    Privacy: {
+      PII: string,
+    } | null
+    Infra: {
+      Provider: string,
+      Region: string
+    } | null
+    PIIEnabled: boolean
+  }
+
   interface PersonalPreferences {
     [key: string]: string | number | boolean | undefined
     firstName?: string

--- a/node/resolvers/profile/fieldResolvers.ts
+++ b/node/resolvers/profile/fieldResolvers.ts
@@ -18,8 +18,8 @@ export default {
     cacheId: prop('id'),
   },
   Profile: {
-    address: (_: any, __: any, context: any) => getAddresses(context),
-    addresses: (_: any, __: any, context: any) => getAddresses(context),
+    address: (obj: any, __: any, context: any) => getAddresses(context, obj),
+    addresses: (obj: any, __: any, context: any) => getAddresses(context, obj),
     birthDate: (obj: any) =>
       obj.birthDate ? new Date(obj.birthDate).toISOString() : obj.birthDate,
     cacheId: prop('email'),
@@ -38,6 +38,7 @@ export default {
     corporateDocument: (obj: any, _: any, __: any) => obj.businessDocument,
     isCorporate: (obj: any, _: any, __: any) => obj.isPJ === 'True',
     tradeName: (obj: any, _: any, __: any) => obj.fancyName,
+    pii: (obj: any, _: any, __: any) => obj.pii,
   },
   ProfileCustomField: {
     cacheId: (root: any) => root.key,

--- a/node/resolvers/profile/index.ts
+++ b/node/resolvers/profile/index.ts
@@ -103,7 +103,7 @@ export const mutations = {
     }
 
     const userProfile = await profile
-      .getProfileInfo({ email, userId: '' })
+      .getProfileInfo({ email, userId: '' }, context, undefined)
       .catch(() => ({}))
 
     if (fields) {
@@ -147,7 +147,8 @@ export const mutations = {
     if (updateData) {
       await profile.updatePersonalPreferences(
         { email, userId: '' },
-        updatedPersonalPreferences
+        updatedPersonalPreferences,
+        context
       )
     }
 

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -196,13 +196,20 @@ export async function saveAddress(
   const addressesData = mapNewAddressToProfile(args.address, currentProfile)
   const [newId] = Object.keys(addressesData)
 
-  const result = await profile.updateAddress(currentProfile, addressesData, context)
+  const result = await profile.updateAddress(
+    currentProfile,
+    addressesData,
+    context
+  )
 
   if (result && result.document) {
     return result.document
   }
 
-  const currentAddresses = await profile.getUserAddresses(currentProfile, context)
+  const currentAddresses = await profile.getUserAddresses(
+    currentProfile,
+    context
+  )
 
   return currentAddresses.find(
     (address: Address) => address.addressName === newId

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -17,7 +17,7 @@ export async function getProfile(context: Context, customFields?: string) {
     : `profilePicture,id`
 
   return profile
-    .getProfileInfo(currentProfile, extraFields)
+    .getProfileInfo(currentProfile, context, extraFields)
     .then((profileData) => {
       if (profileData) {
         return {
@@ -57,7 +57,7 @@ export function getAddresses(context: Context) {
     vtex: { currentProfile },
   } = context
 
-  return profile.getUserAddresses(currentProfile)
+  return profile.getUserAddresses(currentProfile, context)
 }
 
 export async function getPayments(context: Context) {
@@ -66,7 +66,7 @@ export async function getPayments(context: Context) {
     vtex: { currentProfile },
   } = context
 
-  const paymentsRawData = await profile.getUserPayments(currentProfile)
+  const paymentsRawData = await profile.getUserPayments(currentProfile, context)
 
   if (!paymentsRawData?.paymentData) {
     return null
@@ -111,6 +111,7 @@ export async function updateProfile(
     .updateProfileInfo(
       currentProfile,
       newData,
+      context,
       extraFields && extraFields.customFieldsStr
     )
     .then(() => getProfile(context, extraFields && extraFields.customFieldsStr))
@@ -135,7 +136,7 @@ export function createAddress(context: Context, address: AddressInput) {
   const addressesData = mapNewAddressToProfile(address, currentProfile)
 
   return profile
-    .updateAddress(currentProfile, addressesData)
+    .updateAddress(currentProfile, addressesData, context)
     .then(() => getProfile(context))
 }
 
@@ -146,7 +147,7 @@ export function deleteAddress(context: Context, addressName: string) {
   } = context
 
   return profile
-    .deleteAddress(currentProfile, addressName)
+    .deleteAddress(currentProfile, addressName, context)
     .then(() => getProfile(context))
 }
 
@@ -168,7 +169,7 @@ export function updateAddress(
   })
 
   return profile
-    .updateAddress(currentProfile, addressesData)
+    .updateAddress(currentProfile, addressesData, context)
     .then(() => getProfile(context))
 }
 
@@ -195,9 +196,9 @@ export async function saveAddress(
   const addressesData = mapNewAddressToProfile(args.address, currentProfile)
   const [newId] = Object.keys(addressesData)
 
-  await profile.updateAddress(currentProfile, addressesData)
+  await profile.updateAddress(currentProfile, addressesData, context)
 
-  const currentAddresses = await profile.getUserAddresses(currentProfile)
+  const currentAddresses = await profile.getUserAddresses(currentProfile, context)
 
   return currentAddresses.find(
     (address) => address.addressName === newId

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -51,13 +51,13 @@ export function getPasswordLastUpdate(context: Context) {
   }).then((response: any) => response.data.passwordLastUpdate)
 }
 
-export function getAddresses(context: Context) {
+export function getAddresses(context: Context, currentUserProfile?: Profile) {
   const {
     clients: { profile },
     vtex: { currentProfile },
   } = context
 
-  return profile.getUserAddresses(currentProfile, context)
+  return profile.getUserAddresses(currentProfile, context, currentUserProfile)
 }
 
 export async function getPayments(context: Context) {
@@ -78,7 +78,7 @@ export async function getPayments(context: Context) {
   return availableAccounts.map((account: any) => {
     const { bin, availableAddresses, accountId, ...cleanAccount } = account
     const accountAddress = addresses.find(
-      (addr) => addr.addressName === availableAddresses[0]
+      (addr: Address) => addr.addressName === availableAddresses[0]
     )
 
     return { ...cleanAccount, id: accountId, address: accountAddress }
@@ -196,12 +196,16 @@ export async function saveAddress(
   const addressesData = mapNewAddressToProfile(args.address, currentProfile)
   const [newId] = Object.keys(addressesData)
 
-  await profile.updateAddress(currentProfile, addressesData, context)
+  const result = await profile.updateAddress(currentProfile, addressesData, context)
+
+  if (result && result.document) {
+    return result.document
+  }
 
   const currentAddresses = await profile.getUserAddresses(currentProfile, context)
 
   return currentAddresses.find(
-    (address) => address.addressName === newId
+    (address: Address) => address.addressName === newId
   ) as Address
 }
 


### PR DESCRIPTION
#### What problem is this solving?

This PR adds a Profile System V2 client. This new Profile System is the one that supports PII protection. The way we are using it is transparent to the end-user. There's some back and forth data translation because of it.

#### How to test it?

https://profilesystempii--qastoreeu.myvtex.com/_secure/account/orders#/profile
To query for the data (and then know that is PII enabled), you can use [the Profile System V2 API](https://profile-system-beta.vtex.systems/docs/profile-system/swagger/index.html#/) and look for your user email.

#### Screenshots or example usage:

There are no UI changes on this one.