### PR TITLE
Add route to return the rectification config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.172.1] - 2024-10-16
 ### Added
+
+- '/_v/private/rectification-config' route to check if rectification is enabled for the current user.
+
+## [2.172.1] - 2024-10-16
+
+### Added
+
 - Validation for customerID due to email rectification
 
 ## [2.172.0] - 2024-10-10

--- a/node/clients/oms.ts
+++ b/node/clients/oms.ts
@@ -52,4 +52,10 @@ export class OMS extends JanusClient {
       order: (id: string) => `${base}/pvt/orders/${id}`,
     }
   }
+
+  public getRmailRetificationConfig() {
+    return this.http.get('/api/oms/configuration/email-rectification-enabled', {
+      headers: { VtexIdclientAutCookie: this.context.authToken },
+    })
+  }
 }

--- a/node/clients/oms.ts
+++ b/node/clients/oms.ts
@@ -53,7 +53,7 @@ export class OMS extends JanusClient {
     }
   }
 
-  public getRmailRetificationConfig() {
+  public getEmailRetificationConfig() {
     return this.http.get('/api/oms/configuration/email-rectification-enabled', {
       headers: { VtexIdclientAutCookie: this.context.authToken },
     })

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,11 +1,12 @@
 import './globals'
 
-import { LRUCache, Service } from '@vtex/api'
+import { LRUCache, method, Service } from '@vtex/api'
 
 import { Clients } from './clients'
 import { dataSources } from './dataSources'
 import { schemaDirectives } from './directives'
 import { resolvers } from './resolvers'
+import { getEmailRetificationConfig } from './routes'
 
 const TWO_SECONDS_MS = 2 * 1000
 const THREE_SECONDS_MS = 3 * 1000
@@ -61,5 +62,10 @@ export default new Service<Clients, void, CustomContext>({
     dataSources,
     resolvers,
     schemaDirectives,
+  },
+  routes: {
+    'rectification-config': method({
+      GET: [getEmailRetificationConfig],
+    }),
   },
 })

--- a/node/routes/index.ts
+++ b/node/routes/index.ts
@@ -31,7 +31,7 @@ export async function getEmailRetificationConfig(
   // @ts-ignore
   ctx.status = 200
   // @ts-ignore
-  ctx.body = await ctx.clients.oms.getRmailRetificationConfig()
+  ctx.body = await ctx.clients.oms.getEmailRetificationConfig()
 
   await next()
 }

--- a/node/routes/index.ts
+++ b/node/routes/index.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/*
+  Disabling because `status` and `body` are not defined in the `Context` type provided by VTEX.
+  However, they are dynamically added by the middleware in the runtime, and using them works as expected.
+*/
+export async function getEmailRetificationConfig(
+  ctx: Context,
+  next: () => Promise<any>
+) {
+  try {
+    const { storeUserAuthToken } = ctx.vtex
+    const userStoreToken = storeUserAuthToken?.includes('.')
+      ? storeUserAuthToken.split('.')[1]
+      : ''
+
+    const { account } = JSON.parse(
+      Buffer.from(userStoreToken, 'base64').toString()
+    )
+
+    if (account !== ctx.vtex.account) {
+      setForbiddenStatus(ctx)
+
+      return
+    }
+  } catch (e) {
+    setForbiddenStatus(ctx)
+
+    return
+  }
+
+  // @ts-ignore
+  ctx.status = 200
+  // @ts-ignore
+  ctx.body = await ctx.clients.oms.getRmailRetificationConfig()
+
+  await next()
+}
+
+function setForbiddenStatus(ctx: Context) {
+  // @ts-ignore
+  ctx.status = 403
+  // @ts-ignore
+  ctx.body = 'Forbidden'
+}

--- a/node/service.json
+++ b/node/service.json
@@ -5,5 +5,11 @@
   "timeout": 40,
   "minReplicas": 50,
   "maxReplicas": 200,
-  "cpu": 30
+  "cpu": 30,
+  "routes": {
+    "rectification-config": {
+      "path": "/_v/private/rectification-config",
+      "public": true
+    }
+  }
 }


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This pull request introduces a new feature to fetch email rectification configuration from the OMS service. The most important changes include adding a new method to the `OMS` client, updating the service configuration to include a new route, and implementing the route handler.

We need this to make this route accessible only to authenticated shoppers using the application token to retrieve the configuration.

#### How to test it?

[Workspace](https://myordergql--storecomponents.myvtex.com/_v/private/rectification-config)
### New Feature: Email Rectification Configuration

* [`node/clients/oms.ts`](diffhunk://#diff-e7dd1712e4256837e1a9bb4af6d18babaed4555cac29a8ccf95e8bdbc785b3aaR55-R60): Added a new method `getRmailRetificationConfig` to fetch email rectification configuration from the OMS service.
* [`node/index.ts`](diffhunk://#diff-8843f11df3c9cd9d4e863c06541e969d5875d7026f270aa6c133e28793996289L3-R9): Imported the new route handler `getEmailRetificationConfig` and added a new route `rectification-config` to the service configuration. [[1]](diffhunk://#diff-8843f11df3c9cd9d4e863c06541e969d5875d7026f270aa6c133e28793996289L3-R9) [[2]](diffhunk://#diff-8843f11df3c9cd9d4e863c06541e969d5875d7026f270aa6c133e28793996289R66-R70)
* [`node/routes/index.ts`](diffhunk://#diff-6b396e1f7ddbf388226223f79a2e64121251371d76d66156efa6d6898457246fR1-R36): Implemented the `getEmailRetificationConfig` route handler to fetch and return the email rectification configuration, and added a helper function `setForbiddenStatus` to handle authorization errors.
* [`node/service.json`](diffhunk://#diff-d5dcd0c6aea7de2c8347424d20046555c29f8300a49b886d8416344ad4577a4dL8-R14): Updated the service configuration to include the new route `rectification-config` with its path and access settings.

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
