### PR TITLE
Writing newsletter option to the correct place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Writing user preferences in the purchase-info data
+
 ## [2.151.0] - 2022-04-04
 
 ### Fixed

--- a/node/clients/profile/index.ts
+++ b/node/clients/profile/index.ts
@@ -79,11 +79,25 @@ export class ProfileClient extends JanusClient {
   public updatePersonalPreferences = (
     user: CurrentProfile,
     personalPreferences: PersonalPreferences,
-    context: Context
+    context: Context,
+    currentUserProfile?: Profile
   ) =>
-    this.getProfileClient(context).then((profileClient) =>
-      profileClient.updatePersonalPreferences(user, personalPreferences)
-    )
+    this.getProfileClient(context).then((profileClient) => {
+      if (!currentUserProfile) {
+        return profileClient.getProfileInfo(user).then((userProfile) => {
+          profileClient.updatePersonalPreferences(
+            user,
+            personalPreferences,
+            userProfile
+          )
+        })
+      }
+      return profileClient.updatePersonalPreferences(
+        user,
+        personalPreferences,
+        currentUserProfile
+      )
+    })
 
   private getProfileClient = (context: Context) => {
     const licenseManager = context.clients.licenseManagerExtended

--- a/node/clients/profile/profileV1.ts
+++ b/node/clients/profile/profileV1.ts
@@ -87,7 +87,8 @@ export class ProfileClientV1 extends JanusClient {
 
   public updatePersonalPreferences = (
     user: CurrentProfile,
-    personalPreferences: PersonalPreferences
+    personalPreferences: PersonalPreferences,
+    _: Profile
   ) =>
     this.post(
       `${this.baseUrl}/${getUserIdentification(user)}/personalPreferences/`,

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -328,7 +328,7 @@ export class ProfileClientV2 extends JanusClient {
     this.http.patch<T>(url, data, config).catch<any>(statusToError)
 
   protected put = <T>(url: string, data?: any, config?: RequestConfig) =>
-    this.http.patch<T>(url, data, config).catch<any>(statusToError)
+    this.http.put<T>(url, data, config).catch<any>(statusToError)
 
   private baseUrl = 'api/storage/profile-system/profiles'
 

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -49,20 +49,54 @@ export class ProfileClientV2 extends JanusClient {
       params: {
         extraFields: customFields,
       },
-    }).then((profile: ProfileV2[]) => {
-      if (profile.length > 0) {
-        const profileV2 = {
-          ...profile[0].document,
-          pii: true,
-          id: profile[0].id,
+    })
+      .then((profile: ProfileV2[]) => {
+        if (profile.length > 0) {
+          const profileV2 = {
+            ...profile[0].document,
+            pii: true,
+            id: profile[0].id,
+          }
+
+          return profileV2
         }
 
-        profileV2.isNewsletterOptIn = profileV2.isNewsletterOptIn || false
+        return {} as Profile
+      })
+      .then((profile: Profile) => this.fillWithPreferences(profile, piiRequest))
+  }
 
-        return profileV2
+  private fillWithPreferences = (profile: Profile, piiRequest?: PIIRequest) => {
+    return this.getPurchaseInfo(profile, piiRequest)
+      .then((purchaseInfoList: PurchaseInfo[]) => {
+        const purchaseInfo = purchaseInfoList[0]
+
+        profile.isNewsletterOptIn =
+          purchaseInfo.document.clientPreferences?.isNewsletterOptIn ?? false
+        return profile
+      })
+      .catch(() => {
+        profile.isNewsletterOptIn = false
+        return profile
+      })
+  }
+
+  private getPurchaseInfo = (profile: Profile, piiRequest?: PIIRequest) => {
+    const url = this.getPIIUrl(
+      `${this.baseUrl}/${profile.id}/purchase-info`,
+      undefined,
+      piiRequest
+    )
+
+    return this.get<PurchaseInfo>(url, {
+      metric: 'profile-system-v2-getUserPreferences',
+    }).catch<any>((e) => {
+      const { status } = e.response ?? {}
+      if (status === 404) {
+        return [] as PurchaseInfo[]
       }
 
-      return {} as Profile
+      return statusToError(e)
     })
   }
 
@@ -77,19 +111,25 @@ export class ProfileClientV2 extends JanusClient {
     )
 
   public updatePersonalPreferences = (
-    user: CurrentProfile,
-    personalPreferences: PersonalPreferences
+    _: CurrentProfile,
+    personalPreferences: PersonalPreferences,
+    currentUserProfile: Profile
   ) => {
-    const { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
     const parsedPersonalPreferences = Object.fromEntries(
       Object.entries(personalPreferences).map(([key, value]) => {
         return [key, value === 'True']
       })
     )
 
-    return this.patch(
-      `${this.baseUrl}/${userKey}?alternativeKey=${alternativeKey}`,
-      parsedPersonalPreferences,
+    let purchaseInfo = {
+      clientPreferences: {
+        ...parsedPersonalPreferences,
+      },
+    }
+
+    return this.put(
+      `${this.baseUrl}/${currentUserProfile.id}/purchase-info`,
+      purchaseInfo,
       {
         metric: 'profile-system-v2-subscribeNewsletter',
       }
@@ -102,12 +142,6 @@ export class ProfileClientV2 extends JanusClient {
     customFields?: string
   ) => {
     const { userKey, alternativeKey } = this.getUserKeyAndAlternateKey(user)
-
-    if (!(profile as Profile)) {
-      const profileCast = profile as Profile
-      profileCast.gender = profileCast.gender || ''
-      profileCast.document = profileCast.document || ''
-    }
 
     return this.patch(
       `${this.baseUrl}/${userKey}?alternativeKey=${alternativeKey}`,
@@ -291,6 +325,9 @@ export class ProfileClientV2 extends JanusClient {
     this.http.delete<T>(url, config).catch<any>(statusToError)
 
   protected patch = <T>(url: string, data?: any, config?: RequestConfig) =>
+    this.http.patch<T>(url, data, config).catch<any>(statusToError)
+
+  protected put = <T>(url: string, data?: any, config?: RequestConfig) =>
     this.http.patch<T>(url, data, config).catch<any>(statusToError)
 
   private baseUrl = 'api/storage/profile-system/profiles'

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -121,7 +121,7 @@ export class ProfileClientV2 extends JanusClient {
       })
     )
 
-    let purchaseInfo = {
+    const purchaseInfo = {
       clientPreferences: {
         ...parsedPersonalPreferences,
       },

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -135,6 +135,17 @@ declare global {
     isNewsletterOptIn?: boolean
   }
 
+  interface PurchaseInfo {
+    id: string
+    document: {
+      clientPreferences: {
+        userId: string
+        localeDefault: string
+        isNewsletterOptIn?: boolean
+      }
+    }
+  }
+
   interface Account {
     HostName: string
     MainAccountName: string


### PR DESCRIPTION
#### What problem is this solving?
This PR writes the newsletter option in the correct place

#### How to test it?
Use this [Workspace](https://newsletter--qastoreeu.myvtex.com/_secure/account/orders#/profile) and toggle your newsletter preference.
It will be saving in your purchase info in the new Profile System. Link for the Profile System query if you don't belive me in link 1 (you got to find out your user id in it to get it. See link 2. More trouble then it's worth it, I know...)

Link 1: Fetching purchase info -> GET https://portal.vtexcommercestable.com.br/api/storage/profile-system/profiles/<your-user-id>/purchase-info?an=qastoreeu
Link 2: Fetching your user profile -> GET https://portal.vtexcommercestable.com.br/api/storage/profile-system/profiles/<your-email>/?an=qastoreeu&alternativeKey=email
