### PR TITLE
change fields for address at profile V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Profile v2 address reading and updating documents.
+
 ## [2.161.1] - 2023-01-24
 
 ## [2.161.0] - 2023-01-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Profile v2 address reading and updating documents.
+- Profile v2 address reading, updating and saving documents.
 
 ## [2.161.1] - 2023-01-24
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.161.2-beta.0",
+  "version": "2.161.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.161.1",
+  "version": "2.161.2-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -227,6 +227,7 @@ export class ProfileClientV2 extends JanusClient {
           route: address.street,
           streetNumber: address.number ?? '',
           receiverName: address.receiverName,
+          userId: address.userId,
         },
       } as AddressV2
     })

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -191,7 +191,7 @@ export class ProfileClientV2 extends JanusClient {
       return {
         addressName: addressV2.name ?? addressV2.addressName,
         city: addressV2.locality,
-        complement: addressV2.extend,
+        complement: addressV2.complement,
         country: addressV2.countryCode,
         geoCoordinates: addressV2.geoCoordinates ?? [],
         id: address.id,

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -203,7 +203,7 @@ export class ProfileClientV2 extends JanusClient {
         street: addressV2.route,
         userId: addressV2.profileId,
         addressType: addressV2.addressType ?? 'residential',
-        neighborhood: addressV2.localityAreaLevel1,
+        neighborhood: addressV2.localityAreaLevel1 ?? '',
       } as Address
     })
 
@@ -213,6 +213,7 @@ export class ProfileClientV2 extends JanusClient {
         id: address.id,
         document: {
           administrativeAreaLevel1: address.state,
+          addressName: address.addressName,
           addressType: address.addressType ?? 'residential',
           countryCode: address.country,
           complement: address.complement ?? '',
@@ -257,7 +258,6 @@ export class ProfileClientV2 extends JanusClient {
     const [toChange] = addressesV2.filter(
       (addr) => addr.document.name === addressesV1[0].addressName
     )
-
     return this.getProfileInfo(user).then((profile) => {
       return this.getUserAddresses(user, profile).then(
         (addresses: Address[]) => {
@@ -273,7 +273,6 @@ export class ProfileClientV2 extends JanusClient {
               }
             )
           }
-
           return this.post(
             `${this.baseUrl}/${profile.id}/addresses`,
             toChange.document,

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -189,11 +189,11 @@ export class ProfileClientV2 extends JanusClient {
       const addressV2 = address.document
 
       return {
-        addressName: addressV2.name,
-        city: addressV2.localityAreaLevel1,
+        addressName: addressV2.name ?? addressV2.addressName,
+        city: addressV2.locality,
         complement: addressV2.extend,
         country: addressV2.countryCode,
-        geoCoordinates: addressV2.geoCoordinates,
+        geoCoordinates: addressV2.geoCoordinates ?? [],
         id: address.id,
         number: addressV2.streetNumber,
         postalCode: addressV2.postalCode,
@@ -203,7 +203,7 @@ export class ProfileClientV2 extends JanusClient {
         street: addressV2.route,
         userId: addressV2.profileId,
         addressType: addressV2.addressType ?? 'residential',
-        neighborhood: addressV2.neighborhood,
+        neighborhood: addressV2.localityAreaLevel1,
       } as Address
     })
 
@@ -215,9 +215,10 @@ export class ProfileClientV2 extends JanusClient {
           administrativeAreaLevel1: address.state,
           addressType: address.addressType ?? 'residential',
           countryCode: address.country,
-          extend: address.complement ?? '',
-          geoCoordinates: address.geoCoordinates,
-          localityAreaLevel1: address.city,
+          complement: address.complement ?? '',
+          geoCoordinates: address.geoCoordinates ?? [],
+          locality: address.city,
+          localityAreaLevel1: address.neighborhood ?? '',
           name: address.addressName,
           nearly: address.reference ?? '',
           postalCode: address.postalCode,
@@ -225,7 +226,6 @@ export class ProfileClientV2 extends JanusClient {
           route: address.street,
           streetNumber: address.number ?? '',
           receiverName: address.receiverName,
-          neighborhood: address.neighborhood,
         },
       } as AddressV2
     })
@@ -264,7 +264,6 @@ export class ProfileClientV2 extends JanusClient {
           const [address] = addresses.filter(
             (addr) => addr.addressName === addressesV1[0].addressName
           )
-
           if (address) {
             return this.patch(
               `${this.baseUrl}/${profile.id}/addresses/${address.id}`,

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -78,6 +78,7 @@ declare global {
     id: string
     document: {
       administrativeAreaLevel1?: string
+      addressName?: string
       addressType?: string
       countryCode?: string
       extend?: string

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -80,6 +80,7 @@ declare global {
       administrativeAreaLevel1?: string
       addressName?: string
       addressType?: string
+      complement?: string
       countryCode?: string
       extend?: string
       geoCoordinates?: string[]

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -201,9 +201,13 @@ export async function saveAddress(
     addressesData,
     context
   )
-
+  
   if (result?.document) {
     return result.document
+  }
+
+  if (result?.id) {
+    return result.id
   }
 
   const currentAddresses = await profile.getUserAddresses(

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -201,7 +201,7 @@ export async function saveAddress(
     addressesData,
     context
   )
-  
+
   if (result?.document) {
     return result.document
   }


### PR DESCRIPTION
#### What problem is this solving?

My account was unable to access / edit / save addresses created in the new profile system.
Adjustment of the mapping according to the fields saved natively by the checkout.

#### How to test it?

Beta version: vtex.store-graphql@2.161.2-beta.2

Test the native purchase/edit flow via my account:
https://bibiclean--casinofrqa.myvtex.com/

Workspace with changes: 
To test it you must be at an IP address at France (use VPN)

[Workspace](https://withouttheme--casinofrqa.myvtex.com)

The changes were made considering the schema:
https://github.com/vtex/storage/blob/main/schemas/address/address-fra.json
and the checkout flow:
https://github.com/vtex/vcs.checkout/blob/master/src/VTEX%20Checkout/Private%20Assemblies/Vtex.Commerce.Checkout.Services/ClientProfile/V2/ClientProfileServiceV2.cs#L387

#### Screenshots or example usage:

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/67066494/217293796-12e96a20-fe60-450b-9edc-67ff05dfba2a.png">

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/67066494/217293901-2d177e06-e298-4a25-ade9-bff7fdcdaf17.png">


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/ieP701lvn3cCkDxFbi/giphy.gif)
