### PR TITLE
Revert "Revert "Bump y18n from 4.0.0 to 4.0.3 in /node""

### DIFF
--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6666,9 +6666,9 @@ xss@^1.0.8:
     cssfilter "0.0.10"
 
 y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Reverts vtex-apps/store-graphql#614

Reverting again because it was reverted due to another problem that had nothing to do with those changes.