### PR TITLE
Update follow-redirects version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `follow-redirects` to resolutions yarn field
 
 ## [2.155.29] - 2022-08-12
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -57,7 +57,8 @@
     "json-schema": "^0.4.0",
     "jsdom": "^16.5.0",
     "jest-environment-jsdom": "^26.0.0",
-    "node-notifier": "^8.0.1"
+    "node-notifier": "^8.0.1",
+    "follow-redirects": "^1.14.8"
   },
   "version": "2.155.29"
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2899,13 +2899,6 @@ debug@4:
   dependencies:
     ms "2.1.2"
 
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3275,14 +3268,7 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
-
-follow-redirects@^1.14.0, follow-redirects@^1.3.0:
+follow-redirects@1.5.10, follow-redirects@^1.14.0, follow-redirects@^1.14.8, follow-redirects@^1.3.0:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==


### PR DESCRIPTION
#### What problem is this solving?

We are updating dependencies to solve some security issues alerted by `dependabot`.
`dependabot` couldn't update automatically those:

1. https://github.com/vtex-apps/store-graphql/security/dependabot/51
2. https://github.com/vtex-apps/store-graphql/security/dependabot/58

Both are related to `follow-redirects`.

#### How to test it?

Nothing should've changed: [workspace](https://laricia--storecomponents.myvtex.com/)