### PR TITLE
fix: inaccurate price due to the rounded sellingPrice in simulation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Changed how to calculate price in `commertialOffer`, now considering price + pricetags instead of sellingPrice / unitMultiplier
+
 ## [2.152.2] - 2022-06-28
 
 ### Fixed
-- InterestRate should be in its percet format
+- InterestRate should be in its percent format
 
 ## [2.152.1] - 2022-05-23 [YANKED]
 

--- a/node/typings/Checkout.ts
+++ b/node/typings/Checkout.ts
@@ -57,7 +57,7 @@ interface OrderFormItem {
   parentItemIndex: number | null
   parentAssemblyBinding: string | null
   productCategoryIds: string
-  priceTags: string[]
+  priceTags: PriceTag[]
   measurementUnit: string
   additionalInfo: {
     brandName: string
@@ -78,6 +78,12 @@ interface OrderFormItem {
     sellingPrices: SellingPrice[]
     total: number
   } | null
+}
+
+interface PriceTag {
+  value: number
+  rawValue: number
+  isPercentual: boolean
 }
 
 interface SellingPrice {

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -71,9 +71,7 @@ export const orderFormItemToSeller = (
 
   const [logisticsInfo] = orderFormItem.logisticsInfo
 
-  const priceTags = orderFormItem.priceTags?.reduce(
-    (discount, priceTag: PriceTag) => discount + priceTag.value, 0
-  )
+  const priceTags = orderFormItem.priceTags?.reduce((discount, priceTag: PriceTag) => discount + priceTag.value, 0)
 
   const commertialOffer = {
     Price: (orderFormItem.price + priceTags) / 100,

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -68,10 +68,10 @@ export const orderFormItemToSeller = (
     logisticsInfo: any[]
   }
 ) => {
-
   const [logisticsInfo] = orderFormItem.logisticsInfo
 
-  const priceTags = orderFormItem.priceTags?.reduce((discount, priceTag: PriceTag) => discount + priceTag.value, 0)
+  const priceTags = orderFormItem.priceTags?.reduce(
+    (discount, priceTag: PriceTag) => discount + priceTag.value, 0)
 
   const commertialOffer = {
     Price: (orderFormItem.price + priceTags) / 100,

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -68,18 +68,15 @@ export const orderFormItemToSeller = (
     logisticsInfo: any[]
   }
 ) => {
-  const unitMultiplier = orderFormItem.unitMultiplier ?? 1
+
   const [logisticsInfo] = orderFormItem.logisticsInfo
 
+  const priceTags = orderFormItem.priceTags?.reduce(
+    (discount, priceTag: PriceTag) => discount + priceTag.value, 0
+  )
+
   const commertialOffer = {
-    Price: orderFormItem.priceDefinition?.calculatedSellingPrice
-      ? Number(
-          (
-            orderFormItem.priceDefinition.calculatedSellingPrice /
-            (unitMultiplier * 100)
-          ).toFixed(2)
-        )
-      : orderFormItem.price / 100,
+    Price: (orderFormItem.price + priceTags) / 100,
     PriceValidUntil: orderFormItem.priceValidUntil,
     ListPrice: orderFormItem.listPrice / 100,
     PriceWithoutDiscount: orderFormItem.price / 100,


### PR DESCRIPTION
#### What problem is this solving?

We are having Price divergences between PDP and checkout with search queries:

Price nowadays is being calculated in the following way: `SellingPrice / (unitMultiplier * 100)`, and this is not accurate because the selling price is rounded in simulation API. Sometimes when the unit multiplier is an integer value or maybe due to coincidence you will have the price matching, but, when the price is float, the price won't be accurate in most the cases and you will have the discrepancy of cents due to the rounded sellingPrice being divided by a float number in unitMultiplier

So, to fix it, the correct value of price should be price/100 + priceTags, because sellingPrice is always rounded in simulation API, and price and priceTags are always the full prices. With that, we will have more precision in price value. 

For the checkout API the price is what we call in our code priceWithoutDiscount, so, the price with discounts (our current price), should be calculated using the price + price tags (that are the discounts)

Fixing the problem of this change in the PR: #604

#### How to test it?

Account: zonasul
Product id: 5582
SKU: 5566

[PDP:](https://master--zonasul.myvtex.com/tomate-carmen-650g-36919/p) 

<img width="640" alt="image" src="https://user-images.githubusercontent.com/13649073/174496755-cc5b4fe8-f52c-4d1f-b67f-a9a17c81781a.png">


[Search without fix:](https://iespinoza--zonasul.myvtex.com/tomate%20carmen?_q=tomate%20carmen&map=ft) 

(make sure that the prop __unstableProductOriginVtex is set as false, I set it as false in this workspace, but, in master it is set as true)

<img width="588" alt="image" src="https://user-images.githubusercontent.com/13649073/174496823-48f399ec-8eeb-43b8-9c94-5a4a4f0327a0.png">


[Search with fix:](https://iespinoza2--zonasul.myvtex.com/tomate%20carmen?_q=tomate%20carmen&map=ft) 

<img width="513" alt="image" src="https://user-images.githubusercontent.com/13649073/174496979-9c271fe8-d121-4d51-ad1c-11c0188b3045.png">

Another example at zonasul, product: [5629](https://master--zonasul.myvtex.com/aipim-600g-18686/p)


About the problem related to the discounts (pricetags) not being considered in other accounts, solving the problem of the PR #604, I got minisomx as an example on the outlet page:

[How it is now](https://master--minisomx.myvtex.com/outlet)
[Same page, with the old fix without priceTags (not applying discounts)](https://iespinoza2--minisomx.myvtex.com/outlet)
[Same page, with this fix with priceTags (applying discounts)](https://iespinoza--minisomx.myvtex.com/outlet)

<img width="1300" alt="image" src="https://user-images.githubusercontent.com/13649073/174497334-d8c2c3c2-c859-4f1a-a64e-9d17545df808.png">


#### Describe alternatives you've considered if any.

You can also test in the simulation call by checking for the price there:

```
curl --request POST \
  --url 'https://zonasul.vtexcommercestable.com.br/api/checkout/pvt/orderForms/simulation?sc=1' \
  --header 'Content-Type: application/json' \
  --header 'VtexIdclientAutCookie: xx' \
  --data '{"items":
 	[{
		"id":"5566",
		"quantity": 1,
		"seller": "1"
	 }],
 "shippingData":
 	{
		"logisticsInfo":
		[{
			"regionId":""
	 }]
	}
}'
```



new price = (599 (price) + 0 (pricetags) ) / 100 = 5.99 ✅ 
old price = (389 (sellingPrice) / 0.650 (Unit Multiplier) * 100) = 5.984... ❌ .toFixed(2) = 5.98


```
curl --request POST \
  --url 'https://minisomx.vtexcommercestable.com.br/api/checkout/pvt/orderForms/simulation?sc=1' \
  --header 'Content-Type: application/json' \
  --header 'VtexIdclientAutCookie: xx' \
  --data '{"items":
 	[{
		"id":"4108",
		"quantity": 1,
		"seller": "1"
	 }],
 "shippingData":
 	{
		"logisticsInfo":
		[{
			"regionId":""
	 }]
	}
}'
```



new price = (17990 (price) + -8995 (pricetags) ) / 100 = 89.95 ✅ 
old price = (8995 (sellingPrice) / 1 (Unit Multiplier) * 100) = 89.95 ✅ .toFixed(2) = 89.95 

Promotion applied ✅ 


#### Related to / Depends on

Zendesk 578022

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/l0HlVjEQTfcjN7Vh6/giphy.gif)
