### PR TITLE
fix: error when no email found in jwt due to email rectification feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Validation for customerID due to email rectification
 
 ## [2.171.2] - 2024-09-04
 

--- a/node/dataSources/identity.ts
+++ b/node/dataSources/identity.ts
@@ -10,6 +10,7 @@ export interface DefaultUser {
 export interface User extends DefaultUser {
   id: string
   user: string
+  customerId: string
   account: string
   audience: string
 }

--- a/node/directives/withCurrentProfile.ts
+++ b/node/directives/withCurrentProfile.ts
@@ -261,9 +261,10 @@ async function checkUserAccount(
     !(
       tokenUser.account === account &&
       (isUserCallCenterOperator ||
-        tokenUser.user.toLowerCase() === currentProfile?.email.toLowerCase())
+        tokenUser.user.toLowerCase() === currentProfile?.email.toLowerCase() ||
+        tokenUser.customerId === currentProfile?.userId)
     )
   ) {
-    throw new AuthenticationError('')
+    throw new AuthenticationError('Information conflict in tokenUser')
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Now it's possible to navigate at VTEX without email, it's a new feature called email rectification. In this scenario, the validation must be done by the customerId. From now on, every user will have their own customerId and it's supposed to not use email as a primary key anymore

#### How to test it?

You must follow several steps in order to create your user with the permissions, so, when reviewing this, please, contact to me so I can give you the access

- Log with your authorized email in account b2bsuite

[Before](https://b2bsuite.myvtex.com/account#/profile)

<img width="1416" alt="image" src="https://github.com/user-attachments/assets/6e77d0ba-1de1-443b-aabe-ca8b857f3f91">


[After](https://iespinoza--b2bsuite.myvtex.com/account#/profile)

<img width="973" alt="image" src="https://github.com/user-attachments/assets/b3cf9d34-716d-40d7-b588-2c0ba1e66b2b">

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWpiOHowNTE4dGV5MWdsczV6ajAxaWZ5aWdyZ2czeWVzZHJwMWcwdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/H9P66HzvGJsWtmtQuu/giphy.gif)
