### PR TITLE
fix: InterestRate should be in its percet format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- InterestRate should be in its percet format
+
 ## [2.152.1] - 2022-05-23 [YANKED]
 
 ### Fixed

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -103,7 +103,7 @@ export const orderFormItemToSeller = (
     installmentOption.installments.forEach((installment) => {
       commertialOffer.Installments.push({
         Value: installment.value / 100,
-        InterestRate: installment.interestRate,
+        InterestRate: installment.interestRate / 100,
         TotalValuePlusInterestRate: installment.total / 100,
         NumberOfInstallments: installment.count,
         PaymentSystemName: installmentOption.paymentName,


### PR DESCRIPTION
#### What problem is this solving?

InterestRate as integer in simulation API

The simulation API display this value as an integer, duo that, we are displaying wrongly the interest rate on the search side

#### How to test it?

[With the fix](https://iespinoza--omnilink.myvtex.com/omniturbo?_q=Omniturbo&map=ft)

<img width="363" alt="image" src="https://user-images.githubusercontent.com/13649073/175435888-00fd4253-5092-4765-aab8-3abb24ead857.png">


[Without the fix](https://iespinoza2--omnilink.myvtex.com/omniturbo?_q=Omniturbo&map=ft)

<img width="355" alt="image" src="https://user-images.githubusercontent.com/13649073/175435872-91c77751-2694-40a1-ba1d-d7e5d73173f3.png">

Checking simulation call:

```
curl --request POST \
  --url 'https://omnilink.vtexcommercestable.com.br/api/checkout/pvt/orderForms/simulation?sc=1' \
  --header 'Content-Type: application/json' \
  --header 'VtexIdclientAutCookie: xx' \
  --data '{"items":
 	[{
		"id":"2",
		"quantity": 1,
		"seller": "1"
	 }],
 "shippingData":
 	{
		"logisticsInfo":
		[{
			"regionId":""
	 }]
	}
}'
```
<img width="256" alt="image" src="https://user-images.githubusercontent.com/13649073/175436115-b712e859-f099-46f0-a093-2ff1c36f14e8.png">

SOLR Search API: 

`https://omnilink.vtexcommercestable.com.br/api/catalog_system/pub/products/search/omniturbo`

IS API:

`https://omnilink.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/?query=product:2`

Calling store-graphql:

https://github.com/vtex/intelligent-search-api/blob/ac9734f893ac3c81df87a566aaf523b67be2bbe6/node/clients/store/index.ts#L18

#### Related to / Depends on

Zendesk: #575811

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/UuBsS5SAjO0yVJCiuD/giphy.gif)
