### PR TITLE
fix: forward an={account} on VTEX ID outbound calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `an={account}` query string to VTEX ID authentication and user info calls.
+
 ## [2.177.1] - 2026-05-11
 
 ### Added

--- a/node/__tests__/resolvers/paths.test.ts
+++ b/node/__tests__/resolvers/paths.test.ts
@@ -1,0 +1,58 @@
+import paths from '../../resolvers/paths'
+
+describe('VTEX ID paths attach ?an={account}', () => {
+  const ACCOUNT = 'storecomponents'
+
+  it('accessKeySignIn carries an=account', () => {
+    expect(paths.accessKeySignIn(ACCOUNT)).toBe(
+      'http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/validate?an=storecomponents'
+    )
+  })
+
+  it('classicSignIn carries an=account', () => {
+    expect(paths.classicSignIn(ACCOUNT)).toBe(
+      'http://vtexid.vtex.com.br/api/vtexid/pub/authentication/classic/validate?an=storecomponents'
+    )
+  })
+
+  it('setPassword carries an=account', () => {
+    expect(paths.setPassword(ACCOUNT)).toBe(
+      'http://vtexid.vtex.com.br/api/vtexid/pub/authentication/classic/setpassword?an=storecomponents'
+    )
+  })
+
+  it('sendEmailVerification carries an=account', () => {
+    expect(paths.sendEmailVerification(ACCOUNT)).toBe(
+      'http://vtexid.vtex.com.br/api/vtexid/pub/authentication/accesskey/send?an=storecomponents'
+    )
+  })
+
+  it('getUser keeps scope and adds an', () => {
+    const url = paths.getUser(ACCOUNT)
+
+    expect(url).toContain('scope=storecomponents')
+    expect(url).toContain('an=storecomponents')
+  })
+
+  it('sessionToken keeps accountName and does NOT add an (relative callbackUrl/returnUrl trip backend account-host validation)', () => {
+    const url = paths.sessionToken(ACCOUNT, ACCOUNT, '/foo', '/bar')
+
+    expect(url).toContain('accountName=storecomponents')
+    expect(url).not.toContain('an=')
+    expect(url).toContain('callbackUrl=/foo')
+    expect(url).toContain('returnUrl=/bar')
+  })
+
+  it('loginSessions and logOutFromSession remain unchanged (regression guard)', () => {
+    expect(paths.loginSessions(ACCOUNT, ACCOUNT)).toContain(
+      'an=storecomponents'
+    )
+    expect(
+      paths.logOutFromSession({
+        scope: ACCOUNT,
+        account: ACCOUNT,
+        sessionId: 'abc',
+      })
+    ).toContain('an=storecomponents')
+  })
+})

