### PR TITLE
chore: STR-969 catalog platform-flow-id (Shopper#1, Shopper#2, Shopper#4, Shopper#5)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     github.com/project-slug: vtex-apps/store-graphql
     vtex.com/application-id: RHF69SGK
-    vtex.com/platform-flow-id: Shopper#1
+    vtex.com/platform-flow-id: Shopper#1,Shopper#2,Shopper#4,Shopper#5
 spec:
   type: service
   lifecycle: production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update DK Catalog platform-flow-id
+
 ## [2.174.0] - 2025-12-17
 
 ### Added


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` to match the **Platform Flows (Dark Kitchen)** classification for this component (initiative STR-969).

## Change

| Annotation | Value |
|------------|-------|
| `vtex.com/platform-flow-id` | `Shopper#1,Shopper#2,Shopper#4,Shopper#5` |

**Convention:** multiple DK IDs are **comma-separated with no spaces**.

## Classification context (source artifact)

The following summary is taken from the internal classification table (Portuguese) used for STR-969:

> **Serviço:** GraphQL IO que abstrai REST públicas (catálogo, logística, checkout, OMS, perfil). **Decisão:** README lista explicitamente catálogo + checkout + OMS → mapeamento direto a **Shopper#1**, **Shopper#2**, **Shopper#4**, **Shopper#5**; skill: provider típico por trás do `graphql-server`.

## Changelog

- `CHANGELOG.md` — **[Unreleased]** → **Changed**: Update DK Catalog platform-flow-id


---

Reviewers: @vmourac-vtex @iago1501
