### PR TITLE
[CHK-2129] Properly handle the new CheckoutOrderFormOwnership cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [2.157.1] - 2022-09-22
+### Added
+- Handle the new `CheckoutOrderFormOwnership` cookie.
 
 ### Fixed
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,5 +1,7 @@
 directive @withAuthMetrics on FIELD_DEFINITION
 
+directive @withOwnerId on FIELD_DEFINITION
+
 type Query {
   """
   Returns a specified product
@@ -292,6 +294,7 @@ type Query {
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
     @withSegment
     @withOrderFormId
+    @withOwnerId
 
   """
   Returns checkout cart details
@@ -299,6 +302,7 @@ type Query {
   orderForm: OrderForm
     @cacheControl(maxAge: ZERO, scope: PRIVATE)
     @withOrderFormId
+    @withOwnerId
     @withSegment
 
   """
@@ -309,7 +313,7 @@ type Query {
   """
   Returns user orders details
   """
-  orders: [Order] @cacheControl(scope: PRIVATE) @withOrderFormId
+  orders: [Order] @cacheControl(scope: PRIVATE) @withOrderFormId @withOwnerId
 
   """
   Returns a specified user order
@@ -593,21 +597,21 @@ type Mutation {
     Optional marketing UTMi Params to add them to order form
     """
     utmiParams: OrderFormInputUTMIParams
-  ): OrderForm @withSegment @withOrderFormId
+  ): OrderForm @withSegment @withOrderFormId @withOwnerId
   cancelOrder(
     orderFormId: String
       @deprecated(
         reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
       )
     reason: String
-  ): Boolean @withOrderFormId
+  ): Boolean @withOrderFormId @withOwnerId
   updateItems(
     orderFormId: String
       @deprecated(
         reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
       )
     items: [OrderFormItemInput]
-  ): OrderForm @withSegment @withOrderFormId @cacheControl(scope: PRIVATE)
+  ): OrderForm @withSegment @withOrderFormId @withOwnerId @cacheControl(scope: PRIVATE)
 
   """
   Used to update the CL entity on masterData.
@@ -714,35 +718,35 @@ type Mutation {
         reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
       )
     fields: OrderFormProfileInput
-  ): OrderForm @withOrderFormId
+  ): OrderForm @withOrderFormId @withOwnerId
   updateOrderFormShipping(
     orderFormId: String
       @deprecated(
         reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
       )
     address: OrderFormAddressInput
-  ): OrderForm @withOrderFormId
+  ): OrderForm @withOrderFormId @withOwnerId
   updateOrderFormPayment(
     orderFormId: String
       @deprecated(
         reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
       )
     payments: [OrderFormPaymentInput]
-  ): OrderForm @withOrderFormId
+  ): OrderForm @withOrderFormId @withOwnerId
   updateOrderFormIgnoreProfile(
     orderFormId: String
       @deprecated(
         reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
       )
     ignoreProfileData: Boolean
-  ): OrderForm @withOrderFormId
+  ): OrderForm @withOrderFormId @withOwnerId
   addOrderFormPaymentToken(
     orderFormId: String
       @deprecated(
         reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
       )
     paymentToken: OrderFormPaymentTokenInput
-  ): OrderForm @withOrderFormId
+  ): OrderForm @withOrderFormId @withOwnerId
   setOrderFormCustomData(
     orderFormId: String
       @deprecated(
@@ -751,7 +755,7 @@ type Mutation {
     appId: String
     field: String
     value: String
-  ): OrderForm @withOrderFormId
+  ): OrderForm @withOrderFormId @withOwnerId
   addAssemblyOptions(
     orderFormId: String
       @deprecated(
@@ -760,14 +764,14 @@ type Mutation {
     itemId: String
     assemblyOptionsId: String
     options: [AssemblyOptionInput]
-  ): OrderForm @withOrderFormId
+  ): OrderForm @withOrderFormId @withOwnerId
   updateOrderFormCheckin(
     orderFormId: String
       @deprecated(
         reason: "Field is no longer needed. Checkout cookie is automatically taken into account now"
       )
     checkin: OrderFormCheckinInput
-  ): OrderForm @withOrderFormId @cacheControl(scope: PRIVATE)
+  ): OrderForm @withOrderFormId @withOwnerId @cacheControl(scope: PRIVATE)
 
   """
   Payment
@@ -894,13 +898,14 @@ type Mutation {
     The email which will be used to impersonate a user
     """
     email: String!
-  ): Session @withOrderFormId @cacheControl(scope: PRIVATE)
+  ): Session @withOrderFormId @withOwnerId @cacheControl(scope: PRIVATE)
 
   """
   Depersonify a customer
   """
   depersonify: Boolean
     @withOrderFormId
