### PR TITLE
check user email with toLowerCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Check user email with toLowerCase
+
 ## [2.171.0] - 2024-06-28
 
 ### Fixed

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -260,7 +260,8 @@ async function checkUserAccount(
     'id' in tokenUser &&
     !(
       tokenUser.account === account &&
-      (isUserCallCenterOperator || tokenUser.user === currentProfile?.email)
+      (isUserCallCenterOperator ||
+        tokenUser.id.toLowerCase() === currentProfile?.userId.toLowerCase())
     )
   ) {
     throw new AuthenticationError('')

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -261,7 +261,7 @@ async function checkUserAccount(
     !(
       tokenUser.account === account &&
       (isUserCallCenterOperator ||
-        tokenUser.id.toLowerCase() === currentProfile?.userId.toLowerCase())
+        tokenUser.user.toLowerCase() === currentProfile?.email.toLowerCase())
     )
   ) {
     throw new AuthenticationError('')


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Check user email with toLowerCase to prevent error when the identity user has difference from token

https://vtex-dev.atlassian.net/browse/OMS-6340

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
https://profile--dunnesstorespreprod.myvtex.com/account#/profile
User: DQA57@test.com
Password: Dunnes123 

[Workspace](https://profile--dunnesstorespreprod.myvtex.com/account#/profile)
