### PR TITLE
Add holidayHours query to logistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added query to logistics to return holidays
+
 ## [2.152.4] - 2022-07-12
 
 ### Fixed

--- a/graphql/types/Logistics.graphql
+++ b/graphql/types/Logistics.graphql
@@ -17,6 +17,7 @@ type PickupPoint {
   """
   If false, it means pickup point is currently disabled
   """
+  pickupHolidays: [HolidayHours]
   isActive: Boolean
   """
   Distance in kilometers if this is a search result
@@ -48,6 +49,21 @@ type BusinessHours {
   Closing time in format HH:MM:SS
   """
   closingTime: String
+}
+
+type HolidayHours {
+  """
+  date time in format HH:MM:SS
+  """
+  date: String
+  """
+  hourBegin time in format HH:MM:SS
+  """
+  hourBegin: String
+  """
+  hourEnd time in format HH:MM:SS
+  """
+  hourEnd: String
 }
 
 type NearPickupPointQueryResponse {

--- a/graphql/types/Logistics.graphql
+++ b/graphql/types/Logistics.graphql
@@ -17,8 +17,11 @@ type PickupPoint {
   """
   If false, it means pickup point is currently disabled
   """
-  pickupHolidays: [HolidayHours]
   isActive: Boolean
+  """
+    Pickup point restrictions
+  """
+  pickupHolidays: [HolidayHours]
   """
   Distance in kilometers if this is a search result
   """


### PR DESCRIPTION
#### What problem is this solving?
- Currently when retrieving the store information, there weren't any store hours for the holidays, this was added

#### How to test it?
- Using the GraphhQL IDE create a query using any `store id`
- Using it in a working workspace [here](https://beto--productusqa.myvtex.com/store/mexico-pickup-point-ciudad-de-mexico-03580/Mexico1)

#### Screenshots or example usage:
![Image 2022-07-01 at 8 56 48 a m](https://user-images.githubusercontent.com/11176519/176908820-a9526ac8-6131-4179-9438-ae244ff8895f.jpg)
