### PR TITLE
Add PaymentSystemGroupName to itemsWithSimulation response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `PaymentSystemGroupName` to `itemsWithSimulation` response.
+
 ## [2.159.0] - 2022-12-08
 
 ### Added

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -108,6 +108,7 @@ export const orderFormItemToSeller = (
         TotalValuePlusInterestRate: installment.total / 100,
         NumberOfInstallments: installment.count,
         PaymentSystemName: installmentOption.paymentName,
+        PaymentSystemGroupName: installmentOption.paymentGroupName,
         Name: generatePaymentName(
           installment.interestRate,
           installmentOption.paymentName,


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Product search query wasn't returning the `PaymentSystemGroupName` prop because `itemsWithSimulation` didn't have this value

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--carrefourbr.myvtex.com/admin/graphql-ide)

#### Screenshots or example usage:
Before:
![image](https://user-images.githubusercontent.com/20840671/207601715-33fedbfa-bb43-48e0-b415-70fdc720e1a9.png)

After:
![image](https://user-images.githubusercontent.com/20840671/207601583-e48bdecf-934c-4402-baf4-47109be8c93a.png)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
