### PR TITLE
Add: Campaigns object to simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Campaigns context added to checkout simulation
+
 ## [2.168.0] - 2023-08-15
 ### Added
 - `sellerFlag` to change the seller at the simulation

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -394,6 +394,7 @@ export const queries: Record<string, Resolver> = {
       clients: { pvtCheckout },
       vtex: { segment, logger },
     } = ctx
+
     const changeSeller = isSellerFlaggedForChangingOnSimulationBasedOnRegion(ctx.vtex.account)
     return items.map((item) => {
       // eslint-disable-next-line no-async-promise-executor
@@ -404,6 +405,7 @@ export const queries: Record<string, Resolver> = {
           regionId,
           changeSeller
         )
+        
         const simulationPromises = simulationPayloads.map((payload) =>
           pvtCheckout.simulation(payload, salesChannel)
         )

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -394,7 +394,6 @@ export const queries: Record<string, Resolver> = {
       clients: { pvtCheckout },
       vtex: { segment, logger },
     } = ctx
-
     const changeSeller = isSellerFlaggedForChangingOnSimulationBasedOnRegion(ctx.vtex.account)
     return items.map((item) => {
       // eslint-disable-next-line no-async-promise-executor
@@ -405,7 +404,6 @@ export const queries: Record<string, Resolver> = {
           regionId,
           changeSeller
         )
-
         const simulationPromises = simulationPayloads.map((payload) =>
           pvtCheckout.simulation(payload, salesChannel)
         )

--- a/node/resolvers/checkout/index.ts
+++ b/node/resolvers/checkout/index.ts
@@ -395,7 +395,10 @@ export const queries: Record<string, Resolver> = {
       vtex: { segment, logger },
     } = ctx
 
-    const changeSeller = isSellerFlaggedForChangingOnSimulationBasedOnRegion(ctx.vtex.account)
+    const changeSeller = isSellerFlaggedForChangingOnSimulationBasedOnRegion(
+      ctx.vtex.account
+    )
+
     return items.map((item) => {
       // eslint-disable-next-line no-async-promise-executor
       return new Promise(async (resolve) => {
@@ -405,7 +408,7 @@ export const queries: Record<string, Resolver> = {
           regionId,
           changeSeller
         )
-        
+
         const simulationPromises = simulationPayloads.map((payload) =>
           pvtCheckout.simulation(payload, salesChannel)
         )
@@ -514,8 +517,9 @@ export const mutations: Record<string, Resolver> = {
       if (newMarketingData.marketingTags == null) {
         delete newMarketingData.marketingTags
       } else if (Array.isArray(newMarketingData.marketingTags)) {
-        newMarketingData.marketingTags =
-          newMarketingData.marketingTags.filter(Boolean)
+        newMarketingData.marketingTags = newMarketingData.marketingTags.filter(
+          Boolean
+        )
       }
 
       const atLeastOneValidField = Object.values(newMarketingData).some(

--- a/node/utils/flags/flagRegionalization.ts
+++ b/node/utils/flags/flagRegionalization.ts
@@ -1,5 +1,7 @@
-import { regionFlag } from "./regionFlag";
+import { regionFlag } from './regionFlag'
 
-export function isSellerFlaggedForChangingOnSimulationBasedOnRegion(sellerName: string) {
-    return regionFlag.includes(sellerName);
+export function isSellerFlaggedForChangingOnSimulationBasedOnRegion(
+  sellerName: string
+) {
+  return regionFlag.includes(sellerName)
 }

--- a/node/utils/flags/regionFlag.ts
+++ b/node/utils/flags/regionFlag.ts
@@ -1,5 +1,1 @@
-export const regionFlag = [
-    'casinofr',
-    'casinofrprod',
-    'casinofrqa',
-]
+export const regionFlag = ['casinofr', 'casinofrprod', 'casinofrqa']

--- a/node/utils/regionV1.ts
+++ b/node/utils/regionV1.ts
@@ -1,6 +1,7 @@
 export function isRegionV1(regionId: string) {
-  const regex = /v\d+/; 
-  return !regex.test(regionId);
+  const regex = /v\d+/
+
+  return !regex.test(regionId)
 }
 
 export function isUniqueSeller(regionId: string) {

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -12,7 +12,8 @@ const getMarketingData = (segment?: SegmentData) => {
   if (
     !segment?.utm_campaign &&
     !segment?.utm_source &&
-    !segment?.utmi_campaign
+    !segment?.utmi_campaign &&
+    !segment?.campaigns
   ) {
     return
   }
@@ -36,6 +37,13 @@ const getMarketingData = (segment?: SegmentData) => {
     marketingData = {
       ...marketingData,
       utmiCampaign: segment?.utmi_campaign,
+    }
+  }
+
+  if (segment?.campaigns) {
+    marketingData = {
+      ...marketingData,
+      campaigns: [{ id: segment?.campaigns }],
     }
   }
 

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -1,9 +1,8 @@
 import { SegmentData } from '@vtex/api'
+import atob from 'atob'
 
 import { calculatePrice } from './calculatePrice'
 import { isRegionV1, isUniqueSeller } from './regionV1'
-
-import atob from 'atob'
 
 const ALLOWED_TEASER_TYPES = ['Catalog', 'Profiler', 'ConditionalPrice']
 
@@ -55,12 +54,16 @@ export const getSimulationPayloadsByItem = (
   item: ItemWithSimulationInput,
   segment?: SegmentData,
   regionId?: string,
-  useSellerFromRegion?: Boolean
+  useSellerFromRegion?: boolean
 ) => {
   const payloadItems = item.sellers.map((seller) => {
     let sellerFromRegion = null
 
-    if (useSellerFromRegion && regionId && seller.sellerId === MARKETPLACE_SELLER_ID) {
+    if (
+      useSellerFromRegion &&
+      regionId &&
+      seller.sellerId === MARKETPLACE_SELLER_ID
+    ) {
       const regionV1 = isRegionV1(regionId)
       const sellerList = regionV1 ? atob(regionId) : null
 
@@ -70,11 +73,11 @@ export const getSimulationPayloadsByItem = (
         sellerFromRegion = uniqueSeller ? sellerList.split('SW#')[1] : null
       }
     }
-    
+
     return {
       id: item.itemId,
       quantity: 1,
-      seller: sellerFromRegion ? sellerFromRegion : seller.sellerId,
+      seller: sellerFromRegion || seller.sellerId,
     } as PayloadItem
   })
 

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -2,6 +2,7 @@ import { SegmentData } from '@vtex/api'
 
 import { calculatePrice } from './calculatePrice'
 import { isRegionV1, isUniqueSeller } from './regionV1'
+
 import atob from 'atob'
 
 const ALLOWED_TEASER_TYPES = ['Catalog', 'Profiler', 'ConditionalPrice']
@@ -58,14 +59,18 @@ export const getSimulationPayloadsByItem = (
 ) => {
   const payloadItems = item.sellers.map((seller) => {
     let sellerFromRegion = null
+
     if (useSellerFromRegion && regionId && seller.sellerId === MARKETPLACE_SELLER_ID) {
       const regionV1 = isRegionV1(regionId)
       const sellerList = regionV1 ? atob(regionId) : null
+
       if (sellerList) {
         const uniqueSeller = isUniqueSeller(sellerList)
+
         sellerFromRegion = uniqueSeller ? sellerList.split('SW#')[1] : null
       }
     }
+    
     return {
       id: item.itemId,
       quantity: 1,


### PR DESCRIPTION
#### What problem is this solving?

Add the campaign context for the simulation.

#### How to test it?

With the context:

```
curl --location 'https://bibi--northlatamprojects.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1/%2F?simulationBehavior=default&count=10&page=1&hideUnavailableItems=false&query=1661366' \
--header 'Cookie: VtexWorkspace=master%3A-; janus_sid=a02b1cd8-8add-4351-aecc-2875de14f049; vtex_segment=eyJjYW1wYWlnbnMiOiI5YmRiYjYwZC02MDY5LTQ2MzYtOGY3ZS0wZmViODMzMmZjZGUiLCJjaGFubmVsIjoiMSIsInByaWNlVGFibGVzIjpudWxsLCJyZWdpb25JZCI6bnVsbCwidXRtX2NhbXBhaWduIjpudWxsLCJ1dG1fc291cmNlIjpudWxsLCJ1dG1pX2NhbXBhaWduIjpudWxsLCJjdXJyZW5jeUNvZGUiOiJDT1AiLCJjdXJyZW5jeVN5bWJvbCI6IiQiLCJjb3VudHJ5Q29kZSI6IkNPTCIsImN1bHR1cmVJbmZvIjoiZW4tVVMiLCJhZG1pbl9jdWx0dXJlSW5mbyI6ImVuLVVTIiwiY2hhbm5lbFByaXZhY3kiOiJwdWJsaWMifQ; '
```
Without the context:

```
curl --location 'https://northlatamprojects.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1/%2F?simulationBehavior=default&count=10&page=1&hideUnavailableItems=false&query=1661366' \
--header 'Cookie: VtexWorkspace=master%3A-; janus_sid=a02b1cd8-8add-4351-aecc-2875de14f049; vtex_segment=eyJjYW1wYWlnbnMiOiI5YmRiYjYwZC02MDY5LTQ2MzYtOGY3ZS0wZmViODMzMmZjZGUiLCJjaGFubmVsIjoiMSIsInByaWNlVGFibGVzIjpudWxsLCJyZWdpb25JZCI6bnVsbCwidXRtX2NhbXBhaWduIjpudWxsLCJ1dG1fc291cmNlIjpudWxsLCJ1dG1pX2NhbXBhaWduIjpudWxsLCJjdXJyZW5jeUNvZGUiOiJDT1AiLCJjdXJyZW5jeVN5bWJvbCI6IiQiLCJjb3VudHJ5Q29kZSI6IkNPTCIsImN1bHR1cmVJbmZvIjoiZW4tVVMiLCJhZG1pbl9jdWx0dXJlSW5mbyI6ImVuLVVTIiwiY2hhbm5lbFByaXZhY3kiOiJwdWJsaWMifQ; '
```

