### PR TITLE
feat: Add AdminPortal to the list of policies in manifest.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- AdminPortal permission
+
 ### Changed
 
 - Update GitHub actions/cache to v4

--- a/manifest.json
+++ b/manifest.json
@@ -129,6 +129,9 @@
       "name": "LogisticsAdmin"
     },
     {
+      "name": "AdminPortal"
+    },
+    {
       "name": "outbound-access",
       "attrs": {
         "host": "{{account}}.vtexcommercestable.com.br",


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

[#inc-3353-esc](https://vtex.enterprise.slack.com/archives/C0954P4C0CE)

This pull request updates the `manifest.json` file to include a new entry for "AdminPortal" in the list of components.

* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743R131-R133): Added a new component named "AdminPortal" to the configuration.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://storeconfig--recorrenciacharlie.myvtex.com/admin/graphql-ide)

```
{
  storeConfigs{
    siteTitle
    tagManagerId
    kiosk
    tagManagerId
    googleMapsApiKey
    ioExtensions
  }
}
```

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
<img width="1567" height="525" alt="image" src="https://github.com/user-attachments/assets/c73a8d42-5738-4f32-8081-9c9d11207b8a" />

