### PR TITLE
Fix: Save Address Mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Save Address Mutation for addressId null
+
 ## [2.166.0] - 2023-07-31
 
 

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -214,7 +214,7 @@ export async function saveAddress(
     currentProfile,
     context
   )
-  console.log(currentAddresses, newId)
+  
   return currentAddresses.find(
     (address: Address) => address.addressName === newId
   ) as Address

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -214,7 +214,7 @@ export async function saveAddress(
     currentProfile,
     context
   )
-
+  console.log(currentAddresses, newId)
   return currentAddresses.find(
     (address: Address) => address.addressName === newId
   ) as Address
@@ -250,7 +250,7 @@ function mapNewAddressToProfile(
     [id]: JSON.stringify({
       ...addr,
       geoCoordinate: geoCoordinates,
-      addressName: address.addressName ?? id,
+      addressName: id,
       userId: currentProfile.userId,
     }),
   }


### PR DESCRIPTION
#### What problem is this solving?

Mutation was breaking for addressId null:

<img width="1505" alt="image" src="https://github.com/vtex-apps/store-graphql/assets/67066494/8171bee6-bf5d-4777-8685-8db1c51df952">

It should save the Address:

<img width="1505" alt="image" src="https://github.com/vtex-apps/store-graphql/assets/67066494/f0132e32-9ce8-4b98-8095-592b628d0455">

#### How to test it?

Use the saveAddress mutation passing a body like:

```
{
  "address": {
    "city": "TESTE",
    "addressName": "TESTE",
    "country": "BRA",
    "addressType": "residential",
    "complement": "",
    "number": "10",
    "geoCoordinates": [
      -49.34089660644531,
      -25.471193313598633
    ],
    "neighborhood": "TESTE",
    "postalCode": "22222222",
    "receiverName": "TESTE",
    "state": "RJ",
    "street": "TESTE",
    "reference": ""
  }
}
```

After change:

<img width="1505" alt="image" src="https://github.com/vtex-apps/store-graphql/assets/67066494/c1b25948-ce7d-4dc0-9aa5-d51dc050108e">


