### PR TITLE
fix: use PATCH instead of PUT when updating clientPreferences (Profile System V2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `PATCH` instead of `PUT` when updating `clientPreferences` on Profile System V2 to avoid overwriting `paymentData` (saved cards) in the `purchase-info` entity.
+
 ## [2.177.2] - 2026-05-22
 
 ### Fixed

--- a/node/clients/profile/profileV2.ts
+++ b/node/clients/profile/profileV2.ts
@@ -130,7 +130,7 @@ export class ProfileClientV2 extends JanusClient {
       },
     }
 
-    return this.put(
+    return this.patch(
       `${this.baseUrl}/${currentUserProfile.id}/purchase-info`,
       purchaseInfo,
       {


### PR DESCRIPTION
## Problem

When a user updates their newsletter preferences (`updatePersonalPreferences`), `store-graphql` was calling `PUT /purchase-info` sending only the `clientPreferences` payload. Because PUT replaces the entire entity, the `paymentData` field (saved cards) was being wiped from the user's profile.

This was identified as the root cause of a production incident where transactions were being cancelled via the WorldpayVTEX connector: the `gatewayCallback` validation was failing because the saved card appeared to belong to a "loaded profile" (no login), since the card data had been removed from the real profile after the PUT.

The Storage team blocked external write access to `purchase-info` as a mitigation, and this PR addresses the same issue at the `store-graphql` level.

## Fix

Changed `this.put` → `this.patch` in `updatePersonalPreferences` ([profileV2.ts:133](node/clients/profile/profileV2.ts#L133)).

`PATCH` performs a partial update, merging only `clientPreferences` into the existing document and leaving `paymentData` intact.

No other calls to `purchase-info` in this codebase use PUT — the V1 client uses `POST /personalPreferences/` (a different endpoint) and is not affected.