### PR TITLE
Adding public namespace to sessionResolver; Respond B2B impersonate a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- B2B impersonation not loading profile page
 ## [2.149.3] - 2022-03-03
 ### Removed
 - `withCurrentProfile` directive from `subscribeNewsletter` mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - B2B impersonation not loading profile page
+
 ## [2.149.3] - 2022-03-03
 ### Removed
 - `withCurrentProfile` directive from `subscribeNewsletter` mutation.

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -76,9 +76,10 @@ async function getCurrentProfileFromSession(
         ? ({ email: profile.email, userId: profile.id } as CurrentProfile)
         : null,
       // If is impersonate is a call center op
-      userType: session?.impersonate?.profile
-        ? 'CallCenterOperator'
-        : 'StoreUser',
+      userType:
+        session?.impersonate?.profile || session?.public?.impersonate
+          ? 'CallCenterOperator'
+          : 'StoreUser',
     }
   })
 }

--- a/node/resolvers/session/sessionResolver.ts
+++ b/node/resolvers/session/sessionResolver.ts
@@ -118,6 +118,7 @@ export const sessionFields = (session: Session): SessionFields | {} => {
         impersonate: {
           ...setProfileData(namespaces.profile, namespaces.impersonate),
         },
+        public: namespaces.public,
         utmParams: setUtmParams(namespaces.public),
         utmiParams: setUtmiParams(namespaces.public),
         orderFormId: path(['public', 'orderFormId', 'value'], namespaces),


### PR DESCRIPTION
#### What problem is this solving?
B2B impersonation don't require Admin Access / LM Call Center Operator
This change makes the directive `withCurrentProfile` consider **B2B impersonation** as `CallCenterOperator` when responding for `userType`
<!--- What is the motivation and context for this change? -->

#### How to test it?
Access this [workspace](https://wender--b2bstoreqa.myvtex.com/)
Login using `Kevin.yee@vtex.com` and `Vtex1234`

Using GraphiQL IDE, select `storefront-permissions` app
run this mutation
``` graphql
mutation {
  impersonateUser(userId: "1820b65a-a8e8-418d-9c38-c755e015e22c") {
    message
    status
  }
}

```

Refresh the site to apply the sessions, navigate to **my account > profile**

#### Screenshots or example usage:

Without the change 
![image](https://user-images.githubusercontent.com/24723/159299720-96caf2c8-9a32-4f55-ba66-9ce186c2dba9.png)

With the change
![image](https://user-images.githubusercontent.com/24723/159299872-6b91e144-7742-438e-bdb5-96a77069a23c.png)

