### PR TITLE
use get instead of post when requesting the simulation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### CHANGED
+- Use `GET` instead of `POST` when calling the simulation API.
+
 ## [2.170.1] - 2023-10-31
 
 ### Added

--- a/node/__tests__/utils/jsonToQuerystring.test.ts
+++ b/node/__tests__/utils/jsonToQuerystring.test.ts
@@ -1,0 +1,46 @@
+import jsonToQuerystring from '../../utils/jsonToQuerystring'
+
+describe('json to querystring', () => {
+  it('should return null for null objects', () => {
+    expect(jsonToQuerystring('request', null)).toBeNull()
+  })
+
+  it('should convert an array into a querystring', () => {
+    const testArray = ['foo', 'bar']
+    const key = 'myKey'
+
+    expect(jsonToQuerystring(key, testArray)).toBe('myKey[0]=foo&myKey[1]=bar')
+  })
+
+  it('should convert an object into a querystring', () => {
+    const testObj = { foo: 'foo', bar: 'bar' }
+    const key = 'myKey'
+
+    expect(jsonToQuerystring(key, testObj)).toBe('myKey.foo=foo&myKey.bar=bar')
+  })
+
+  it('should convert an object with nested objects, arrays, null fields and undefined fields into a querystring', () => {
+    const testObj = {
+      items: [
+        { id: '1', quantity: 1, seller: '1' },
+        { id: '2', quantity: 1, seller: '2' },
+      ],
+      shippingData: {
+        logisticsInfo: [{ regionId: 'v2.3C4B555127ED49C492010704E5A0417F' }],
+      },
+      marketingData: {
+        utmSource: 'UTMSOURCE',
+        utmCampaign: 'UTMCAMPAIGN',
+      },
+      isCheckedIn: false,
+      undefinedParameter: undefined,
+      nullParameter: null,
+    }
+
+    const key = 'myKey'
+
+    expect(jsonToQuerystring(key, testObj)).toBe(
+      'myKey.items[0].id=1&myKey.items[0].quantity=1&myKey.items[0].seller=1&myKey.items[1].id=2&myKey.items[1].quantity=1&myKey.items[1].seller=2&myKey.shippingData.logisticsInfo[0].regionId=v2.3C4B555127ED49C492010704E5A0417F&myKey.marketingData.utmSource=UTMSOURCE&myKey.marketingData.utmCampaign=UTMCAMPAIGN&myKey.isCheckedIn=false'
+    )
+  })
+})

--- a/node/clients/PvtCheckout.ts
+++ b/node/clients/PvtCheckout.ts
@@ -6,6 +6,7 @@ import {
 } from '@vtex/api'
 
 import { statusToError } from '../utils'
+import jsonToQuerystring from '../utils/jsonToQuerystring'
 
 export class PvtCheckout extends JanusClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
@@ -43,23 +44,25 @@ export class PvtCheckout extends JanusClient {
   }
 
   public simulation = (simulation: SimulationPayload, salesChannel?: string) =>
-    this.post<SimulationOrderForm>(
-      this.routes.simulation(this.getChannelQueryString(salesChannel)),
-      simulation,
+    this.get<SimulationOrderForm>(
+      this.routes.simulation(
+        `${this.getChannelQueryString(salesChannel)}&${jsonToQuerystring(
+          'request',
+          simulation
+        )}`
+      ),
       {
         metric: 'pvt-checkout-simulation',
       }
     )
 
-  protected post = <T>(url: string, data?: any, config: RequestConfig = {}) => {
+  protected get = <T>(url: string, config: RequestConfig = {}) => {
     config.headers = {
       ...config.headers,
       ...this.getCommonHeaders(),
     }
 
-    return this.http.post<T>(url, data, config).catch(statusToError) as Promise<
-      T
-    >
+    return this.http.get<T>(url, config).catch(statusToError) as Promise<T>
   }
 
   private get routes() {

--- a/node/utils/jsonToQuerystring.ts
+++ b/node/utils/jsonToQuerystring.ts
@@ -1,0 +1,32 @@
+export default function jsonToQuerystring(
+  key: string,
+  value: any
+): string | null {
+  if (value === null || typeof value === 'undefined') {
+    return null
+  }
+
+  // Example: {obj: {foo: {'fooValue'}, bar: 'barValue'}}
+  // Result: "obj.foo=fooValue&obj.bar=barValue"
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return Object.entries(value)
+      .map(([currentKey, currentValue]) =>
+        jsonToQuerystring(`${key}.${currentKey}`, currentValue)
+      )
+      .filter((querystring) => !!querystring)
+      .join('&')
+  }
+
+  // Example: {obj: ['foo', 'bar']}
+  // Result: "obj[0]=foo&obj[1]=bar"
+  if (Array.isArray(value)) {
+    return value
+      .map((currentValue, index) =>
+        jsonToQuerystring(`${key}[${index}]`, currentValue)
+      )
+      .filter((querystring) => !!querystring)
+      .join('&')
+  }
+
+  return `${key}=${value}`
+}


### PR DESCRIPTION
#### What problem is this solving?

[Jira card](https://vtex-dev.atlassian.net/browse/IS-4752)

The simulation API only caches the result when it's called via a GET request. Currently we call it via a POST request.

In order to the benefits from the cache, this PR changes the method from POST to GET.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--carrefourbr.myvtex.com/)

