### PR TITLE
Fix/discount price tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.152.3] - 2022-07-04
+### Fixed
+- Price shouldn't consider tax, this is sellingPriceWithoutTax, considering only discounts in pricetags at `simulation.ts`  
 
 ## [2.152.3] - 2022-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.152.3] - 2022-07-04
+
 ## [2.152.3] - 2022-06-30
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.152.4-beta.0",
+  "version": "2.152.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.152.3-beta.0",
+  "version": "2.152.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.152.3",
+  "version": "2.152.4-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.152.2",
+  "version": "2.152.3-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.152.2",
+  "version": "2.152.3",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.152.3",
+  "version": "2.152.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/typings/Checkout.ts
+++ b/node/typings/Checkout.ts
@@ -81,6 +81,7 @@ interface OrderFormItem {
 }
 
 interface PriceTag {
+  name: string,
   value: number
   rawValue: number
   isPercentual: boolean

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -72,8 +72,8 @@ export const orderFormItemToSeller = (
 
   const discountPriceTags = orderFormItem.priceTags?.reduce(
     (discount, priceTag: PriceTag) =>
-      priceTag.name.includes("discount") ? discount + priceTag.value: discount,
-       0
+      priceTag.name.includes('discount') ? discount + priceTag.value: discount,
+      0
   )
 
   const commertialOffer = {

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -72,8 +72,8 @@ export const orderFormItemToSeller = (
 
   const discountPriceTags = orderFormItem.priceTags?.reduce(
     (discount, priceTag: PriceTag) =>
-      priceTag.name.includes('discount') ? discount + priceTag.value: discount,
-      0
+      priceTag.name.includes('discount') ? discount + priceTag.value : discount,
+    0
   )
 
   const commertialOffer = {

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -81,7 +81,6 @@ export const orderFormItemToSeller = (
     PriceValidUntil: orderFormItem.priceValidUntil,
     ListPrice: orderFormItem.listPrice / 100,
     PriceWithoutDiscount: orderFormItem.price / 100,
-    Tax: orderFormItem.tax,
     AvailableQuantity:
       orderFormItem?.availability === 'available' &&
       (logisticsInfo ? logisticsInfo.stockBalance : 1)

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -72,8 +72,8 @@ export const orderFormItemToSeller = (
 
   const discountPriceTags = orderFormItem.priceTags?.reduce(
     (discount, priceTag: PriceTag) =>
-      priceTag.name.includes("discount") ? discount + priceTag.value
-        : discount, 0
+      priceTag.name.includes("discount") ? discount + priceTag.value: discount,
+       0
   )
 
   const commertialOffer = {

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -70,14 +70,18 @@ export const orderFormItemToSeller = (
 ) => {
   const [logisticsInfo] = orderFormItem.logisticsInfo
 
-  const priceTags = orderFormItem.priceTags?.reduce(
-    (discount, priceTag: PriceTag) => discount + priceTag.value, 0)
+  const discountPriceTags = orderFormItem.priceTags?.reduce(
+    (discount, priceTag: PriceTag) =>
+      priceTag.name.includes("discount") ? discount + priceTag.value
+        : discount, 0
+  )
 
   const commertialOffer = {
-    Price: (orderFormItem.price + priceTags) / 100,
+    Price: (orderFormItem.price + discountPriceTags) / 100,
     PriceValidUntil: orderFormItem.priceValidUntil,
     ListPrice: orderFormItem.listPrice / 100,
     PriceWithoutDiscount: orderFormItem.price / 100,
+    Tax: orderFormItem.tax,
     AvailableQuantity:
       orderFormItem?.availability === 'available' &&
       (logisticsInfo ? logisticsInfo.stockBalance : 1)


### PR DESCRIPTION
#### What problem is this solving?

We are considering tax in price, we should only consider discount pricetags because this price is the "priceWithoutTax"

#### How to test it?

[Without Tax (only discount)](https://pricetagsdiscount--dmujeresec.myvtex.com/24359)

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/13649073/178406859-00e98d14-e44b-4154-b104-4aac5b4c13f1.png">


[With Tax (installing v2.152.3)](https://pricetagstax--dmujeresec.myvtex.com/24359)

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/13649073/178406686-632cf3c2-5106-468a-ab32-7e69ed17aec3.png">

```
curl --request POST \
  --url 'https://dmujeresec.vtexcommercestable.com.br/api/checkout/pvt/orderForms/simulation?sc=1' \
  --header 'Content-Type: application/json' \
  --header 'VtexIdclientAutCookie: xxx' \
  --data '{"items":
 	[{
		"id":"24359",
		"quantity": 1,
		"seller": "1"
	 }],
 "shippingData":
 	{
		"logisticsInfo":
		[{
			"regionId":""
	 }]
	}
}'
```

Other test account: capsulasexpressdev
Product id: 33

Without Tax
<img width="976" alt="image" src="https://user-images.githubusercontent.com/13649073/178408118-b84a89ba-285f-4afe-9140-bb88d4cd46e9.png">

With tax
<img width="944" alt="image" src="https://user-images.githubusercontent.com/13649073/178408627-94cc8082-94a9-4bbb-8fba-193520e841d3.png">

Checking in miniso

Without fix from this and other PRs: 
https://master--minisomx.myvtex.com/outlet

With the fix (still showing the discounts)
https://iespinoza--minisomx.myvtex.com/outlet

#### Related to / Depends on

#608 and #604

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/5Z71mBwbsOevBg35po/giphy.gif)
