### PR TITLE
Adds directive to monitor origin of orders endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Directive to monitor origin of requests to the orders endpoint.
 
 ## [2.160.0] - 2022-12-22
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -2,6 +2,8 @@ directive @withAuthMetrics on FIELD_DEFINITION
 
 directive @withOwnerId on FIELD_DEFINITION
 
+directive @monitorOrigin on FIELD_DEFINITION
+
 type Query {
   """
   Returns a specified product
@@ -313,7 +315,7 @@ type Query {
   """
   Returns user orders details
   """
-  orders: [Order] @cacheControl(scope: PRIVATE) @withOrderFormId @withOwnerId
+  orders: [Order] @cacheControl(scope: PRIVATE) @withOrderFormId @withOwnerId @monitorOrigin
 
   """
   Returns a specified user order

--- a/node/directives/index.ts
+++ b/node/directives/index.ts
@@ -4,6 +4,7 @@ import { WithOrderFormId } from './withOrderFormId'
 import { ToVtexAssets } from './toVtexAssets'
 import { AuthorizationMetrics } from './authorizationMetrics'
 import { WithOwnerId } from './withOwnerId'
+import { MonitorOrigin } from './monitorOrigin'
 
 export const schemaDirectives = {
   toVtexAssets: ToVtexAssets,
@@ -12,4 +13,5 @@ export const schemaDirectives = {
   withOrderFormId: WithOrderFormId,
   withOwnerId: WithOwnerId,
   withAuthMetrics: AuthorizationMetrics,
+  monitorOrigin: MonitorOrigin,
 }

--- a/node/directives/monitorOrigin.ts
+++ b/node/directives/monitorOrigin.ts
@@ -1,0 +1,57 @@
+import { defaultFieldResolver, GraphQLField } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+
+function logRequest({
+  ctx,
+  info,
+  args,
+}: {
+  ctx: any
+  info: any
+  args: any
+}) {
+  const {
+    request: {
+      headers: {
+        'user-agent': userAgent,
+        'x-forwarded-host': forwardedHost,
+        'x-forwarded-path': forwardedPath,
+        'x-vtex-caller': vtexCaller,
+      },
+    },
+    vtex: { account, logger },
+  } = ctx
+
+  if (Math.floor(Math.random() * 100) <= 50) {
+    logger.log({
+      message: 'Old orders endpoint called',
+      account,
+      userAgent,
+      forwardedHost,
+      forwardedPath,
+      vtexCaller,
+      queryName: info?.fieldName,
+      args
+    })
+  }
+}
+
+export class MonitorOrigin extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field
+
+    field.resolve = async (root: any, args: any, ctx: any, info: any) => {
+
+      try {
+        return await resolve(root, args, ctx, info)
+      } finally {
+
+        logRequest({
+          ctx,
+          info,
+          args,
+        })
+      }
+    }
+  }
+}

--- a/node/directives/monitorOrigin.ts
+++ b/node/directives/monitorOrigin.ts
@@ -1,15 +1,7 @@
 import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 
-function logRequest({
-  ctx,
-  info,
-  args,
-}: {
-  ctx: any
-  info: any
-  args: any
-}) {
+function logRequest({ ctx, info, args }: { ctx: any; info: any; args: any }) {
   const {
     request: {
       headers: {
@@ -31,7 +23,7 @@ function logRequest({
       forwardedPath,
       vtexCaller,
       queryName: info?.fieldName,
-      args
+      args,
     })
   }
 }
@@ -41,11 +33,9 @@ export class MonitorOrigin extends SchemaDirectiveVisitor {
     const { resolve = defaultFieldResolver } = field
 
     field.resolve = async (root: any, args: any, ctx: any, info: any) => {
-
       try {
         return await resolve(root, args, ctx, info)
       } finally {
-
         logRequest({
           ctx,
           info,


### PR DESCRIPTION
#### What problem is this solving?

This PR adds a directive to monitor the origin of all requests to the `orders` endpoint.

#### How to test it?

Install a beta version and make a request to the orders endpoint using postman or curl