### PR TITLE
fix: price should consider orderForm price instead of sellingPrice with unitMultiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Discrepancy in simulation's Price duo unitMultiplier
+- Discrepancy in simulation's Price due to unitMultiplier
 
 ## [2.152.0] - 2022-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Discrepancy in simulation's Price duo unitMultiplier
+
 ## [2.152.0] - 2022-04-18
 
 ### Fixed

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -114,6 +114,7 @@ interface CommertialOffer {
   BuyTogether: any[]
   ItemMetadataAttachment: any[]
   Price: number
+  PriceWithPriceTags: number
   ListPrice: number
   PriceWithoutDiscount: number
   RewardValue: number

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -68,18 +68,10 @@ export const orderFormItemToSeller = (
     logisticsInfo: any[]
   }
 ) => {
-  const unitMultiplier = orderFormItem.unitMultiplier ?? 1
   const [logisticsInfo] = orderFormItem.logisticsInfo
 
   const commertialOffer = {
-    Price: orderFormItem.priceDefinition?.calculatedSellingPrice
-      ? Number(
-          (
-            orderFormItem.priceDefinition.calculatedSellingPrice /
-            (unitMultiplier * 100)
-          ).toFixed(2)
-        )
-      : orderFormItem.price / 100,
+    Price: orderFormItem.price / 100,
     PriceValidUntil: orderFormItem.priceValidUntil,
     ListPrice: orderFormItem.listPrice / 100,
     PriceWithoutDiscount: orderFormItem.price / 100,


### PR DESCRIPTION
#### What problem is this solving?

We are having Price divergences between PDP and checkout with search queries:

Price nowadays is being calculated in the following way: `SellingPrice / (unitMultiplier * 100)`, and this is not accurate. Sometimes when the unit multiplier is an integer value or maybe duo coincidence you will have the price matching, but, when the price is float, the price won't be accurate in most the cases and you will have the discrepancy of cents

So, to fix it, the correct value of price should be price/100, we will have the same value of the checkout API

#### How to test it?

[PDP:](https://master--gbarbosaqa.myvtex.com/manga-rosa-kg/p) 

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/13649073/169170680-11895744-9124-411d-89f5-6a9a2158b106.png">

[Search without fix:](https://master--gbarbosaqa.myvtex.com/hortifruti) 

<img width="519" alt="image" src="https://user-images.githubusercontent.com/13649073/169170835-b5a30dd3-b43f-46d5-9d65-f4c900bdf231.png">

[Search with fix:](https://rbussola--gbarbosaqa.myvtex.com/hortifruti) 

<img width="516" alt="image" src="https://user-images.githubusercontent.com/13649073/169171275-a342e70a-ead6-40eb-92f3-cb9906f72e83.png">

Other examples at zonasul, products: [20457](https://iespinoza--zonasul.myvtex.com/alho-roxo-150g-93009/p)


#### Describe alternatives you've considered, if any.

You can also test in the simulation call checking for the price there:

```
curl --request POST \
  --url 'https://gbarbosaqa.vtexcommercestable.com.br/api/checkout/pvt/orderForms/simulation?sc=1' \
  --header 'Content-Type: application/json' \
  --header 'VtexIdclientAutCookie: xx' \
  --data '{"items":
 	[{
		"id":"84",
		"quantity": 1,
		"seller": "1"
	 }],
 "shippingData":
 	{
		"logisticsInfo":
		[{
			"regionId":""
	 }]
	}
}'
```

<img width="350" alt="image" src="https://user-images.githubusercontent.com/13649073/169172604-67ccc2e4-3b0d-414e-b713-1b39be6b4466.png">


new price = 697 (price) / 100 = 6.97 ✅ 
old price = 104 (sellingPrice) / (0.1500 (Unit Multiplier) * 100) = 6.9333... ❌ 


#### Related to / Depends on

Zendesk 578022

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/3oEjHZKRgiZXYmVVbq/giphy.gif)
