### PR TITLE
Fixing bug PII address street number null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixing null streetNumber bug
+
 ## [2.154.0] - 2022-08-04
 
 ### Fixed

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -219,7 +219,7 @@ export class ProfileClientV2 extends JanusClient {
           postalCode: address.postalCode,
           profileId: address.userId,
           route: address.street,
-          streetNumber: address.number,
+          streetNumber: address.number || '',
           receiverName: address.receiverName,
           neighborhood: address.neighborhood,
         },

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -219,7 +219,7 @@ export class ProfileClientV2 extends JanusClient {
           postalCode: address.postalCode,
           profileId: address.userId,
           route: address.street,
-          streetNumber: address.number || '',
+          streetNumber: address.number ?? '',
           receiverName: address.receiverName,
           neighborhood: address.neighborhood,
         },


### PR DESCRIPTION
#### What problem is this solving?
https://vtex.slack.com/archives/G016AGYHTV2/p1655995368610139

#### How to test it?

[Workspace](https://vtex.slack.com/archives/G016AGYHTV2/p1655995368610139https://fixaddress--gmheritageprod.myvtex.com/account)
Create a new profile (by accessing the user profile page) and create a new address. This should work just fine. It is not in stable.

#### How does this PR make you feel? [:link:](http://giphy.com/)
Happy

![](put .gif link here - can be found under "advanced" on giphy)
