### PR TITLE
Adds sampling on authorizationMetrics logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `withAuthMetrics` directive now logs 1 from 100 unauthorized requests
 
 ## [2.155.31] - 2022-08-15
 ### Added

--- a/node/directives/authorizationMetrics.ts
+++ b/node/directives/authorizationMetrics.ts
@@ -20,7 +20,7 @@ function checkForAuthorization(ctx: any, info: GraphQLResolveInfo) {
   const vtexIdToken =
     ctx.cookies.get('VtexIdclientAutCookie') ?? ctx.get('VtexIdclientAutCookie')
 
-  if (!vtexIdToken) {
+  if (!vtexIdToken && Math.floor(Math.random() * 100) == 0) {
     logger.warn({
       message: 'Private route being accessed by unauthorized user',
       userAgent,

--- a/node/directives/authorizationMetrics.ts
+++ b/node/directives/authorizationMetrics.ts
@@ -20,7 +20,7 @@ function checkForAuthorization(ctx: any, info: GraphQLResolveInfo) {
   const vtexIdToken =
     ctx.cookies.get('VtexIdclientAutCookie') ?? ctx.get('VtexIdclientAutCookie')
 
-  if (!vtexIdToken && Math.floor(Math.random() * 100) == 0) {
+  if (!vtexIdToken && Math.floor(Math.random() * 100) === 0) {
     logger.warn({
       message: 'Private route being accessed by unauthorized user',
       userAgent,


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds sampling to the `authorizationMetrics` directive logs.

#### What problem is this solving?
We found that logs with the message `Private route being accessed by unauthorized user` are responsible for sending **3GB of data to Splunk by hour**.

So, this PR adds a random function to reduce the amount 100x, decreasing the amount logged to 30MB per hour.

#### How should this be manually tested?
Nothing should have changed, and the amount logged should decrease