### PR TITLE
fix: Prevent email rectification from user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.173.2] - 2025-07-28
+
+### Fixed
+
+- Email rectification validation for customer ID
+
 ## [2.173.1] - 2025-07-11
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.173.2",
+  "version": "2.173.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-graphql",
-  "version": "2.173.1",
+  "version": "2.173.2",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -15,7 +15,7 @@ interface AutocompleteArgs {
 }
 
 const inflightKey = ({ baseURL, url, params, headers }: RequestConfig) => {
-  const segmentToken = headers['x-vtex-segment']
+  const segmentToken = headers && headers['x-vtex-segment']
   const segmentQs = segmentToken ? `&segmentToken=${segmentToken}` : ''
 
   return (

--- a/node/resolvers/profile/services.ts
+++ b/node/resolvers/profile/services.ts
@@ -113,8 +113,11 @@ export async function updateProfile(
 
   const extraFields = customFields && mapCustomFieldsToObjNStr(customFields)
 
+  // Remove email field from profile to prevent sending it in the payload
+  const { email, ...profileWithoutEmail } = profile
+
   const newData = {
-    ...profile,
+    ...profileWithoutEmail,
     // Read the comments in Profile in fieldResolvers.ts files
     // to understand the following transformations
     businessDocument: profile.corporateDocument,


### PR DESCRIPTION
#### What problem is this solving?

This PR addresses an issue with email rectification by users in the store-graphql API. The current implementation was allowing email rectification from users when it should be prevented, allowing rectifications just from Admin.

#### How to test it?

Already tested by Gabriel Fuentes Rojas from Sec Red Team, from Sec perspective. 
There are some steps to validate, so please contact me when reviewing and I can provide the workspace and the details.

#### Screenshots or example usage:

No visual changes - this is a backend API fix for email rectification validation logic.


## Changelog Entry
### Fixed
- Prevent email rectification from user

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/3o7abKhOpu0NwenH3O/giphy.gif)