### PR TITLE
feat: scalar coercion via resolver map override (Approach 1 — Global)

### DIFF
--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,4 +1,5 @@
 import { mutations as authMutations, queries as authQueries } from './auth'
+import { CoercibleFloat, CoercibleInt, CoercibleString } from '../scalars'
 import {
   fieldResolvers as benefitsFieldResolvers,
   queries as benefitsQueries,
@@ -39,6 +40,9 @@ import {
 } from './session'
 
 export const resolvers = {
+  Int: CoercibleInt,
+  Float: CoercibleFloat,
+  String: CoercibleString,
   ...catalogFieldResolvers,
   ...benefitsFieldResolvers,
   ...profileFieldResolvers,

--- a/node/scalars/index.ts
+++ b/node/scalars/index.ts
@@ -1,0 +1,86 @@
+import {
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLScalarType,
+  GraphQLString,
+} from 'graphql'
+import { Kind } from 'graphql/language'
+
+// Replaces GraphQLInt in schema._typeMap so all Int fields accept "20" as 20.
+// parseValue handles variables ({ qty: "20" }), parseLiteral handles inline values.
+export const CoercibleInt = new GraphQLScalarType({
+  name: 'Int',
+  description: GraphQLInt.description,
+  serialize: GraphQLInt.serialize,
+  parseValue: (value) => {
+    const parsed = parseInt(String(value), 10)
+
+    if (isNaN(parsed)) {
+      throw new Error(`Int cannot represent non-integer value: ${value}`)
+    }
+
+    return parsed
+  },
+  parseLiteral: (ast) => {
+    if (ast.kind === Kind.INT) {
+      return parseInt(ast.value, 10)
+    }
+
+    if (ast.kind === Kind.STRING) {
+      const parsed = parseInt(ast.value, 10)
+
+      if (!isNaN(parsed)) return parsed
+    }
+
+    return null
+  },
+})
+
+// Replaces GraphQLFloat in schema._typeMap so all Float fields accept "3.14" as 3.14.
+export const CoercibleFloat = new GraphQLScalarType({
+  name: 'Float',
+  description: GraphQLFloat.description,
+  serialize: GraphQLFloat.serialize,
+  parseValue: (value) => {
+    const parsed = parseFloat(String(value))
+
+    if (isNaN(parsed)) {
+      throw new Error(`Float cannot represent non-numeric value: ${value}`)
+    }
+
+    return parsed
+  },
+  parseLiteral: (ast) => {
+    if (ast.kind === Kind.FLOAT || ast.kind === Kind.INT) {
+      return parseFloat(ast.value)
+    }
+
+    if (ast.kind === Kind.STRING) {
+      const parsed = parseFloat(ast.value)
+
+      if (!isNaN(parsed)) return parsed
+    }
+
+    return null
+  },
+})
+
+// Replaces GraphQLString in schema._typeMap so all String fields accept numbers as strings.
+export const CoercibleString = new GraphQLScalarType({
+  name: 'String',
+  description: GraphQLString.description,
+  serialize: GraphQLString.serialize,
+  parseValue: (value) => String(value),
+  parseLiteral: (ast) => {
+    if (
+      ast.kind === Kind.STRING ||
+      ast.kind === Kind.INT ||
+      ast.kind === Kind.FLOAT ||
+      ast.kind === Kind.BOOLEAN
+    ) {
+      return String(ast.value)
+    }
+
+    return null
+  },
+})


### PR DESCRIPTION
## Context

GraphQL's built-in scalars (`Int`, `Float`, `String`) have strict `parseValue` and `parseLiteral` implementations. When clients or upstream systems send values in a compatible but different format — e.g. `"20"` instead of `20` for an `Int` field — the operation fails at the scalar validation layer.

This PR explores **Approach 1: global interception** by replacing the built-in scalars in the schema's type map.

## How it works

`graphql-tools` v3.x (`makeExecutableSchema`) processes the resolver map via `addResolversToSchema`. When it finds a `GraphQLScalarType` **instance** (not just a plain object) registered under a built-in scalar name (`Int`, `Float`, `String`), it replaces the entry in `schema._typeMap[name]` — the schema's own private type registry. This is safe because:

- It does **not** mutate the global `GraphQLInt`/`GraphQLFloat`/`GraphQLString` singletons from the `graphql` package.
- The replacement is scoped to this schema instance only.
- `serialize` is delegated unchanged to the original scalar, so output coercion is not affected.

## Changes

### `node/scalars/index.ts` (new)
Three `GraphQLScalarType` instances named `Int`, `Float`, and `String`:

| Scalar | `parseValue` behavior | `parseLiteral` addition |
|--------|-----------------------|------------------------|
| `Int` | `parseInt(String(value))` — accepts `"20"`, `20.9` | Also handles `Kind.STRING` literals |
| `Float` | `parseFloat(String(value))` — accepts `"3.14"`, `3` | Also handles `Kind.STRING`, `Kind.INT` literals |
| `String` | `String(value)` — accepts numbers, booleans | Also handles `Kind.INT`, `Kind.FLOAT`, `Kind.BOOLEAN` literals |

### `node/resolvers/index.ts`
Adds `Int`, `Float`, `String` entries pointing to the coercible scalar instances.

## Trade-offs

| | Approach 1 (this PR) |
|---|---|
| **Scope** | All fields in the entire schema automatically |
| **SDL changes** | None required |
| **Risk** | Removes strict type validation globally — e.g. a malformed `"abc"` for an `Int` throws at runtime instead of schema validation time |
| **Maintenance** | Single file to update |

> Compare with [Approach 2 — @coerce directive](../pull/new/feat/coerce-directive) which applies coercion surgically per field.

## References
- `graphql-tools` v3.x `addResolversToSchema` — handles `GraphQLScalarType` instances by replacing `schema._typeMap[name]`
- node-vtex-api `@sanitize` directive — established precedent of replacing scalar types at schema-build time
- `graphql@0.13.2` scalar resolution flow: `parseLiteral` for inline values, `parseValue` for variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)