--- a/node/resolvers/auth/index.ts
+++ b/node/resolvers/auth/index.ts
@@ -207,7 +207,7 @@ export const mutations = {
     } = await makeRequest({
       ctx: ioContext,
       method: 'POST',
-      url: paths.accessKeySignIn(),
+      url: paths.accessKeySignIn(ioContext.account),
       body: {
         accesskey: args.code,
         authenticationToken: VtexSessionToken,
@@ -238,7 +238,7 @@ export const mutations = {
     } = await makeRequest({
       ctx: ioContext,
       method: 'POST',
-      url: paths.classicSignIn(),
+      url: paths.classicSignIn(ioContext.account),
       body: {
         authenticationToken: VtexSessionToken,
         login: args.email,
@@ -343,7 +343,7 @@ export const mutations = {
     } = await makeRequest({
       ctx: ioContext,
       method: 'POST',
-      url: paths.setPassword(),
+      url: paths.setPassword(ioContext.account),
       body,
     })
 
@@ -379,7 +379,7 @@ export const mutations = {
     } = await makeRequest({
       ctx: ioContext,
       method: 'POST',
-      url: paths.setPassword(),
+      url: paths.setPassword(ioContext.account),
       body,
       vtexIdVersion: args.vtexIdVersion,
     })
@@ -409,7 +409,7 @@ export const mutations = {
     await makeRequest({
       ctx: ioContext,
       method: 'POST',
-      url: paths.sendEmailVerification(),
+      url: paths.sendEmailVerification(ioContext.account),
       body: {
         authenticationToken: VtexSessionToken,
         email: args.email,

--- a/node/resolvers/paths.ts
+++ b/node/resolvers/paths.ts
@@ -48,15 +48,18 @@ const paths = {
     `${paths.gateway(account)}/pub/sessions/${sessionId}/tokens`,
 
   /** VTEX ID API */
-  accessKeySignIn: () => `${paths.vtexIdPub}/authentication/accesskey/validate`,
-  classicSignIn: () => `${paths.vtexIdPub}/authentication/classic/validate`,
-  getUser: (accountName: any) =>
-    `${paths.vtexIdPvt}/user/detailedinfo?scope=${accountName}`,
+  accessKeySignIn: (account: string) =>
+    `${paths.vtexIdPub}/authentication/accesskey/validate?an=${account}`,
+  classicSignIn: (account: string) =>
+    `${paths.vtexIdPub}/authentication/classic/validate?an=${account}`,
+  getUser: (accountName: string) =>
+    `${paths.vtexIdPvt}/user/detailedinfo?scope=${accountName}&an=${accountName}`,
   oAuth: (authenticationToken: any, providerName: any) =>
     `${paths.vtexIdPub}/authentication/oauth/redirect?authenticationToken=${authenticationToken}&providerName=${providerName}`,
-  setPassword: () => `${paths.vtexIdPub}/authentication/classic/setpassword`,
-  sendEmailVerification: () =>
-    `${paths.vtexIdPub}/authentication/accesskey/send`,
+  setPassword: (account: string) =>
+    `${paths.vtexIdPub}/authentication/classic/setpassword?an=${account}`,
+  sendEmailVerification: (account: string) =>
+    `${paths.vtexIdPub}/authentication/accesskey/send?an=${account}`,
   sessionToken: (scope: any, account: any, redirect = '/', returnUrl = '/') =>
     `${
       paths.vtexIdPub


### PR DESCRIPTION
## Summary

Some axios-based callers in `node/resolvers/auth` and `node/resolvers/profile/services` were hitting `vtexid.vtex.com.br` without the `an={account}` query string. This caused the backend to reject some flows in production — for example, `pub/authentication/accesskey/send` returns HTTP 401 from `storecomponents/master` and the same call returns 200 once `an=storecomponents` is present (validated below).

This change adds `?an={account}` to every direct call that previously omitted it, while keeping the host (`vtexid.vtex.com.br`) and the route shape unchanged.

## Endpoints touched

| Path | Status |
|---|---|
| `pub/authentication/accesskey/validate` | adds `an` |
| `pub/authentication/accesskey/send` | adds `an` |
| `pub/authentication/classic/validate` | adds `an` |
| `pub/authentication/classic/setpassword` | adds `an` |
| `pvt/user/detailedinfo` | adds `an` |
| `pub/authentication/start` (sessionToken) | **intentionally not changed** |

`pub/authentication/start` is left without `an` because the backend validates that the host of `callbackUrl` and `returnUrl` matches the account in `an`. Callers in this codebase pass relative URLs (`/`), so adding `an` there returns HTTP 400 (`The host and {callbackUrl,returnUrl} accounts do not match`).

`getAuthenticatedUser` and `IdentityClient.getUserWithToken` already propagate `an` (via `JanusClient` and explicitly, respectively); `loginSessions`/`logOutFromSession` already had `an` in the URL.

## Files

- `node/resolvers/paths.ts` — URL builders accept `account` and append `&an=${account}`.
- `node/resolvers/auth/index.ts` — 5 call sites pass `ioContext.account`.
- `node/__tests__/resolvers/paths.test.ts` — 7 unit tests for the URL builders (including a regression guard for `loginSessions`/`logOutFromSession` and an explicit assertion that `sessionToken` does **not** carry `an`).
- `CHANGELOG.md` — entry under `[Unreleased] - Fixed`.

## Test plan

Unit suite (`node/`):

- `yarn test` → 871/871 green.

End-to-end via curl, comparing `storecomponents/master` (production, without the fix) against `storecomponents/vulnsg` (with this branch linked):

| Scenario | master | vulnsg | Result |
|---|---|---|---|
| `loginOptions` query | 200 OK | 200 OK (byte-identical) | no regression |
| `classicSignIn` mutation (invalid creds) | `WrongCredentials` | `WrongCredentials` (byte-identical) | no regression |
| `sendEmailVerification` mutation (fresh email) | **HTTP 401** | **`{ sendEmailVerification: true }` (200 OK)** | fix unblocks the flow |

Direct curls to `vtexid.vtex.com.br` confirmed that `accesskey/{validate,send}`, `classic/{validate,setpassword}` and `pvt/user/detailedinfo` accept `an=` without changing the response shape; only `pub/authentication/start` rejects `an` when `callbackUrl`/`returnUrl` are relative — hence the carve-out.