### PR TITLE
feat: simulation now returning hot and not cached tax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Add
+- Tax on simulation return
+
 ## [2.158.0] - 2022-11-03
 
 ## [2.157.1] - 2022-09-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Add
+### Added
+
 - Tax on simulation return
 
 ## [2.158.0] - 2022-11-03

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -83,6 +83,7 @@ export const orderFormItemToSeller = (
     PriceValidUntil: orderFormItem.priceValidUntil,
     ListPrice: orderFormItem.listPrice / 100,
     PriceWithoutDiscount: orderFormItem.price / 100,
+    Tax: orderFormItem.tax / 100,
     AvailableQuantity:
       orderFormItem?.availability === 'available' &&
       (logisticsInfo ? logisticsInfo.stockBalance : 1)


### PR DESCRIPTION
#### What problem is this solving?

Tax was being returned cached instead of hot when using simulation call

#### How to test it?

Log into and check the shelves

[Workspace](https://testvtex2--coexitob2b.myvtex.com/?)

To ask for credentials, DM me please

#### Screenshots or example usage:

Before:

![image](https://user-images.githubusercontent.com/13649073/198849877-4443d5d4-ed7a-4d28-af1c-a5ee9a03a5a1.png)

After:

![image](https://user-images.githubusercontent.com/13649073/198849892-c587cb9b-61f5-49ae-b09d-76832485b412.png)


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

https://github.com/vtex/intelligent-search-api/pull/45

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/lXiRMGxuBQvkBKhDG/giphy.gif)
