### PR TITLE
Fix: telesales for PII accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- enable telesales for PII accounts
+
 ## [2.170.2] - 2024-05-02
 
 ### Changed

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -188,7 +188,11 @@ export class Checkout extends JanusClient {
     return this.post<OrderForm>(
       this.routes.orderForm(orderFormId),
       { expectedOrderFormSections: ['items'] },
-      { metric: 'checkout-orderForm' }
+      { metric: 'checkout-orderForm',
+      headers: {
+        'VtexIdclientAutCookie': this.context.adminUserAuthToken
+      }
+       },
     )
   }
 


### PR DESCRIPTION
#### What problem is this solving?

Telesales feature not working for PII accounts. 

This endpoint is not public for PII accounts:
```
curl --location 'https://dunnesstoresqa.vtexcommercestable.com.br/api/checkout/pub/orderForm/ef55388eedd04d6da04e42dd05251570' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--header 'Cookie: CheckoutOrderFormOwnership=; checkout.vtex.com=__ofid=ef55388eedd04d6da04e42dd05251570' \
--data '{
    "expectedOrderFormSections": [
        "items"
    ]
}'
```
I need to double check with the checkout team but the error returned is:
```
{
    "fields": {},
    "error": {
        "code": "001",
        "message": "The key \"schema\" was not found in the response",
        "exception": null
    },
    "operationId": "917e31e9-a252-4dc8-82cb-c3611fd16706"
}
```

#### How to test it?

1. Enter a PII account
2.  Add the telesales toolbar
3. Add a telesales role to your user
4. Call the store-graphql for impersonification 
5. With the previous version the return is 500 and with the current version is 200

[Workspace](https://bibi--dunnesstoresqa.myvtex.com/)

Only this PR do not solve the telesales problem since the profile was not completed by the session. It was needed to develop an extra App in order to do so.

#### Related to / Depends on

Only this PR do not solve the telesales problem since the profile was not completed by the session. It was needed to develop an extra App in order to do so but that is a private app.


Uploading Screen Recording 2024-05-17 at 23.22.38.mov…


