### PR TITLE
fix: remove white space on graphql schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove white space on graphql schema
+
 ## [2.154.2] - 2022-08-08
 
 ## [2.154.1] - 2022-08-05

--- a/graphql/types/Logistics.graphql
+++ b/graphql/types/Logistics.graphql
@@ -19,7 +19,7 @@ type PickupPoint {
   """
   isActive: Boolean
   """
-    Pickup point restrictions
+  Pickup point restrictions
   """
   pickupHolidays: [HolidayHours]
   """


### PR DESCRIPTION
This pr try to solve this problem
```cmd
error:build.status: fail - New GraphQL route types or parameters have been added since the previously published version of the app. This app should be published as a new minor.
New features:
HolidayHours was added.
PickupPoint.pickupHolidays was added.
```

So, we try to re-publish the graphql as a minor