### PR TITLE
Reverts change on how to calculate price in `commertialOffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Revert change on how to calculate price in `commertialOffer` done at [#608](https://github.com/vtex-apps/store-graphql/pull/608)
 ## [2.153.0] - 2022-07-19
 
 ### Added

--- a/node/typings/Checkout.ts
+++ b/node/typings/Checkout.ts
@@ -57,7 +57,7 @@ interface OrderFormItem {
   parentItemIndex: number | null
   parentAssemblyBinding: string | null
   productCategoryIds: string
-  priceTags: PriceTag[]
+  priceTags: string[]
   measurementUnit: string
   additionalInfo: {
     brandName: string
@@ -78,13 +78,6 @@ interface OrderFormItem {
     sellingPrices: SellingPrice[]
     total: number
   } | null
-}
-
-interface PriceTag {
-  name: string,
-  value: number
-  rawValue: number
-  isPercentual: boolean
 }
 
 interface SellingPrice {

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -68,16 +68,18 @@ export const orderFormItemToSeller = (
     logisticsInfo: any[]
   }
 ) => {
+  const unitMultiplier = orderFormItem.unitMultiplier ?? 1
   const [logisticsInfo] = orderFormItem.logisticsInfo
 
-  const discountPriceTags = orderFormItem.priceTags?.reduce(
-    (discount, priceTag: PriceTag) =>
-      priceTag.name.includes('discount') ? discount + priceTag.value : discount,
-    0
-  )
-
   const commertialOffer = {
-    Price: (orderFormItem.price + discountPriceTags) / 100,
+    Price: orderFormItem.priceDefinition?.calculatedSellingPrice
+    ? Number(
+        (
+          orderFormItem.priceDefinition.calculatedSellingPrice /
+          (unitMultiplier * 100)
+        ).toFixed(2)
+      )
+    : orderFormItem.price / 100,
     PriceValidUntil: orderFormItem.priceValidUntil,
     ListPrice: orderFormItem.listPrice / 100,
     PriceWithoutDiscount: orderFormItem.price / 100,


### PR DESCRIPTION
## problem is this solving?

This PR reverted changes made at #608 that caused prices to be wrong displayed in product list pages:

### Before Changes (with negative prices)
![image](https://user-images.githubusercontent.com/8497187/181361072-96ed7451-eaf1-4c64-a020-0f325e4cb3d4.png)

### After Changes (with correct prices)
![image](https://user-images.githubusercontent.com/8497187/181361163-07c63613-8683-489b-b0c0-5b4e953264ac.png)

### How to test it?

[Workspace](https://danzan--masonlineprod.myvtex.com/donuts?_q=donuts&map=ft)

### Related to / Depends on

Related escalation: https://vtex.slack.com/archives/C017NPK8U86/p1658826643797209

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3d6WO0F9SK9hbmpsiX/giphy.gif)