+    @withOwnerId
     @withSegment
     @cacheControl(scope: PRIVATE)
 
@@ -960,4 +965,5 @@ type Mutation {
   newOrderForm(orderFormId: String): OrderForm
     @cacheControl(scope: PRIVATE)
     @withOrderFormId
+    @withOwnerId
 }

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -7,7 +7,7 @@ import {
 } from '@vtex/api'
 import { AxiosError } from 'axios'
 
-import { checkoutCookieFormat, statusToError } from '../utils'
+import { checkoutCookieFormat, ownershipCookieFormat, statusToError } from '../utils'
 
 export class Checkout extends JanusClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
@@ -24,10 +24,11 @@ export class Checkout extends JanusClient {
   }
 
   private getCommonHeaders = () => {
-    const { orderFormId, segmentToken, sessionToken } = this
+    const { orderFormId, ownerId, segmentToken, sessionToken } = this
       .context as CustomIOContext
 
     const checkoutCookie = orderFormId ? checkoutCookieFormat(orderFormId) : ''
+    const ownershipCookie = ownerId ? ownershipCookieFormat(ownerId) : ''
     const segmentTokenCookie = segmentToken
       ? `vtex_segment=${segmentToken};`
       : ''
@@ -37,7 +38,7 @@ export class Checkout extends JanusClient {
       : ''
 
     return {
-      Cookie: `${checkoutCookie}${segmentTokenCookie}${sessionTokenCookie}`,
+      Cookie: `${checkoutCookie}${ownershipCookie}${segmentTokenCookie}${sessionTokenCookie}`,
     }
   }
 

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -6,8 +6,9 @@ import {
   IOContext,
 } from '@vtex/api'
 import { AxiosError } from 'axios'
+import { setCheckoutCookies } from '../resolvers/checkout'
 
-import { checkoutCookieFormat, ownershipCookieFormat, statusToError } from '../utils'
+import { checkoutCookieFormat, ownershipCookieFormat, OWNERSHIP_COOKIE, statusToError } from '../utils'
 
 export class Checkout extends JanusClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
@@ -100,12 +101,15 @@ export class Checkout extends JanusClient {
       { metric: 'checkout-updateOrderFormPayment' }
     )
 
-  public updateOrderFormProfile = (orderFormId: string, fields: any) =>
-    this.post(
+  public updateOrderFormProfile = async (orderFormId: string, fields: any, ctx: Context) => {
+    const { data, headers } = await this.postRaw(
       this.routes.attachmentsData(orderFormId, 'clientProfileData'),
       fields,
       { metric: 'checkout-updateOrderFormProfile' }
     )
+    setCheckoutCookies(headers, ctx, [OWNERSHIP_COOKIE])
+    return data
+  }
 
   public updateOrderFormShipping = (orderFormId: string, shipping: any) =>
     this.post(

--- a/node/directives/index.ts
+++ b/node/directives/index.ts
@@ -3,11 +3,13 @@ import { WithSegment } from './withSegment'
 import { WithOrderFormId } from './withOrderFormId'
 import { ToVtexAssets } from './toVtexAssets'
 import { AuthorizationMetrics } from './authorizationMetrics'
+import { WithOwnerId } from './withOwnerId'
 
 export const schemaDirectives = {
   toVtexAssets: ToVtexAssets,
   withCurrentProfile: WithCurrentProfile,
   withSegment: WithSegment,
   withOrderFormId: WithOrderFormId,
+  withOwnerId: WithOwnerId,
   withAuthMetrics: AuthorizationMetrics,
 }

--- a/node/directives/withOwnerId.ts
+++ b/node/directives/withOwnerId.ts
@@ -1,0 +1,18 @@
+import { defaultFieldResolver, GraphQLField } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+
+import { getOwnerIdFromCookie } from '../utils'
+
+export class WithOwnerId extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field
+
+    field.resolve = async (root: any, args: any, ctx: Context, info: any) => {
+      const checkoutOwnerId = getOwnerIdFromCookie(ctx.cookies)
+
+      ctx.vtex.ownerId = checkoutOwnerId
+
+      return resolve(root, args, ctx, info)
+    }
+  }
+}

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -27,6 +27,7 @@ declare global {
     currentProfile: CurrentProfile
     segment?: SegmentData
     orderFormId?: string
+    ownerId?: string
   }
 
   interface StoreGraphQLDataSources {

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -15,7 +15,7 @@ import {
 import { resolvers as orderFormItemResolvers } from './orderFormItem'
 import paymentTokenResolver from './paymentTokenResolver'
 import { fieldResolvers as shippingFieldResolvers } from './shipping'
-import { CHECKOUT_COOKIE, parseCookie } from '../../utils'
+import { CHECKOUT_COOKIE, OWNERSHIP_COOKIE, parseCookie } from '../../utils'
 import {
   getSimulationPayloadsByItem,
   orderFormItemToSeller,
@@ -23,7 +23,7 @@ import {
 import { LogisticPickupPoint } from '../logistics/types'
 import logisticPickupResolvers from '../logistics/fieldResolvers'
 
-const SetCookieWhitelist = [CHECKOUT_COOKIE, '.ASPXAUTH', 'CheckoutOrderFormOwnership']
+const SetCookieWhitelist = [CHECKOUT_COOKIE, '.ASPXAUTH', OWNERSHIP_COOKIE]
 
 const isWhitelistedSetCookie = (cookie: string) => {
   const [key] = cookie.split('=')

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -23,7 +23,7 @@ import {
 import { LogisticPickupPoint } from '../logistics/types'
 import logisticPickupResolvers from '../logistics/fieldResolvers'
 
-const SetCookieWhitelist = [CHECKOUT_COOKIE, '.ASPXAUTH']
+const SetCookieWhitelist = [CHECKOUT_COOKIE, '.ASPXAUTH', 'CheckoutOrderFormOwnership']
 
 const isWhitelistedSetCookie = (cookie: string) => {
   const [key] = cookie.split('=')

--- a/node/resolvers/session/index.ts
+++ b/node/resolvers/session/index.ts
@@ -66,7 +66,7 @@ export const mutations = {
       await checkout.updateOrderFormProfile(orderForm.orderFormId, {
         ...clientProfileData,
         email,
-      })
+      }, ctx)
     }
 
     ctx.response.set(

--- a/node/utils/cookie.ts
+++ b/node/utils/cookie.ts
@@ -33,6 +33,7 @@ const parseCookie = (cookie: string): ParsedCookie => {
 
 /** Checkout cookie methods */
 const CHECKOUT_COOKIE = 'checkout.vtex.com'
+const ASPXAUTH_COOKIE = '.ASPXAUTH'
 const OWNERSHIP_COOKIE = 'CheckoutOrderFormOwnership'
 
 const checkoutCookieFormat = (orderFormId: string) =>
@@ -55,6 +56,7 @@ export function getOwnerIdFromCookie(cookies: Context['cookies']) {
 export {
   isUserLoggedIn,
   CHECKOUT_COOKIE,
+  ASPXAUTH_COOKIE,
   OWNERSHIP_COOKIE,
   checkoutCookieFormat,
   getOrderFormIdFromCookie,

--- a/node/utils/cookie.ts
+++ b/node/utils/cookie.ts
@@ -33,9 +33,14 @@ const parseCookie = (cookie: string): ParsedCookie => {
 
 /** Checkout cookie methods */
 const CHECKOUT_COOKIE = 'checkout.vtex.com'
+const OWNERSHIP_COOKIE = 'CheckoutOrderFormOwnership'
 
 const checkoutCookieFormat = (orderFormId: string) =>
   `${CHECKOUT_COOKIE}=__ofid=${orderFormId};`
+
+export function ownershipCookieFormat(ownerId: string) {
+  return `${OWNERSHIP_COOKIE}=${ownerId};`
+}
 
 const getOrderFormIdFromCookie = (cookies: Context['cookies']) => {
   const cookie = cookies.get(CHECKOUT_COOKIE)
@@ -43,9 +48,14 @@ const getOrderFormIdFromCookie = (cookies: Context['cookies']) => {
   return cookie?.split('=')[1]
 }
 
+export function getOwnerIdFromCookie(cookies: Context['cookies']) {
+  return cookies.get(OWNERSHIP_COOKIE)
+}
+
 export {
   isUserLoggedIn,
   CHECKOUT_COOKIE,
+  OWNERSHIP_COOKIE,
   checkoutCookieFormat,
   getOrderFormIdFromCookie,
   parseCookie,


### PR DESCRIPTION
[Jira Issue](https://vtex-dev.atlassian.net/browse/CHK-2128)

#### What problem is this solving?
Handle the new CheckoutOrderFormOwnership cookie, forwarding when necessary.
Just like https://github.com/vtex-apps/checkout-graphql/pull/183

#### How to test it?

It is linked in `qastore` workspace `brunoh2`.

#### Screenshots or example usage:

The cookie comes back in set-cookie when included in the API requests:
```
$ curl -v 'https://brunoh2--qastore.myvtex.com/_v/private/graphql/v1' \
  -H 'content-type: application/json' \
  -H 'cookie: checkout.vtex.com=__ofid=bec5432879934595babe0d4efe39beac; CheckoutOrderFormOwnership=2d048a247bdf461fb298bfff177ec665; vtex-commerce-env=beta' \
  --data-raw '{"operationName":"orderForm","variables":{},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"1ecfbc15a63112ff28cf95d4789812438cf2e9a3a67fcf1dd4d89b6bdf78e39e","sender":"vtex.store-resources@0.x","provider":"vtex.store-graphql@2.x"}}}' \
  2>&1 | grep -Fi set-cookie:

< set-cookie: checkout.vtex.com=__ofid=bec5432879934595babe0d4efe39beac; path=/; expires=Tue, 25 Apr 2023 20:45:30 GMT; domain=brunoh2--qastore.myvtex.com; samesite=lax; secure; httponly
< set-cookie: CheckoutOrderFormOwnership=2d048a247bdf461fb298bfff177ec665; path=/; expires=Tue, 25 Apr 2023 20:45:30 GMT; domain=brunoh2--qastore.myvtex.com; samesite=strict; secure; httponly
```

The set-cookie is included when updating the clientProfileAttachment (which generates an `ownerId`):
```
$ curl -v 'https://brunoh2--qastore.myvtex.com/_v/private/graphql/v1' \
  -H 'content-type: application/json' \
  -H 'cookie: checkout.vtex.com=__ofid=bec5432879934595babe0d4efe39beac; vtex-commerce-env=beta' \
  --data-raw '{"query":"mutation {updateOrderFormProfile (fields: {email: \"newshopper_100@mailinator.com\"}) @context(provider: \"vtex.store-graphql@2.x\") { userProfileId }}"}' \
  2>&1 | grep -Fi set-cookie:

< set-cookie: CheckoutOrderFormOwnership=0f3f6f0e1ebf42f5870317e3202fb5a0; path=/; expires=Tue, 25 Apr 2023 20:50:06 GMT; domain=brunoh2--qastore.myvtex.com; samesite=strict; secure; httponly
```
PS: In this case the set-cookie will just appear the first time a "new" profile attachment is sent (new email).
Example:
call one time with "newshopper_100@mailinator.com" => receive set-cookie
call another time with "newshopper_100@mailinator.com" => no set-cookie
call another time with "newshopper_101@mailinator.com" => receive set-cookie

This behavior is not related to this PR, it is just how it was implemented in the Checkout API.