### PR TITLE
Add: filter logic for "pickup" addressType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Filter out "pickup" addresses type temporarily while is still being saved at Profile V2.
+
 ## [2.170.2] - 2024-05-02
 
 ### Changed

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -57,7 +57,15 @@ export function getAddresses(context: Context, currentUserProfile?: Profile) {
     vtex: { currentProfile },
   } = context
 
-  return profile.getUserAddresses(currentProfile, context, currentUserProfile)
+  // Filter out temporarily addresses with addressType "pickup" because its also saved at Profile V2
+  return profile
+    .getUserAddresses(currentProfile, context, currentUserProfile)
+    .then((addresses: any[]) => {
+      const residentialAddresses = addresses.filter(
+        (address: { addressType: string }) => address.addressType !== 'pickup'
+      )
+      return residentialAddresses
+    })
 }
 
 export async function getPayments(context: Context) {


### PR DESCRIPTION
#### What did you change? \*

Add a filter to not show "pickup" AddressType at the my account.

Before:
<img width="1393" alt="image" src="https://github.com/vtex-apps/my-account/assets/67066494/84ef00e1-1d21-4cfc-b787-fb49e3a2fb78">


After:
<img width="1393" alt="image" src="https://github.com/vtex-apps/my-account/assets/67066494/0c09874b-af0f-45d3-beba-6f708fd77ffc">


#### Why? \*

This type of address should not be saved at the user profile  but different from Profile V1 the Profile V2 saves it so we are filtering by those in order to nor impact the User Experience. 


