### PR TITLE
fix: UnitMultiplier type from simulation call is always a float number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- unitMultiplier type from Int to float in OrderItem and LogisticsItem
+
 ## [2.170.1] - 2023-10-31
 
 ### Added

--- a/graphql/types/Order.graphql
+++ b/graphql/types/Order.graphql
@@ -46,7 +46,7 @@ type OrderItem {
   detailUrl: String
   availability: String
   measurementUnit: String
-  unitMultiplier: Int
+  unitMultiplier: Float
   parentItemIndex: Int
   parentAssemblyBinding: String
   bundleItems: [OrderItem]

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -82,7 +82,7 @@ type LogisticsItem {
   rewardValue: Int
   sellingPrice: Int
   measurementUnit: String
-  unitMultiplier: Int
+  unitMultiplier: Float
   availability: String
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Products are allowed to add float values in unitMultiplier, such as kilogram and meter types, for example:

<img width="389" alt="image" src="https://github.com/vtex-apps/store-graphql/assets/13649073/59164ca2-4a5a-4cb5-b220-29f896e0351d">


#### How to test it?

Select store-graphql at: [Workspace](https://iespinoza--cassol.myvtex.com/admin/graphql-ide)

Query:
```
query getShippingEstimates(
$items: [ShippingItem]
$postalCode: String
$country: String
) {
shipping(items: $items, postalCode: $postalCode, country: $country) {
items {
id
seller
sellerChain
price
listPrice
sellingPrice
measurementUnit
unitMultiplier
}
logisticsInfo {
itemIndex
slas {
id
friendlyName
price
shippingEstimate
shippingEstimateDate
deliveryChannel
}
}
}
}
```

```
{
"items": [
{
"id": "1638431",
"quantity": 1,
"seller": "1"
}
],
"country": "BRA",
"postalCode": "49032-000"
}

```

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/store-graphql/assets/13649073/72b4b00a-4cb6-46b1-8bfe-c86893985dd1)

<img width="872" alt="image" src="https://github.com/vtex-apps/store-graphql/assets/13649073/bdd45e37-7970-451e-801f-5873eb457489">


#### Related to / Depends on

Zendesk: #869926

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMXBoMWFha2Q1dHVnYmgyMnYzbW8wZGxyczBldWk2OWFxYWl3bXl5eiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/d9ktmdBGKn4DjZ7QNz/giphy.gif)
