### PR TITLE
Feat/orderform same site cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Support cross-site stores
+
 ## [2.157.1] - 2022-09-22
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,4 +1,5 @@
 directive @withAuthMetrics on FIELD_DEFINITION
+directive @withSettings on FIELD_DEFINITION
 
 type Query {
   """
@@ -300,6 +301,7 @@ type Query {
     @cacheControl(maxAge: ZERO, scope: PRIVATE)
     @withOrderFormId
     @withSegment
+    @withSettings
 
   """
   returns a certain checkout cart details

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,18 @@
     "vtex.catalog-api-proxy": "0.x",
     "vtex.file-manager": "0.x"
   },
+  "settingsSchema": {
+    "title": "VTEX Store Config",
+    "type": "object",
+    "properties": {
+      "checkoutCrossSite": {
+        "title": "Enable checkout cookies cross-site",
+        "type": "boolean",
+        "default": false,
+        "description": "Enable checkout cookies for cross-site (SameSite='None') this only works with OrderForm legacy provider"
+      }
+    }
+  },
   "policies": [
     {
       "name": "outbound-access",
@@ -196,6 +208,15 @@
     },
     {
       "name": "vtex.rewriter:resolve-graphql"
+    },
+    {
+      "name": "read-workspace-apps"
+    },
+    {
+      "name": "read-public-registry-assets"
+    },
+    {
+      "name": "read-private-registry-assets"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/directives/index.ts
+++ b/node/directives/index.ts
@@ -3,6 +3,7 @@ import { WithSegment } from './withSegment'
 import { WithOrderFormId } from './withOrderFormId'
 import { ToVtexAssets } from './toVtexAssets'
 import { AuthorizationMetrics } from './authorizationMetrics'
+import { WithSettings } from './withSettings'
 
 export const schemaDirectives = {
   toVtexAssets: ToVtexAssets,
@@ -10,4 +11,5 @@ export const schemaDirectives = {
   withSegment: WithSegment,
   withOrderFormId: WithOrderFormId,
   withAuthMetrics: AuthorizationMetrics,
+  withSettings: WithSettings,
 }

--- a/node/directives/withSettings.ts
+++ b/node/directives/withSettings.ts
@@ -1,0 +1,29 @@
+import { appIdToAppAtMajor } from '@vtex/api'
+import { defaultFieldResolver, GraphQLField } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+
+const appAtMajor = appIdToAppAtMajor(process.env.VTEX_APP_ID!)
+
+export interface Settings {
+  checkoutCrossSite: boolean
+}
+
+export class WithSettings extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field
+
+    field.resolve = async (root: any, args: any, ctx: Context, info: any) => {
+      try {
+        const {
+          clients: { apps },
+        } = ctx
+
+        ctx.settings = await apps.getAppSettings(appAtMajor)
+
+        return resolve(root, args, ctx, info)
+      } catch (error) {
+        return resolve(root, args, ctx, info)
+      }
+    }
+  }
+}

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -7,6 +7,7 @@ import {
 
 import { Clients } from './clients'
 import { IdentityDataSource } from './dataSources/identity'
+import { Settings } from './directives/withSettings'
 
 if (!global.metrics) {
   console.error('No global.metrics at require time')
@@ -21,6 +22,7 @@ declare global {
     dataSources: StoreGraphQLDataSources
     originalPath: string
     vtex: CustomIOContext
+    settings: Settings
   }
 
   interface CustomIOContext extends IOContext {

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -238,6 +238,7 @@ export async function setCheckoutCookies(
 
     if (ctx?.settings?.checkoutCrossSite) {
       options = { ...options, secure: true, sameSite: 'none' }
+      ctx.cookies.secure = true
     }
 
     ctx.cookies.set(name, value, options)

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -237,7 +237,7 @@ export async function setCheckoutCookies(
     }
 
     if (ctx?.settings?.checkoutCrossSite) {
-      options = { ...options, sameSite: 'none' }
+      options = { ...options, secure: true, sameSite: 'none' }
     }
 
     ctx.cookies.set(name, value, options)

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -236,6 +236,10 @@ export async function setCheckoutCookies(
       ctx.cookies.secure = true
     }
 
+    if (ctx?.settings?.checkoutCrossSite) {
+      options = { ...options, sameSite: 'none' }
+    }
+
     ctx.cookies.set(name, value, options)
   })
 }


### PR DESCRIPTION
#### What problem is this solving?

Many stores need to be inside an iframe, this is only possible if the orderform cookie (checkout.vtex.com) has the SameSite='None' property set, an option was created in the app configuration to enable this feature, by default it is set to false to keep the stores that do not need this feature unaffected.

#### How to test it?

1. Link the application
2. Set the SameSite='None' flag to true through the administrator.
3. See how the cookie property changes.

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/26680887/210371737-8fb1ed90-1157-426c-94bb-e606f83cf9a6.png)
![image](https://user-images.githubusercontent.com/26680887/210372369-13b3d7ba-3b28-4c31-97a9-50a12f74c164.png)
